### PR TITLE
fix(adminAuth): persist used nonces in SQLite to prevent replay

### DIFF
--- a/lib/__tests__/adminAuth.test.ts
+++ b/lib/__tests__/adminAuth.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import Database from 'better-sqlite3';
+import { privateKeyToAccount } from 'viem/accounts';
+
+const ADMIN_PK = '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d';
+const admin = privateKeyToAccount(ADMIN_PK);
+const ADMIN_ADDRESS = admin.address.toLowerCase();
+
+const { sharedDb, dbMocks } = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const BetterSqlite = require('better-sqlite3') as typeof import('better-sqlite3');
+  const db = new BetterSqlite(':memory:');
+  db.exec(`
+    CREATE TABLE admin_nonces (
+      nonce TEXT PRIMARY KEY,
+      expires_at INTEGER NOT NULL
+    );
+  `);
+  return {
+    sharedDb: db,
+    dbMocks: {
+      claimAdminNonce: (nonce: string, expiresAt: number): boolean => {
+        return db
+          .prepare('INSERT OR IGNORE INTO admin_nonces (nonce, expires_at) VALUES (?, ?)')
+          .run(nonce, expiresAt).changes === 1;
+      },
+      pruneExpiredAdminNonces: (now: number): number => {
+        return db
+          .prepare('DELETE FROM admin_nonces WHERE expires_at <= ?')
+          .run(now).changes;
+      },
+    },
+  };
+});
+
+vi.mock('../config', () => ({
+  ADMIN_WALLET_ADDRESS: ADMIN_ADDRESS,
+}));
+
+vi.mock('../logger', () => ({
+  logger: {
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+vi.mock('../db', () => dbMocks);
+
+async function makeAuthHeader(timestampMs: number): Promise<string> {
+  const signature = await admin.signMessage({
+    message: `SWO Admin Access\nTimestamp: ${timestampMs}`,
+  });
+  return `${ADMIN_ADDRESS}:${timestampMs}:${signature}`;
+}
+
+function requestWith(header: string | null): Request {
+  const headers = new Headers();
+  if (header !== null) headers.set('x-admin-auth', header);
+  return new Request('http://localhost/api/admin', { method: 'POST', headers });
+}
+
+describe('verifyAdminAccess — SQLite-backed nonce', () => {
+  let verifyAdminAccess: typeof import('../adminAuth').verifyAdminAccess;
+
+  beforeEach(async () => {
+    sharedDb.exec('DELETE FROM admin_nonces');
+    vi.resetModules();
+    ({ verifyAdminAccess } = await import('../adminAuth'));
+  });
+
+  it('accepts a valid signed request', async () => {
+    const ts = Date.now();
+    const header = await makeAuthHeader(ts);
+    const result = await verifyAdminAccess(requestWith(header));
+    expect(result.valid).toBe(true);
+    expect(result.adminAddress).toBe(ADMIN_ADDRESS);
+  });
+
+  it('rejects replay of the same timestamp', async () => {
+    const ts = Date.now();
+    const header = await makeAuthHeader(ts);
+    const first = await verifyAdminAccess(requestWith(header));
+    expect(first.valid).toBe(true);
+
+    const second = await verifyAdminAccess(requestWith(header));
+    expect(second.valid).toBe(false);
+    expect(second.error).toBe('Authentication already used');
+  });
+
+  it('persists consumed nonces across simulated process restarts', async () => {
+    const ts = Date.now();
+    const header = await makeAuthHeader(ts);
+    const first = await verifyAdminAccess(requestWith(header));
+    expect(first.valid).toBe(true);
+
+    // Simulate a second serverless instance: reload the adminAuth module. The
+    // db mock shares the same sqlite connection, so nonce state persists as
+    // it would in real SQLite/KV storage. This is the regression test for the
+    // original in-memory Map that would have let the replay succeed here.
+    vi.resetModules();
+    const fresh = await import('../adminAuth');
+    const replay = await fresh.verifyAdminAccess(requestWith(header));
+    expect(replay.valid).toBe(false);
+    expect(replay.error).toBe('Authentication already used');
+  });
+
+  it('rejects stale timestamps (> 5 min skew)', async () => {
+    const ts = Date.now() - 6 * 60 * 1000;
+    const header = await makeAuthHeader(ts);
+    const result = await verifyAdminAccess(requestWith(header));
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('Authentication expired');
+  });
+
+  it('rejects missing header', async () => {
+    const result = await verifyAdminAccess(requestWith(null));
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects non-admin wallet', async () => {
+    const ts = Date.now();
+    const header = `0x0000000000000000000000000000000000000001:${ts}:0xdeadbeef`;
+    const result = await verifyAdminAccess(requestWith(header));
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('Unauthorized wallet address');
+  });
+
+  it('rejects invalid signature from admin address', async () => {
+    const ts = Date.now();
+    // Sign a different message so recovered address won't match, but the
+    // signature is still structurally valid.
+    const wrongSig = await admin.signMessage({ message: 'not the admin message' });
+    const header = `${ADMIN_ADDRESS}:${ts}:${wrongSig}`;
+    const result = await verifyAdminAccess(requestWith(header));
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('Invalid signature');
+  });
+
+  it('does not consume the nonce on invalid signature', async () => {
+    const ts = Date.now();
+    const wrongSig = await admin.signMessage({ message: 'wrong message' });
+    const badHeader = `${ADMIN_ADDRESS}:${ts}:${wrongSig}`;
+    const rejected = await verifyAdminAccess(requestWith(badHeader));
+    expect(rejected.valid).toBe(false);
+
+    // A later legitimate signature for the same timestamp should still succeed,
+    // proving the bad attempt did not burn the nonce.
+    const goodHeader = await makeAuthHeader(ts);
+    const accepted = await verifyAdminAccess(requestWith(goodHeader));
+    expect(accepted.valid).toBe(true);
+  });
+});

--- a/lib/adminAuth.ts
+++ b/lib/adminAuth.ts
@@ -1,6 +1,7 @@
 import { verifyMessage } from 'viem';
 import { ADMIN_WALLET_ADDRESS } from './config';
 import { logger } from './logger';
+import { claimAdminNonce, pruneExpiredAdminNonces } from './db';
 
 export interface AdminAuthResult {
   valid: boolean;
@@ -9,15 +10,8 @@ export interface AdminAuthResult {
 }
 
 const NONCE_EXPIRY_MS = 5 * 60 * 1000; // 5 minutes
-const usedNonces = new Map<string, number>();
-
-function pruneExpiredNonces(now: number): void {
-  for (const [nonce, expiresAt] of usedNonces.entries()) {
-    if (expiresAt <= now) {
-      usedNonces.delete(nonce);
-    }
-  }
-}
+const PRUNE_INTERVAL_MS = 60 * 1000;   // best-effort GC once a minute
+let lastPruneAt = 0;
 
 function parseAuthHeader(authHeader: string): { address: string; timestamp: string; signature: string } | null {
   const [address, timestamp, signature] = authHeader.split(':');
@@ -50,16 +44,18 @@ export async function verifyAdminAccess(request: Request): Promise<AdminAuthResu
     }
 
     const now = Date.now();
-    pruneExpiredNonces(now);
+    if (now - lastPruneAt > PRUNE_INTERVAL_MS) {
+      lastPruneAt = now;
+      try {
+        pruneExpiredAdminNonces(now);
+      } catch (err) {
+        logger.warn('Admin auth: nonce prune failed', { error: String(err) });
+      }
+    }
 
     const timestampNum = Number.parseInt(parsed.timestamp, 10);
     if (Number.isNaN(timestampNum) || Math.abs(now - timestampNum) > NONCE_EXPIRY_MS) {
       return { valid: false, error: 'Authentication expired' };
-    }
-
-    const nonce = `${normalizedAddress}:${parsed.timestamp}`;
-    if (usedNonces.has(nonce)) {
-      return { valid: false, error: 'Authentication already used' };
     }
 
     const message = getSignedMessage(parsed.timestamp);
@@ -73,11 +69,18 @@ export async function verifyAdminAccess(request: Request): Promise<AdminAuthResu
       return { valid: false, error: 'Invalid signature' };
     }
 
-    usedNonces.set(nonce, now + NONCE_EXPIRY_MS);
+    // Claim the nonce atomically — only succeeds the first time.
+    // Keyed on (address, timestamp) so each signed timestamp can be used once,
+    // matching the original in-memory semantics.
+    const nonce = `${normalizedAddress}:${parsed.timestamp}`;
+    const claimed = claimAdminNonce(nonce, now + NONCE_EXPIRY_MS);
+    if (!claimed) {
+      return { valid: false, error: 'Authentication already used' };
+    }
+
     return { valid: true, adminAddress: normalizedAddress };
   } catch (error) {
     logger.error('Admin auth: authentication error', { error: String(error) });
     return { valid: false, error: 'Authentication failed' };
   }
 }
-

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -536,6 +536,20 @@ function initializeDatabase(database: Database.Database): void {
     CREATE INDEX IF NOT EXISTS idx_governance_nonces_expires ON governance_nonces(status, expires_at);
   `);
 
+  // Admin auth nonces table - persists consumed admin-auth nonces across process
+  // restarts and serverless instances so a signed admin message cannot be
+  // replayed within its TTL window.
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS admin_nonces (
+      nonce TEXT PRIMARY KEY,
+      expires_at INTEGER NOT NULL,
+      created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000)
+    )
+  `);
+  database.exec(`
+    CREATE INDEX IF NOT EXISTS idx_admin_nonces_expires ON admin_nonces(expires_at);
+  `);
+
   // ============================================================
   // FORUM TABLES (Database-backed with likes and edits)
   // ============================================================
@@ -5163,6 +5177,34 @@ export function getGovernanceNonceByValue(nonce: string): GovernanceNonce | null
   const db = getDatabase();
   const stmt = db.prepare('SELECT * FROM governance_nonces WHERE nonce = ?');
   return stmt.get(nonce) as GovernanceNonce | null;
+}
+
+// ============================================================
+// Admin Nonce Management (replay protection for admin auth)
+// ============================================================
+
+/**
+ * Atomically claim an admin-auth nonce. Returns true on first use, false if
+ * the nonce has already been consumed within its TTL window.
+ * Uses INSERT OR IGNORE so concurrent requests can't both succeed.
+ */
+export function claimAdminNonce(nonce: string, expiresAtMs: number): boolean {
+  const db = getDatabase();
+  const stmt = db.prepare(
+    'INSERT OR IGNORE INTO admin_nonces (nonce, expires_at) VALUES (?, ?)'
+  );
+  const result = stmt.run(nonce, expiresAtMs);
+  return result.changes === 1;
+}
+
+/**
+ * Delete admin nonces whose TTL has elapsed. Returns count removed.
+ */
+export function pruneExpiredAdminNonces(nowMs: number = Date.now()): number {
+  const db = getDatabase();
+  const stmt = db.prepare('DELETE FROM admin_nonces WHERE expires_at <= ?');
+  const result = stmt.run(nowMs);
+  return result.changes;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

**P1 from security audit.** `lib/adminAuth.ts:12` used an in-memory `usedNonces` Map to block replay of signed admin messages. That map does not survive process restarts and is not shared across serverless instances — within the 5-minute TTL window, the same signed header could be replayed on any instance that had not yet seen it.

This PR moves the used-nonce store to the existing SQLite database (`data/swo.db`) so replay protection holds across processes and instances.

## Changes

- **`lib/db.ts`**: new `admin_nonces` table (nonce PK, `expires_at`, indexed). Add `claimAdminNonce` (atomic `INSERT OR IGNORE`) and `pruneExpiredAdminNonces` helpers.
- **`lib/adminAuth.ts`**: replace in-memory Map with SQLite-backed claim. Claim the nonce *after* signature verification so a bogus signer cannot burn the real admin's nonces. Best-effort prune of expired rows once per minute per instance.
- **`lib/__tests__/adminAuth.test.ts`**: 8 tests — valid flow, replay within same instance, replay across simulated process restart (the regression guard), stale timestamp, missing header, non-admin wallet, invalid signature, and nonce preservation on failed auth.

## Test plan

- [x] `npx vitest run lib/__tests__/adminAuth.test.ts` — all 8 pass
- [x] `npx tsc --noEmit` — clean
- [ ] Manual smoke: call an admin-gated endpoint twice with the same header; second call returns `Authentication already used`
- [ ] Verify `admin_nonces` rows appear in `data/swo.db` and are pruned after 5 min

Note: the atomicity guarantee comes from SQLite's `INSERT OR IGNORE` on a UNIQUE PK, so concurrent requests with the same nonce can't both succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)