### PR TITLE
fix: Verify governance voting power server-side

### DIFF
--- a/app/api/governance/route.ts
+++ b/app/api/governance/route.ts
@@ -46,6 +46,7 @@ import {
 } from '@/lib/voteSignature';
 import { verifyAdminAccess } from '@/lib/adminAuth';
 import { verifyWalletAccess } from '@/lib/walletAuth';
+import { checkStarOwnershipBatched } from '@/lib/starSkrumpey';
 
 /**
  * GET /api/governance
@@ -331,6 +332,15 @@ export async function POST(request: NextRequest) {
         );
       }
 
+      // Verify proposer holds at least one Star Skrumpey
+      const proposerStars = await checkStarOwnershipBatched(proposerAddress);
+      if (proposerStars.length === 0) {
+        return NextResponse.json(
+          { success: false, error: 'You must hold at least one Star Skrumpey to create proposals' },
+          { status: 403 }
+        );
+      }
+
       // Validate voting duration (1-4 weeks)
       const duration = parseInt(votingDurationWeeks, 10) || 1;
       if (duration < 1 || duration > 4) {
@@ -415,7 +425,7 @@ export async function POST(request: NextRequest) {
 
     // Cast a vote
     if (action === 'vote') {
-      const { proposalId, voterAddress, support, votingPower, reason, signature, nonce, signatureVersion, typedData } = body;
+      const { proposalId, voterAddress, support, reason, signature, nonce, signatureVersion } = body;
 
       // Strict input validation
       if (!proposalId || !voterAddress || support === undefined) {
@@ -535,10 +545,27 @@ export async function POST(request: NextRequest) {
       }
 
       // Signature is valid, proceed with vote
-      logger.info('Governance: Valid signature verified', { 
-        proposalId, 
+      logger.info('Governance: Valid signature verified', {
+        proposalId,
         voterAddress: normalizedVoterAddress.slice(0, 10) + '...',
         version
+      });
+
+      // Server-side voting power verification: 1 Star Skrumpey = 1 Vote
+      // NEVER trust client-supplied votingPower
+      const voterStars = await checkStarOwnershipBatched(normalizedVoterAddress);
+      const verifiedVotingPower = voterStars.length;
+
+      if (verifiedVotingPower === 0) {
+        return NextResponse.json(
+          { success: false, error: 'You must hold at least one Star Skrumpey to vote' },
+          { status: 403 }
+        );
+      }
+
+      logger.info('Governance: Voting power verified on-chain', {
+        voterAddress: normalizedVoterAddress.slice(0, 10) + '...',
+        verifiedVotingPower,
       });
 
       // Store vote with signature data
@@ -546,7 +573,7 @@ export async function POST(request: NextRequest) {
         proposalId,
         voterAddress: normalizedVoterAddress,
         support: supportValue,
-        votingPower: parseInt(votingPower, 10) || 1,
+        votingPower: verifiedVotingPower,
         reason,
         signature,
         signatureVersion: version,


### PR DESCRIPTION
## Summary

- **Fixes critical security vulnerability**: The governance vote endpoint previously accepted `votingPower` directly from the client POST body without any server-side verification. An attacker could submit `votingPower: 9999` to inflate their vote count, completely undermining DAO governance integrity.
- **Adds Star holder gate for proposal creation**: Previously any connected wallet could create governance proposals. Now only Star Skrumpey holders can create proposals, matching the DAO's design intent.
- **Voting power is now verified on-chain**: Calls `checkStarOwnershipBatched()` to count actual Star Skrumpey NFT ownership before recording votes. This leverages the existing 30-second ownership cache to minimize RPC overhead.

## What Changed

**`app/api/governance/route.ts`**:
1. **Vote action** (line ~554-576): Replaced `parseInt(votingPower, 10) || 1` (client-supplied) with server-side `checkStarOwnershipBatched()` call. Non-holders are rejected with 403.
2. **Proposal creation** (line ~334-340): Added `checkStarOwnershipBatched()` gate before proposal creation. Non-holders are rejected with 403.
3. Removed unused `votingPower` and `typedData` from request body destructuring.

## Test plan

- [x] `npm run type-check` — passes
- [x] `npm run test` — 69/69 tests pass
- [x] `npm run build` — builds successfully (49 routes)
- [x] No new lint errors introduced (only pre-existing `any` type on line 500)
- [ ] Manual test: attempt to vote with a wallet holding 0 Stars → should get 403
- [ ] Manual test: vote with a Star holder wallet → voting power should equal actual Star count
- [ ] Manual test: create proposal with non-holder wallet → should get 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)