### PR TITLE
feat: V1 companion dashboard with quick actions

### DIFF
--- a/app/api/sanctuary/companion/interact/route.ts
+++ b/app/api/sanctuary/companion/interact/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { interactWithCompanion } from '@/lib/db';
+
+const VALID_ACTIONS = ['feed', 'pet', 'talk'] as const;
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { address, token_id, action } = body;
+
+    if (!address || token_id === undefined || !action) {
+      return NextResponse.json(
+        { success: false, error: 'address, token_id, and action are required' },
+        { status: 400 }
+      );
+    }
+
+    if (!VALID_ACTIONS.includes(action)) {
+      return NextResponse.json(
+        { success: false, error: `Invalid action. Must be one of: ${VALID_ACTIONS.join(', ')}` },
+        { status: 400 }
+      );
+    }
+
+    const result = interactWithCompanion(address, token_id, action);
+    return NextResponse.json({ success: true, ...result });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to interact';
+    const status = message.includes('No active companion') ? 404 : 500;
+    return NextResponse.json({ success: false, error: message }, { status });
+  }
+}

--- a/app/api/sanctuary/companion/route.ts
+++ b/app/api/sanctuary/companion/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getActiveCompanion, getAllCompanions } from '@/lib/db';
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const address = searchParams.get('address');
+
+    if (!address) {
+      return NextResponse.json({ success: false, error: 'Address is required' }, { status: 400 });
+    }
+
+    const all = searchParams.get('all') === 'true';
+
+    if (all) {
+      const companions = getAllCompanions(address);
+      return NextResponse.json({ success: true, companions });
+    }
+
+    const companion = getActiveCompanion(address);
+    return NextResponse.json({ success: true, companion });
+  } catch (error) {
+    console.error('Sanctuary companion GET error:', error);
+    return NextResponse.json({ success: false, error: 'Failed to fetch companion' }, { status: 500 });
+  }
+}

--- a/app/api/sanctuary/companion/select/route.ts
+++ b/app/api/sanctuary/companion/select/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { selectCompanion } from '@/lib/db';
+import { verifyWalletAccess } from '@/lib/walletAuth';
+import { checkStarOwnershipBatched } from '@/lib/starSkrumpey';
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { walletAddress, tokenId } = body;
+
+    if (!walletAddress || tokenId == null) {
+      return NextResponse.json(
+        { success: false, error: 'walletAddress and tokenId are required' },
+        { status: 400 }
+      );
+    }
+
+    const auth = await verifyWalletAccess(request, walletAddress);
+    if (!auth.valid) {
+      return NextResponse.json({ success: false, error: auth.error }, { status: 401 });
+    }
+
+    const ownedTokens = await checkStarOwnershipBatched(walletAddress);
+    const ownsToken = ownedTokens.some(t => t.tokenId === tokenId);
+    if (!ownsToken) {
+      return NextResponse.json(
+        { success: false, error: 'You do not own this Star Skrumpey' },
+        { status: 403 }
+      );
+    }
+
+    const companion = selectCompanion(walletAddress, tokenId);
+    return NextResponse.json({ success: true, companion });
+  } catch (error) {
+    console.error('Sanctuary companion select error:', error);
+    return NextResponse.json({ success: false, error: 'Failed to select companion' }, { status: 500 });
+  }
+}

--- a/app/api/sanctuary/companion/switch/route.ts
+++ b/app/api/sanctuary/companion/switch/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { switchCompanion } from '@/lib/db';
+import { verifyWalletAccess } from '@/lib/walletAuth';
+import { checkStarOwnershipBatched } from '@/lib/starSkrumpey';
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { walletAddress, tokenId } = body;
+
+    if (!walletAddress || tokenId == null) {
+      return NextResponse.json(
+        { success: false, error: 'walletAddress and tokenId are required' },
+        { status: 400 }
+      );
+    }
+
+    const auth = await verifyWalletAccess(request, walletAddress);
+    if (!auth.valid) {
+      return NextResponse.json({ success: false, error: auth.error }, { status: 401 });
+    }
+
+    const ownedTokens = await checkStarOwnershipBatched(walletAddress);
+    const ownsToken = ownedTokens.some(t => t.tokenId === tokenId);
+    if (!ownsToken) {
+      return NextResponse.json(
+        { success: false, error: 'You do not own this Star Skrumpey' },
+        { status: 403 }
+      );
+    }
+
+    const companion = switchCompanion(walletAddress, tokenId);
+    return NextResponse.json({ success: true, companion });
+  } catch (error) {
+    console.error('Sanctuary companion switch error:', error);
+    return NextResponse.json({ success: false, error: 'Failed to switch companion' }, { status: 500 });
+  }
+}

--- a/app/api/sanctuary/map/route.ts
+++ b/app/api/sanctuary/map/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server';
+import { getSanctuaryMapLocations } from '@/lib/db';
+
+export async function GET() {
+  try {
+    const locations = getSanctuaryMapLocations();
+    return NextResponse.json({ success: true, locations });
+  } catch (error) {
+    console.error('Sanctuary map GET error:', error);
+    return NextResponse.json({ success: false, error: 'Failed to fetch map' }, { status: 500 });
+  }
+}

--- a/app/api/sanctuary/state/route.ts
+++ b/app/api/sanctuary/state/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSanctuaryState } from '@/lib/db';
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const address = searchParams.get('address');
+
+    if (!address) {
+      return NextResponse.json({ success: false, error: 'Address is required' }, { status: 400 });
+    }
+
+    const state = getSanctuaryState(address);
+    return NextResponse.json({ success: true, ...state });
+  } catch (error) {
+    console.error('Sanctuary state GET error:', error);
+    return NextResponse.json({ success: false, error: 'Failed to fetch sanctuary state' }, { status: 500 });
+  }
+}

--- a/app/sanctuary/SanctuaryContent.tsx
+++ b/app/sanctuary/SanctuaryContent.tsx
@@ -72,39 +72,106 @@ function PublicWorldView({ locations }: { locations: MapLocation[] }) {
   );
 }
 
-function CompanionPanel({ companion }: { companion: Companion }) {
+const MOOD_CONFIG: Record<string, { emoji: string; label: string; color: string }> = {
+  happy: { emoji: '😊', label: 'Happy', color: '#44ff88' },
+  excited: { emoji: '🤩', label: 'Excited', color: '#ffd700' },
+  calm: { emoji: '😌', label: 'Calm', color: '#66bbff' },
+  sleepy: { emoji: '😴', label: 'Sleepy', color: '#9966ff' },
+  curious: { emoji: '🧐', label: 'Curious', color: '#ff9944' },
+};
+const DEFAULT_MOOD = { emoji: '🐸', label: 'Neutral', color: '#888' };
+
+function StatBar({ label, value, max, color }: { label: string; value: number; max: number; color: string }) {
+  const pct = Math.min((value / max) * 100, 100);
   return (
-    <div className="pixel-card p-6">
-      <div className="flex items-center gap-3 mb-4">
-        <div className="text-3xl">
-          {companion.mood === 'happy' ? '😊' : companion.mood === 'excited' ? '🤩' : companion.mood === 'calm' ? '😌' : '🐸'}
+    <div>
+      <div className="flex justify-between text-[8px] mb-0.5">
+        <span className="text-gray-500">{label}</span>
+        <span style={{ color }}>{value.toFixed(1)} / {max}</span>
+      </div>
+      <div className="h-1.5 bg-[#1a1a2e] rounded-full overflow-hidden border border-[#2a2a4e]">
+        <div className="h-full rounded-full transition-all duration-500" style={{ width: `${pct}%`, backgroundColor: color }} />
+      </div>
+    </div>
+  );
+}
+
+function CompanionPanel({
+  companion,
+  latestJournal,
+  onInteract,
+  interacting,
+}: {
+  companion: Companion;
+  latestJournal: JournalEntry | null;
+  onInteract: (action: 'feed' | 'pet' | 'talk') => void;
+  interacting: string | null;
+}) {
+  const mood = MOOD_CONFIG[companion.mood ?? ''] ?? DEFAULT_MOOD;
+  const traits = [companion.constellation, companion.aura, companion.form].filter(Boolean);
+
+  return (
+    <div className="pixel-card p-6 space-y-4">
+      {/* Header: Avatar + Identity */}
+      <div className="flex items-start gap-4">
+        <div className="flex-shrink-0 w-16 h-16 rounded-lg bg-[#0a0a15] border-2 border-[#2a2a4e] flex items-center justify-center text-4xl">
+          {mood.emoji}
         </div>
-        <div>
-          <h3 className="text-[#ffd700] text-xs tracking-wider">
+        <div className="flex-1 min-w-0">
+          <h3 className="text-[#ffd700] text-sm tracking-wider truncate">
             {companion.nickname || `Star #${companion.token_id}`}
           </h3>
-          <p className="text-[#9966ff] text-[8px] uppercase">
-            {companion.constellation} {companion.aura ? `/ ${companion.aura}` : ''}
+          <p className="text-gray-400 text-[8px] mt-0.5">
+            LV.{companion.level} · <span style={{ color: mood.color }}>{mood.label}</span>
           </p>
+          {traits.length > 0 && (
+            <div className="flex flex-wrap gap-1 mt-1.5">
+              {traits.map((t) => (
+                <span key={t} className="text-[7px] px-1.5 py-0.5 rounded bg-[#9966ff]/15 text-[#9966ff] border border-[#9966ff]/30 uppercase">
+                  {t}
+                </span>
+              ))}
+            </div>
+          )}
         </div>
       </div>
-      <div className="grid grid-cols-2 gap-3 text-[8px]">
-        <div>
-          <p className="text-gray-500">BOND</p>
-          <p className="text-[#44ff88]">{companion.bond_score.toFixed(1)}</p>
+
+      {/* Stats */}
+      <div className="space-y-2">
+        <StatBar label="BOND" value={companion.bond_score} max={100} color="#ff66aa" />
+        <StatBar label="XP" value={companion.total_xp} max={companion.level * 100} color="#ffd700" />
+      </div>
+
+      {/* Current Activity */}
+      <div className="bg-[#0a0a15] rounded-lg p-3 border border-[#2a2a4e]">
+        <p className="text-gray-500 text-[7px] mb-1">CURRENT ACTIVITY</p>
+        <p className="text-white text-[10px] uppercase tracking-wide">{companion.current_activity}</p>
+        <p className="text-gray-600 text-[7px]">{companion.total_interactions} total interactions</p>
+      </div>
+
+      {/* Latest Journal Snippet */}
+      {latestJournal && (
+        <div className="border-l-2 border-[#9966ff]/40 pl-2">
+          <p className="text-gray-400 text-[8px] italic">&ldquo;{latestJournal.content}&rdquo;</p>
+          <p className="text-gray-600 text-[6px] mt-0.5">{new Date(latestJournal.created_at).toLocaleDateString()}</p>
         </div>
-        <div>
-          <p className="text-gray-500">INTERACTIONS</p>
-          <p className="text-[#44ff88]">{companion.total_interactions}</p>
-        </div>
-        <div>
-          <p className="text-gray-500">ACTIVITY</p>
-          <p className="text-white uppercase">{companion.current_activity}</p>
-        </div>
-        <div>
-          <p className="text-gray-500">LEVEL</p>
-          <p className="text-[#ffd700]">{companion.level}</p>
-        </div>
+      )}
+
+      {/* Quick Actions */}
+      <div className="grid grid-cols-3 gap-2">
+        {([['feed', '🍎', 'Feed'], ['pet', '✋', 'Pet'], ['talk', '💬', 'Talk']] as const).map(([action, icon, label]) => (
+          <button
+            key={action}
+            onClick={() => onInteract(action)}
+            disabled={interacting !== null}
+            className="pixel-card p-2 text-center hover:border-[#ffd700]/50 transition-colors disabled:opacity-40 disabled:cursor-not-allowed group"
+          >
+            <span className="text-lg block group-hover:scale-110 transition-transform">
+              {interacting === action ? '⏳' : icon}
+            </span>
+            <span className="text-[7px] text-gray-400 group-hover:text-[#ffd700] transition-colors">{label}</span>
+          </button>
+        ))}
       </div>
     </div>
   );
@@ -138,6 +205,7 @@ function HolderSanctuary() {
   const [locations, setLocations] = useState<MapLocation[]>([]);
   const [journal, setJournal] = useState<JournalEntry[]>([]);
   const [loading, setLoading] = useState(true);
+  const [interacting, setInteracting] = useState<string | null>(null);
 
   useEffect(() => {
     if (!address) return;
@@ -159,6 +227,33 @@ function HolderSanctuary() {
       .catch(() => {})
       .finally(() => setLoading(false));
   }, [address]);
+
+  const handleInteract = async (action: 'feed' | 'pet' | 'talk') => {
+    if (!address || !companion || interacting) return;
+    setInteracting(action);
+    try {
+      const res = await fetch('/api/sanctuary/companion/interact', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ address, token_id: companion.token_id, action }),
+      });
+      const data = await res.json();
+      if (data.success) {
+        setCompanion((prev) => prev ? {
+          ...prev,
+          bond_score: data.companion.bond_score,
+          total_interactions: data.companion.total_interactions,
+        } : null);
+        if (data.journal) {
+          setJournal((prev) => [data.journal, ...prev].slice(0, 10));
+        }
+      }
+    } catch {
+      // silently fail
+    } finally {
+      setInteracting(null);
+    }
+  };
 
   if (loading) {
     return (
@@ -185,7 +280,12 @@ function HolderSanctuary() {
       <div className="grid md:grid-cols-2 gap-6">
         {companion ? (
           <>
-            <CompanionPanel companion={companion} />
+            <CompanionPanel
+              companion={companion}
+              latestJournal={journal[0] ?? null}
+              onInteract={handleInteract}
+              interacting={interacting}
+            />
             <JournalPanel entries={journal} />
           </>
         ) : (

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -605,6 +605,9 @@ function initializeDatabase(database: Database.Database): void {
 
   // Insert default quests if none exist
   insertDefaultQuests(database);
+
+  // Sanctuary tables
+  initializeSanctuary(database);
 }
 
 /**
@@ -5530,23 +5533,288 @@ export function getUserLikeStatus(userAddress: string, targetId: string, targetT
 export function getUserLikeStatuses(userAddress: string, targetIds: string[], targetType: 'thread' | 'reply'): Map<string, ForumLike> {
   const db = getDatabase();
   const result = new Map<string, ForumLike>();
-  
+
   if (targetIds.length === 0) return result;
-  
+
   try {
     const placeholders = targetIds.map(() => '?').join(',');
     const stmt = db.prepare(`
-      SELECT * FROM forum_likes 
+      SELECT * FROM forum_likes
       WHERE user_address = ? AND target_type = ? AND target_id IN (${placeholders})
     `);
     const likes = stmt.all(userAddress.toLowerCase(), targetType, ...targetIds) as ForumLike[];
-    
+
     for (const like of likes) {
       result.set(like.target_id, like);
     }
-    
+
     return result;
   } catch {
     return result;
   }
+}
+
+// ============================================================
+// Sanctuary — Companion, Journal, Map
+// ============================================================
+
+export interface SanctuaryCompanion {
+  id: number;
+  wallet_address: string;
+  token_id: number;
+  is_active: number;
+  nickname: string | null;
+  current_activity: string;
+  activity_started_at: string | null;
+  activity_ends_at: string | null;
+  bond_score: number;
+  total_interactions: number;
+  equipped_cosmetics: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface SanctuaryCompanionWithMeta extends SanctuaryCompanion {
+  constellation: string | null;
+  aura: string | null;
+  form: string | null;
+  mood: string | null;
+  total_xp: number;
+  level: number;
+}
+
+export interface SanctuaryJournalEntry {
+  id: number;
+  wallet_address: string;
+  token_id: number;
+  entry_type: string;
+  content: string;
+  metadata: string;
+  created_at: string;
+}
+
+export interface SanctuaryMapLocation {
+  id: number;
+  name: string;
+  description: string | null;
+  max_capacity: number;
+  unlock_level: number;
+  position_x: number;
+  position_y: number;
+}
+
+function initializeSanctuary(database: Database.Database): void {
+  const sqlPath = path.join(process.cwd(), 'scripts', 'init-sanctuary.sql');
+  if (fs.existsSync(sqlPath)) {
+    const sql = fs.readFileSync(sqlPath, 'utf-8');
+    database.exec(sql);
+  }
+  seedSanctuaryMapLocations(database);
+}
+
+function seedSanctuaryMapLocations(database: Database.Database): void {
+  const countStmt = database.prepare('SELECT COUNT(*) as count FROM sanctuary_map_locations');
+  const { count } = countStmt.get() as { count: number };
+  if (count > 0) return;
+
+  const locations = [
+    { name: 'Hot Springs', description: 'A relaxing place for tired Skrumpeys to unwind.', position_x: 0.2, position_y: 0.3, unlock_level: 1 },
+    { name: 'Training Grounds', description: 'Practice arena where Skrumpeys sharpen their skills.', position_x: 0.7, position_y: 0.2, unlock_level: 1 },
+    { name: 'Star Garden', description: 'A mystical garden where constellations bloom.', position_x: 0.5, position_y: 0.5, unlock_level: 2 },
+    { name: 'Cosmic Library', description: 'Ancient texts and forgotten lore.', position_x: 0.8, position_y: 0.6, unlock_level: 3 },
+    { name: 'Nebula Kitchen', description: 'Cook up cosmic treats for your companion.', position_x: 0.3, position_y: 0.7, unlock_level: 2 },
+    { name: 'Dream Hollow', description: 'Where Skrumpeys rest and dream of adventures.', position_x: 0.1, position_y: 0.8, unlock_level: 1 },
+    { name: 'Aura Forge', description: 'Channel aura energy into powerful bonds.', position_x: 0.9, position_y: 0.4, unlock_level: 5 },
+    { name: 'Observatory', description: 'Gaze at the stars and discover hidden constellations.', position_x: 0.5, position_y: 0.1, unlock_level: 4 },
+  ];
+
+  const insert = database.prepare(`
+    INSERT INTO sanctuary_map_locations (name, description, position_x, position_y, unlock_level)
+    VALUES (?, ?, ?, ?, ?)
+  `);
+  for (const loc of locations) {
+    insert.run(loc.name, loc.description, loc.position_x, loc.position_y, loc.unlock_level);
+  }
+}
+
+export function getSanctuaryCompanion(walletAddress: string, tokenId: number): SanctuaryCompanion | null {
+  const db = getDatabase();
+  const stmt = db.prepare('SELECT * FROM sanctuary_companions WHERE wallet_address = ? AND token_id = ?');
+  return (stmt.get(walletAddress.toLowerCase(), tokenId) as SanctuaryCompanion) || null;
+}
+
+export function getActiveCompanion(walletAddress: string): SanctuaryCompanionWithMeta | null {
+  const db = getDatabase();
+  const stmt = db.prepare(`
+    SELECT sc.*, ssm.constellation, ssm.aura, ssm.form, ssm.mood,
+           COALESCE(ux.total_xp, 0) as total_xp, COALESCE(ux.level, 1) as level
+    FROM sanctuary_companions sc
+    JOIN star_skrumpey_metadata ssm ON sc.token_id = ssm.token_id
+    LEFT JOIN user_xp ux ON sc.wallet_address = ux.wallet_address
+    WHERE sc.wallet_address = ? AND sc.is_active = 1
+  `);
+  return (stmt.get(walletAddress.toLowerCase()) as SanctuaryCompanionWithMeta) || null;
+}
+
+export function getAllCompanions(walletAddress: string): SanctuaryCompanionWithMeta[] {
+  const db = getDatabase();
+  const stmt = db.prepare(`
+    SELECT sc.*, ssm.constellation, ssm.aura, ssm.form, ssm.mood,
+           COALESCE(ux.total_xp, 0) as total_xp, COALESCE(ux.level, 1) as level
+    FROM sanctuary_companions sc
+    JOIN star_skrumpey_metadata ssm ON sc.token_id = ssm.token_id
+    LEFT JOIN user_xp ux ON sc.wallet_address = ux.wallet_address
+    WHERE sc.wallet_address = ?
+    ORDER BY sc.is_active DESC, sc.updated_at DESC
+  `);
+  return stmt.all(walletAddress.toLowerCase()) as SanctuaryCompanionWithMeta[];
+}
+
+export function selectCompanion(walletAddress: string, tokenId: number): SanctuaryCompanion {
+  const db = getDatabase();
+  const addr = walletAddress.toLowerCase();
+
+  const txn = db.transaction(() => {
+    db.prepare('UPDATE sanctuary_companions SET is_active = 0, updated_at = CURRENT_TIMESTAMP WHERE wallet_address = ? AND is_active = 1')
+      .run(addr);
+
+    const existing = db.prepare('SELECT id FROM sanctuary_companions WHERE wallet_address = ? AND token_id = ?')
+      .get(addr, tokenId) as { id: number } | undefined;
+
+    if (existing) {
+      db.prepare('UPDATE sanctuary_companions SET is_active = 1, updated_at = CURRENT_TIMESTAMP WHERE id = ?')
+        .run(existing.id);
+    } else {
+      db.prepare(`
+        INSERT INTO sanctuary_companions (wallet_address, token_id, is_active, current_activity, bond_score, total_interactions)
+        VALUES (?, ?, 1, 'lounging', 0.0, 0)
+      `).run(addr, tokenId);
+
+      addJournalEntry(addr, tokenId, 'system', 'Companion awakened in the Sanctuary for the first time.');
+    }
+
+    return db.prepare('SELECT * FROM sanctuary_companions WHERE wallet_address = ? AND token_id = ?')
+      .get(addr, tokenId) as SanctuaryCompanion;
+  });
+
+  return txn();
+}
+
+export function switchCompanion(walletAddress: string, newTokenId: number): SanctuaryCompanion {
+  const db = getDatabase();
+  const addr = walletAddress.toLowerCase();
+
+  const txn = db.transaction(() => {
+    const current = db.prepare('SELECT * FROM sanctuary_companions WHERE wallet_address = ? AND is_active = 1')
+      .get(addr) as SanctuaryCompanion | undefined;
+
+    if (current) {
+      db.prepare('UPDATE sanctuary_companions SET is_active = 0, updated_at = CURRENT_TIMESTAMP WHERE id = ?')
+        .run(current.id);
+      addJournalEntry(addr, current.token_id, 'system', 'Companion resting while another takes the lead.');
+    }
+
+    const existing = db.prepare('SELECT id FROM sanctuary_companions WHERE wallet_address = ? AND token_id = ?')
+      .get(addr, newTokenId) as { id: number } | undefined;
+
+    if (existing) {
+      db.prepare('UPDATE sanctuary_companions SET is_active = 1, updated_at = CURRENT_TIMESTAMP WHERE id = ?')
+        .run(existing.id);
+    } else {
+      db.prepare(`
+        INSERT INTO sanctuary_companions (wallet_address, token_id, is_active, current_activity, bond_score, total_interactions)
+        VALUES (?, ?, 1, 'lounging', 0.0, 0)
+      `).run(addr, newTokenId);
+    }
+
+    addJournalEntry(addr, newTokenId, 'system', 'Companion activated as the new lead.');
+
+    return db.prepare('SELECT * FROM sanctuary_companions WHERE wallet_address = ? AND token_id = ?')
+      .get(addr, newTokenId) as SanctuaryCompanion;
+  });
+
+  return txn();
+}
+
+export function interactWithCompanion(
+  walletAddress: string, tokenId: number, action: 'feed' | 'pet' | 'talk'
+): { companion: SanctuaryCompanion; journal: SanctuaryJournalEntry } {
+  const db = getDatabase();
+  const addr = walletAddress.toLowerCase();
+
+  const bondGain: Record<string, number> = { feed: 0.5, pet: 0.3, talk: 0.2 };
+  const messages: Record<string, string> = {
+    feed: 'Enjoyed a tasty cosmic treat. Bond strengthened!',
+    pet: 'Received gentle pats. Feeling cozy and loved.',
+    talk: 'Had a heartfelt conversation with their owner.',
+  };
+
+  const txn = db.transaction(() => {
+    const comp = db.prepare(
+      'SELECT * FROM sanctuary_companions WHERE wallet_address = ? AND token_id = ? AND is_active = 1'
+    ).get(addr, tokenId) as SanctuaryCompanion | undefined;
+
+    if (!comp) throw new Error('No active companion found');
+
+    db.prepare(`
+      UPDATE sanctuary_companions
+      SET bond_score = MIN(bond_score + ?, 100.0),
+          total_interactions = total_interactions + 1,
+          updated_at = CURRENT_TIMESTAMP
+      WHERE id = ?
+    `).run(bondGain[action], comp.id);
+
+    const journal = addJournalEntry(addr, tokenId, 'interaction', messages[action],
+      JSON.stringify({ action }));
+
+    const updated = db.prepare('SELECT * FROM sanctuary_companions WHERE id = ?')
+      .get(comp.id) as SanctuaryCompanion;
+
+    return { companion: updated, journal };
+  });
+
+  return txn();
+}
+
+export function addJournalEntry(
+  walletAddress: string, tokenId: number, entryType: string, content: string, metadata: string = '{}'
+): SanctuaryJournalEntry {
+  const db = getDatabase();
+  const stmt = db.prepare(`
+    INSERT INTO sanctuary_journal (wallet_address, token_id, entry_type, content, metadata)
+    VALUES (?, ?, ?, ?, ?)
+  `);
+  const result = stmt.run(walletAddress.toLowerCase(), tokenId, entryType, content, metadata);
+  return db.prepare('SELECT * FROM sanctuary_journal WHERE id = ?').get(result.lastInsertRowid) as SanctuaryJournalEntry;
+}
+
+export function getJournalEntries(walletAddress: string, tokenId: number, limit: number = 20): SanctuaryJournalEntry[] {
+  const db = getDatabase();
+  const stmt = db.prepare(`
+    SELECT * FROM sanctuary_journal
+    WHERE wallet_address = ? AND token_id = ?
+    ORDER BY created_at DESC
+    LIMIT ?
+  `);
+  return stmt.all(walletAddress.toLowerCase(), tokenId, limit) as SanctuaryJournalEntry[];
+}
+
+export function getSanctuaryMapLocations(): SanctuaryMapLocation[] {
+  const db = getDatabase();
+  return db.prepare('SELECT * FROM sanctuary_map_locations ORDER BY unlock_level, name').all() as SanctuaryMapLocation[];
+}
+
+export function getSanctuaryState(walletAddress: string): {
+  activeCompanion: SanctuaryCompanionWithMeta | null;
+  companions: SanctuaryCompanionWithMeta[];
+  recentJournal: SanctuaryJournalEntry[];
+} {
+  const addr = walletAddress.toLowerCase();
+  const activeCompanion = getActiveCompanion(addr);
+  const companions = getAllCompanions(addr);
+  const recentJournal = activeCompanion
+    ? getJournalEntries(addr, activeCompanion.token_id, 10)
+    : [];
+
+  return { activeCompanion, companions, recentJournal };
 }

--- a/lib/sanctuary/__tests__/db.test.ts
+++ b/lib/sanctuary/__tests__/db.test.ts
@@ -1,0 +1,286 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import Database from 'better-sqlite3';
+import fs from 'fs';
+import path from 'path';
+
+function createTestDb(): Database.Database {
+  const db = new Database(':memory:');
+  db.pragma('journal_mode = WAL');
+  db.pragma('foreign_keys = ON');
+
+  db.exec(`
+    CREATE TABLE star_skrumpey_metadata (
+      token_id INTEGER PRIMARY KEY,
+      name TEXT,
+      constellation TEXT,
+      aura TEXT,
+      form TEXT,
+      mood TEXT,
+      eyes TEXT,
+      background TEXT
+    )
+  `);
+
+  db.exec(`
+    CREATE TABLE user_xp (
+      wallet_address TEXT PRIMARY KEY,
+      total_xp INTEGER DEFAULT 0,
+      level INTEGER DEFAULT 1
+    )
+  `);
+
+  db.exec(`
+    CREATE TABLE user_profiles (
+      wallet_address TEXT PRIMARY KEY,
+      display_name TEXT
+    )
+  `);
+
+  const sanctuarySql = fs.readFileSync(
+    path.join(process.cwd(), 'scripts', 'init-sanctuary.sql'), 'utf-8'
+  );
+  db.exec(sanctuarySql);
+
+  db.prepare('INSERT INTO star_skrumpey_metadata (token_id, name, constellation, aura, form, mood) VALUES (?, ?, ?, ?, ?, ?)')
+    .run(3, 'Star #3', 'aether', 'mystic', 'classic', 'happy');
+  db.prepare('INSERT INTO star_skrumpey_metadata (token_id, name, constellation, aura, form, mood) VALUES (?, ?, ?, ?, ?, ?)')
+    .run(17, 'Star #17', 'spectra', 'radiant', 'evolved', 'calm');
+  db.prepare('INSERT INTO star_skrumpey_metadata (token_id, name, constellation, aura, form, mood) VALUES (?, ?, ?, ?, ?, ?)')
+    .run(20, 'Star #20', 'solveil', 'bright', 'prime', 'excited');
+
+  db.prepare('INSERT INTO user_xp (wallet_address, total_xp, level) VALUES (?, ?, ?)')
+    .run('0xalice', 500, 5);
+  db.prepare('INSERT INTO user_xp (wallet_address, total_xp, level) VALUES (?, ?, ?)')
+    .run('0xbob', 100, 2);
+
+  return db;
+}
+
+describe('Sanctuary Schema', () => {
+  let db: Database.Database;
+
+  beforeAll(() => {
+    db = createTestDb();
+  });
+
+  it('creates sanctuary_companions table', () => {
+    const tables = db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'sanctuary_%'").all() as { name: string }[];
+    const names = tables.map(t => t.name);
+    expect(names).toContain('sanctuary_companions');
+    expect(names).toContain('sanctuary_map_locations');
+    expect(names).toContain('sanctuary_journal');
+  });
+
+  it('enforces unique wallet+token constraint', () => {
+    db.prepare('INSERT INTO sanctuary_companions (wallet_address, token_id, is_active) VALUES (?, ?, ?)').run('0xalice', 3, 1);
+    expect(() => {
+      db.prepare('INSERT INTO sanctuary_companions (wallet_address, token_id, is_active) VALUES (?, ?, ?)').run('0xalice', 3, 0);
+    }).toThrow();
+  });
+
+  it('enforces foreign key to star_skrumpey_metadata', () => {
+    expect(() => {
+      db.prepare('INSERT INTO sanctuary_companions (wallet_address, token_id, is_active) VALUES (?, ?, ?)').run('0xalice', 99999, 0);
+    }).toThrow();
+  });
+
+  it('enforces journal entry_type check constraint', () => {
+    expect(() => {
+      db.prepare("INSERT INTO sanctuary_journal (wallet_address, token_id, entry_type, content) VALUES (?, ?, ?, ?)")
+        .run('0xalice', 3, 'invalid_type', 'test');
+    }).toThrow();
+  });
+});
+
+describe('Companion Selection', () => {
+  let db: Database.Database;
+
+  beforeAll(() => {
+    db = createTestDb();
+  });
+
+  it('selects a companion and marks it active', () => {
+    db.prepare('INSERT INTO sanctuary_companions (wallet_address, token_id, is_active) VALUES (?, ?, ?)').run('0xalice', 3, 1);
+    const row = db.prepare('SELECT * FROM sanctuary_companions WHERE wallet_address = ? AND is_active = 1').get('0xalice') as any;
+    expect(row).toBeTruthy();
+    expect(row.token_id).toBe(3);
+    expect(row.bond_score).toBe(0.0);
+    expect(row.current_activity).toBe('lounging');
+  });
+
+  it('switching deactivates previous and activates new', () => {
+    db.prepare('UPDATE sanctuary_companions SET is_active = 0 WHERE wallet_address = ?').run('0xalice');
+    db.prepare('INSERT INTO sanctuary_companions (wallet_address, token_id, is_active) VALUES (?, ?, ?)').run('0xalice', 17, 1);
+
+    const active = db.prepare('SELECT * FROM sanctuary_companions WHERE wallet_address = ? AND is_active = 1').all('0xalice') as any[];
+    expect(active.length).toBe(1);
+    expect(active[0].token_id).toBe(17);
+
+    const old = db.prepare('SELECT * FROM sanctuary_companions WHERE wallet_address = ? AND token_id = ?').get('0xalice', 3) as any;
+    expect(old.is_active).toBe(0);
+  });
+
+  it('preserves per-token progress on switch', () => {
+    db.prepare('UPDATE sanctuary_companions SET bond_score = 5.5, total_interactions = 10 WHERE wallet_address = ? AND token_id = ?')
+      .run('0xalice', 3);
+
+    db.prepare('UPDATE sanctuary_companions SET is_active = 0 WHERE wallet_address = ?').run('0xalice');
+    db.prepare('UPDATE sanctuary_companions SET is_active = 1 WHERE wallet_address = ? AND token_id = ?').run('0xalice', 3);
+
+    const restored = db.prepare('SELECT * FROM sanctuary_companions WHERE wallet_address = ? AND token_id = ?').get('0xalice', 3) as any;
+    expect(restored.bond_score).toBe(5.5);
+    expect(restored.total_interactions).toBe(10);
+    expect(restored.is_active).toBe(1);
+  });
+
+  it('different wallets have independent companions', () => {
+    db.prepare('INSERT INTO sanctuary_companions (wallet_address, token_id, is_active) VALUES (?, ?, ?)').run('0xbob', 20, 1);
+
+    const aliceActive = db.prepare('SELECT * FROM sanctuary_companions WHERE wallet_address = ? AND is_active = 1').get('0xalice') as any;
+    const bobActive = db.prepare('SELECT * FROM sanctuary_companions WHERE wallet_address = ? AND is_active = 1').get('0xbob') as any;
+
+    expect(aliceActive.token_id).toBe(3);
+    expect(bobActive.token_id).toBe(20);
+  });
+});
+
+describe('Companion + Metadata Join', () => {
+  let db: Database.Database;
+
+  beforeAll(() => {
+    db = createTestDb();
+    db.prepare('INSERT INTO sanctuary_companions (wallet_address, token_id, is_active) VALUES (?, ?, ?)').run('0xalice', 3, 1);
+  });
+
+  it('joins companion with NFT metadata and XP', () => {
+    const row = db.prepare(`
+      SELECT sc.*, ssm.constellation, ssm.aura, ssm.form, ssm.mood,
+             COALESCE(ux.total_xp, 0) as total_xp, COALESCE(ux.level, 1) as level
+      FROM sanctuary_companions sc
+      JOIN star_skrumpey_metadata ssm ON sc.token_id = ssm.token_id
+      LEFT JOIN user_xp ux ON sc.wallet_address = ux.wallet_address
+      WHERE sc.wallet_address = ? AND sc.is_active = 1
+    `).get('0xalice') as any;
+
+    expect(row).toBeTruthy();
+    expect(row.token_id).toBe(3);
+    expect(row.constellation).toBe('aether');
+    expect(row.aura).toBe('mystic');
+    expect(row.total_xp).toBe(500);
+    expect(row.level).toBe(5);
+  });
+
+  it('returns level 1 for wallet with no XP', () => {
+    db.prepare('INSERT INTO sanctuary_companions (wallet_address, token_id, is_active) VALUES (?, ?, ?)').run('0xcharlie', 17, 1);
+
+    const row = db.prepare(`
+      SELECT sc.*, COALESCE(ux.total_xp, 0) as total_xp, COALESCE(ux.level, 1) as level
+      FROM sanctuary_companions sc
+      LEFT JOIN user_xp ux ON sc.wallet_address = ux.wallet_address
+      WHERE sc.wallet_address = ? AND sc.is_active = 1
+    `).get('0xcharlie') as any;
+
+    expect(row.total_xp).toBe(0);
+    expect(row.level).toBe(1);
+  });
+});
+
+describe('Journal', () => {
+  let db: Database.Database;
+
+  beforeAll(() => {
+    db = createTestDb();
+  });
+
+  it('records journal entries', () => {
+    db.prepare("INSERT INTO sanctuary_journal (wallet_address, token_id, entry_type, content) VALUES (?, ?, ?, ?)")
+      .run('0xalice', 3, 'system', 'Companion awakened.');
+    db.prepare("INSERT INTO sanctuary_journal (wallet_address, token_id, entry_type, content) VALUES (?, ?, ?, ?)")
+      .run('0xalice', 3, 'interaction', 'Fed a cosmic treat.');
+
+    const entries = db.prepare('SELECT * FROM sanctuary_journal WHERE wallet_address = ? AND token_id = ? ORDER BY id DESC')
+      .all('0xalice', 3) as any[];
+
+    expect(entries.length).toBe(2);
+    expect(entries[0].entry_type).toBe('interaction');
+    expect(entries[1].entry_type).toBe('system');
+  });
+
+  it('journal entries are per-companion', () => {
+    db.prepare("INSERT INTO sanctuary_journal (wallet_address, token_id, entry_type, content) VALUES (?, ?, ?, ?)")
+      .run('0xalice', 17, 'system', 'Different companion journal.');
+
+    const token3 = db.prepare('SELECT COUNT(*) as count FROM sanctuary_journal WHERE wallet_address = ? AND token_id = ?')
+      .get('0xalice', 3) as { count: number };
+    const token17 = db.prepare('SELECT COUNT(*) as count FROM sanctuary_journal WHERE wallet_address = ? AND token_id = ?')
+      .get('0xalice', 17) as { count: number };
+
+    expect(token3.count).toBe(2);
+    expect(token17.count).toBe(1);
+  });
+});
+
+describe('Companion Interactions', () => {
+  let db: Database.Database;
+
+  beforeAll(() => {
+    db = createTestDb();
+    db.prepare('INSERT INTO sanctuary_companions (wallet_address, token_id, is_active, bond_score, total_interactions) VALUES (?, ?, ?, ?, ?)')
+      .run('0xalice', 3, 1, 2.0, 5);
+  });
+
+  it('feed increases bond by 0.5 and increments interactions', () => {
+    db.prepare('UPDATE sanctuary_companions SET bond_score = bond_score + 0.5, total_interactions = total_interactions + 1, updated_at = CURRENT_TIMESTAMP WHERE wallet_address = ? AND token_id = ? AND is_active = 1')
+      .run('0xalice', 3);
+    db.prepare("INSERT INTO sanctuary_journal (wallet_address, token_id, entry_type, content, metadata) VALUES (?, ?, ?, ?, ?)")
+      .run('0xalice', 3, 'interaction', 'Enjoyed a tasty cosmic treat. Bond strengthened!', '{"action":"feed"}');
+
+    const comp = db.prepare('SELECT * FROM sanctuary_companions WHERE wallet_address = ? AND token_id = ?').get('0xalice', 3) as any;
+    expect(comp.bond_score).toBe(2.5);
+    expect(comp.total_interactions).toBe(6);
+
+    const journal = db.prepare("SELECT * FROM sanctuary_journal WHERE wallet_address = ? AND token_id = ? ORDER BY id DESC LIMIT 1").get('0xalice', 3) as any;
+    expect(journal.entry_type).toBe('interaction');
+    expect(JSON.parse(journal.metadata).action).toBe('feed');
+  });
+
+  it('bond_score caps at 100', () => {
+    db.prepare('UPDATE sanctuary_companions SET bond_score = 99.8 WHERE wallet_address = ? AND token_id = ?').run('0xalice', 3);
+    db.prepare('UPDATE sanctuary_companions SET bond_score = MIN(bond_score + 0.5, 100.0) WHERE wallet_address = ? AND token_id = ?').run('0xalice', 3);
+
+    const comp = db.prepare('SELECT * FROM sanctuary_companions WHERE wallet_address = ? AND token_id = ?').get('0xalice', 3) as any;
+    expect(comp.bond_score).toBe(100.0);
+  });
+});
+
+describe('Map Locations', () => {
+  let db: Database.Database;
+
+  beforeAll(() => {
+    db = createTestDb();
+
+    const locations = [
+      { name: 'Hot Springs', desc: 'Relaxing.', x: 0.2, y: 0.3, level: 1 },
+      { name: 'Training Grounds', desc: 'Practice.', x: 0.7, y: 0.2, level: 1 },
+      { name: 'Aura Forge', desc: 'Power.', x: 0.9, y: 0.4, level: 5 },
+    ];
+    const insert = db.prepare('INSERT INTO sanctuary_map_locations (name, description, position_x, position_y, unlock_level) VALUES (?, ?, ?, ?, ?)');
+    for (const loc of locations) {
+      insert.run(loc.name, loc.desc, loc.x, loc.y, loc.level);
+    }
+  });
+
+  it('returns seeded locations', () => {
+    const locs = db.prepare('SELECT * FROM sanctuary_map_locations ORDER BY unlock_level, name').all() as any[];
+    expect(locs.length).toBe(3);
+    expect(locs[0].name).toBe('Hot Springs');
+    expect(locs[2].name).toBe('Aura Forge');
+    expect(locs[2].unlock_level).toBe(5);
+  });
+
+  it('enforces unique location names', () => {
+    expect(() => {
+      db.prepare('INSERT INTO sanctuary_map_locations (name, position_x, position_y) VALUES (?, ?, ?)').run('Hot Springs', 0, 0);
+    }).toThrow();
+  });
+});

--- a/scripts/init-sanctuary.sql
+++ b/scripts/init-sanctuary.sql
@@ -1,0 +1,52 @@
+-- Star Sanctuary — V1 Foundation Schema
+-- Run from lib/db.ts initializeDatabase() via initializeSanctuary()
+
+-- Core companion state: which Skrumpey is active, its persistent state
+CREATE TABLE IF NOT EXISTS sanctuary_companions (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  wallet_address TEXT NOT NULL,
+  token_id INTEGER NOT NULL,
+  is_active INTEGER NOT NULL DEFAULT 0,
+  nickname TEXT,
+  current_activity TEXT DEFAULT 'lounging',
+  activity_started_at DATETIME,
+  activity_ends_at DATETIME,
+  bond_score REAL NOT NULL DEFAULT 0.0,
+  total_interactions INTEGER NOT NULL DEFAULT 0,
+  equipped_cosmetics TEXT DEFAULT '{}',
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE(wallet_address, token_id),
+  FOREIGN KEY (token_id) REFERENCES star_skrumpey_metadata(token_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_sanctuary_companions_wallet
+  ON sanctuary_companions(wallet_address);
+CREATE INDEX IF NOT EXISTS idx_sanctuary_companions_active
+  ON sanctuary_companions(wallet_address, is_active) WHERE is_active = 1;
+
+-- World map location definitions (seeded, not user-created)
+CREATE TABLE IF NOT EXISTS sanctuary_map_locations (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL UNIQUE,
+  description TEXT,
+  max_capacity INTEGER DEFAULT 20,
+  unlock_level INTEGER DEFAULT 1,
+  position_x REAL NOT NULL DEFAULT 0,
+  position_y REAL NOT NULL DEFAULT 0
+);
+
+-- Activity/interaction journal entries per companion
+CREATE TABLE IF NOT EXISTS sanctuary_journal (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  wallet_address TEXT NOT NULL,
+  token_id INTEGER NOT NULL,
+  entry_type TEXT NOT NULL CHECK (entry_type IN ('activity', 'interaction', 'quest', 'achievement', 'system')),
+  content TEXT NOT NULL,
+  metadata TEXT DEFAULT '{}',
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (token_id) REFERENCES star_skrumpey_metadata(token_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_sanctuary_journal_companion
+  ON sanctuary_journal(wallet_address, token_id, created_at DESC);


### PR DESCRIPTION
## Summary
- Enhanced `CompanionPanel` with mood emoji display, trait badges (constellation/aura/form), bond + XP progress bars, current activity block, latest journal snippet, and feed/pet/talk quick action buttons
- Added `interactWithCompanion()` DB function with per-action bond gains (feed +0.5, pet +0.3, talk +0.2), 100 cap, and automatic journal logging
- Added `POST /api/sanctuary/companion/interact` API route with input validation
- Also includes previously uncommitted API routes (companion, select, switch, state, map) and `init-sanctuary.sql` schema
- 103 tests passing (added 2 interaction tests)

## Test plan
- [x] `npx tsc --noEmit` — clean type check
- [x] `npx vitest run` — 103/103 tests pass
- [ ] Manual: connect wallet with Star Skrumpey, verify companion panel renders with all sections
- [ ] Manual: click feed/pet/talk, verify bond increases and journal updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)