### PR TITLE
Npm install error investigation

### DIFF
--- a/app/api/starforge/commit/route.ts
+++ b/app/api/starforge/commit/route.ts
@@ -10,8 +10,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { 
   createCommitment,
-  createStarForgeGame,
 } from '@/lib/starforge';
+import { createStarForgeGame } from '@/lib/db';
 import { logger } from '@/lib/logger';
 import { isStarSkrumpeyId } from '@/lib/starSkrumpey';
 import { parseEther } from 'viem';


### PR DESCRIPTION
Fix build error by correcting the import path for `createStarForgeGame`.

The function `createStarForgeGame` was being imported from `@/lib/starforge` but is actually exported from `@/lib/db`, leading to a build failure.

---
<a href="https://cursor.com/background-agent?bcId=bc-d50b3165-e92a-4252-80cd-b73cf2d315b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d50b3165-e92a-4252-80cd-b73cf2d315b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Resolves build error caused by incorrect import in the Star Forge commit endpoint.
> 
> - In `app/api/starforge/commit/route.ts`, `createStarForgeGame` is now imported from `@/lib/db` and removed from the `@/lib/starforge` import list
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 00c86eb8082e6557415b0b607d0cb61f7c87482f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->