### PR TITLE
fix: social-connections GET auth to prevent username leakage

### DIFF
--- a/app/api/social-connections/route.ts
+++ b/app/api/social-connections/route.ts
@@ -29,7 +29,9 @@ function isValidWalletAddress(address: string): boolean {
 }
 
 /**
- * GET - Retrieve social connections for a wallet address
+ * GET - Retrieve social connections for a wallet address.
+ * Authenticated owner gets full connection details.
+ * Non-owner / unauthenticated callers get boolean flags only.
  */
 export async function GET(request: NextRequest) {
   try {
@@ -50,26 +52,38 @@ export async function GET(request: NextRequest) {
       );
     }
 
+    const auth = await verifyWalletAccess(request, walletAddress);
+    const isOwner = auth.valid;
+
     const db = getDatabase();
     const stmt = db.prepare(`
-      SELECT id, wallet_address, platform, platform_user_id, username, 
+      SELECT id, wallet_address, platform, platform_user_id, username,
              display_name, avatar_url, connected_at, updated_at
-      FROM social_connections 
+      FROM social_connections
       WHERE wallet_address = ?
       ORDER BY platform
     `);
-    
+
     const connections = stmt.all(walletAddress.toLowerCase()) as SocialConnectionRecord[];
 
-    // Transform to a more friendly format
-    const result = {
-      discord: connections.find(c => c.platform === 'discord') || null,
-      x: connections.find(c => c.platform === 'x') || null,
-    };
+    if (isOwner) {
+      const result = {
+        discord: connections.find(c => c.platform === 'discord') || null,
+        x: connections.find(c => c.platform === 'x') || null,
+      };
+
+      return NextResponse.json({
+        success: true,
+        connections: result,
+      });
+    }
 
     return NextResponse.json({
       success: true,
-      connections: result,
+      connections: {
+        discord: connections.some(c => c.platform === 'discord'),
+        x: connections.some(c => c.platform === 'x'),
+      },
     });
   } catch (err) {
     console.error('Failed to get social connections:', err);

--- a/components/SocialConnect.tsx
+++ b/components/SocialConnect.tsx
@@ -84,11 +84,16 @@ export default function SocialConnect({ connections = [], onConnectionChange }: 
   useEffect(() => {
     async function fetchConnections() {
       if (!address) return;
-      
+
       try {
-        const response = await fetch(`/api/social-connections?wallet=${address}`);
+        const headers: Record<string, string> = {};
+        const walletAuthHeader = await getWalletAuthHeader(address);
+        if (walletAuthHeader) {
+          headers['x-wallet-auth'] = walletAuthHeader;
+        }
+        const response = await fetch(`/api/social-connections?wallet=${address}`, { headers });
         const data = await response.json();
-        
+
         if (data.success && data.connections) {
           const fetchedConnections = transformDbConnections(data.connections as SocialConnectionResponse);
           setLocalConnections(fetchedConnections);
@@ -98,7 +103,7 @@ export default function SocialConnect({ connections = [], onConnectionChange }: 
         console.error('Failed to fetch social connections:', error);
       }
     }
-    
+
     fetchConnections();
   }, [address, onConnectionChange]);
 
@@ -116,16 +121,24 @@ export default function SocialConnect({ connections = [], onConnectionChange }: 
       window.history.replaceState({}, '', window.location.pathname);
       // Refresh connections
       if (address) {
-        fetch(`/api/social-connections?wallet=${address}`)
-          .then(res => res.json())
-          .then(data => {
+        (async () => {
+          try {
+            const headers: Record<string, string> = {};
+            const authHeader = await getWalletAuthHeader(address);
+            if (authHeader) {
+              headers['x-wallet-auth'] = authHeader;
+            }
+            const res = await fetch(`/api/social-connections?wallet=${address}`, { headers });
+            const data = await res.json();
             if (data.success && data.connections) {
               const fetchedConnections = transformDbConnections(data.connections as SocialConnectionResponse);
               setLocalConnections(fetchedConnections);
               onConnectionChange?.(fetchedConnections);
             }
-          })
-          .catch(console.error);
+          } catch (e) {
+            console.error('Failed to refresh connections:', e);
+          }
+        })();
       }
     } else if (error) {
       setMessage({ type: 'error', text: decodeURIComponent(error) });

--- a/components/UserProfileModal.tsx
+++ b/components/UserProfileModal.tsx
@@ -60,6 +60,8 @@ interface UserProfileData {
   xp?: number;
   discordUsername?: string | null;
   xUsername?: string | null;
+  hasDiscord?: boolean;
+  hasX?: boolean;
   starCount?: number;
   displayedBadges?: string[];
 }
@@ -163,8 +165,10 @@ export default function UserProfileModal({
         bio: profileData.profile?.bio,
         avatarTokenId: avatarTokenId,
         displayedBadges: profileData.profile?.displayed_badges ? JSON.parse(profileData.profile.displayed_badges) : [],
-        discordUsername: socialData.connections?.discord?.username || null,
-        xUsername: socialData.connections?.x?.username || null,
+        discordUsername: typeof socialData.connections?.discord === 'object' ? socialData.connections.discord?.username || null : null,
+        xUsername: typeof socialData.connections?.x === 'object' ? socialData.connections.x?.username || null : null,
+        hasDiscord: typeof socialData.connections?.discord === 'boolean' ? socialData.connections.discord : !!socialData.connections?.discord,
+        hasX: typeof socialData.connections?.x === 'boolean' ? socialData.connections.x : !!socialData.connections?.x,
         level: xpData.xp?.level || 1,
         xp: xpData.xp?.total_xp || 0,
         starCount: profileData.starCount || 0,
@@ -384,18 +388,18 @@ export default function UserProfileModal({
             )}
 
             {/* Social Connections */}
-            {(profile?.discordUsername || profile?.xUsername) && (
+            {(profile?.discordUsername || profile?.xUsername || profile?.hasDiscord || profile?.hasX) && (
               <div className="mb-4 flex justify-center gap-4">
-                {profile.discordUsername && (
+                {(profile.discordUsername || profile.hasDiscord) && (
                   <div className="flex items-center gap-2 text-xs bg-[#5865F2]/20 px-3 py-2 rounded-lg border border-[#5865F2]/30">
                     <span className="text-[#5865F2]">Discord:</span>
-                    <span className="text-white">{profile.discordUsername}</span>
+                    <span className="text-white">{profile.discordUsername || 'Connected'}</span>
                   </div>
                 )}
-                {profile.xUsername && (
+                {(profile.xUsername || profile.hasX) && (
                   <div className="flex items-center gap-2 text-xs bg-white/10 px-3 py-2 rounded-lg border border-white/20">
                     <span className="text-gray-400">𝕏:</span>
-                    <span className="text-white">@{profile.xUsername}</span>
+                    <span className="text-white">{profile.xUsername ? `@${profile.xUsername}` : 'Connected'}</span>
                   </div>
                 )}
               </div>


### PR DESCRIPTION
## Summary
- `/api/social-connections` GET now checks `x-wallet-auth` header to determine if the caller owns the queried wallet
- **Owner (authenticated)**: returns full connection details (username, platform_user_id, avatar, etc.)
- **Non-owner / unauthenticated**: returns only boolean flags (`{ discord: true/false, x: true/false }`)
- Updated `SocialConnect.tsx` to send auth header on GET requests (owner managing own connections)
- Updated `UserProfileModal.tsx` to gracefully handle boolean flags — shows "Connected" badge instead of username for other users' profiles

Fixes audit finding H-2: social-connections GET leaked Discord/X usernames without auth.

## Files Changed
- `app/api/social-connections/route.ts` — added `verifyWalletAccess` to GET, conditional response shape
- `components/SocialConnect.tsx` — added `x-wallet-auth` header to GET fetches
- `components/UserProfileModal.tsx` — handles both full objects and boolean flags in social data

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS
- **vitest run**: PASS (69/69)
Overall: PASS

## Test plan
- [ ] Verify owner can see their own full social connections on profile/settings
- [ ] Verify viewing another user's profile shows "Connected" badges (not usernames)
- [ ] Verify unauthenticated API call returns `{ discord: true/false, x: true/false }`
- [ ] Verify DELETE still works with wallet auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)