### PR TITLE
ci: add GitHub Actions test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [dev]
+  pull_request:
+    branches: [dev]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - run: npm run test


### PR DESCRIPTION
## Summary
- Adds a CI workflow (`.github/workflows/ci.yml`) that runs on pushes to `dev` and PRs targeting `dev`
- Runs checkout, Node.js 20 setup with npm cache, `npm ci`, `npm run build`, and `npm run test`
- Job timeout set to 10 minutes

## Test plan
- [ ] Verify workflow triggers on PR to dev
- [ ] Verify build step passes
- [ ] Verify test step passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)