### PR TITLE
feat: sanctuary journal system + balance pass + chat architecture

### DIFF
--- a/app/api/sanctuary/companion/interact/route.ts
+++ b/app/api/sanctuary/companion/interact/route.ts
@@ -26,7 +26,9 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ success: true, ...result });
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Failed to interact';
-    const status = message.includes('No active companion') ? 404 : 500;
+    const status = message.includes('No active companion') ? 404
+      : message.includes('Daily interaction limit') ? 429
+      : 500;
     return NextResponse.json({ success: false, error: message }, { status });
   }
 }

--- a/app/api/sanctuary/companion/journal/route.ts
+++ b/app/api/sanctuary/companion/journal/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getActiveCompanion, getJournalEntriesPaginated, getJournalStats } from '@/lib/db';
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const address = searchParams.get('address');
+
+    if (!address) {
+      return NextResponse.json({ success: false, error: 'Address is required' }, { status: 400 });
+    }
+
+    const tokenIdParam = searchParams.get('token_id');
+    let tokenId: number;
+
+    if (tokenIdParam) {
+      tokenId = parseInt(tokenIdParam, 10);
+      if (isNaN(tokenId)) {
+        return NextResponse.json({ success: false, error: 'Invalid token_id' }, { status: 400 });
+      }
+    } else {
+      const active = getActiveCompanion(address);
+      if (!active) {
+        return NextResponse.json({ success: false, error: 'No active companion' }, { status: 404 });
+      }
+      tokenId = active.token_id;
+    }
+
+    const page = parseInt(searchParams.get('page') ?? '1', 10);
+    const limit = parseInt(searchParams.get('limit') ?? '20', 10);
+    const type = searchParams.get('type') ?? undefined;
+    const before = searchParams.get('before') ?? undefined;
+    const includeStats = searchParams.get('stats') === 'true';
+
+    const result = getJournalEntriesPaginated(address, tokenId, { page, limit, type, before });
+
+    const response: Record<string, unknown> = {
+      success: true,
+      ...result,
+    };
+
+    if (includeStats) {
+      response.stats = getJournalStats(address, tokenId);
+    }
+
+    return NextResponse.json(response);
+  } catch (error) {
+    console.error('Sanctuary journal GET error:', error);
+    return NextResponse.json({ success: false, error: 'Failed to fetch journal' }, { status: 500 });
+  }
+}

--- a/app/sanctuary/SanctuaryContent.tsx
+++ b/app/sanctuary/SanctuaryContent.tsx
@@ -231,6 +231,7 @@ function CompanionPanel({
   onSendToActivity,
   onCompleteActivity,
   interacting,
+  interactError,
 }: {
   companion: Companion;
   latestJournal: JournalEntry | null;
@@ -239,6 +240,7 @@ function CompanionPanel({
   onSendToActivity: (locationId: number) => void;
   onCompleteActivity: () => void;
   interacting: string | null;
+  interactError?: string | null;
 }) {
   const [showLocations, setShowLocations] = useState(false);
   const mood = MOOD_CONFIG[companion.mood ?? ''] ?? DEFAULT_MOOD;
@@ -333,6 +335,10 @@ function CompanionPanel({
           <span className="text-[7px] text-gray-400 group-hover:text-[#ffd700] transition-colors">Send</span>
         </button>
       </div>
+
+      {interactError && (
+        <p className="text-red-400 text-[7px] text-center">{interactError}</p>
+      )}
 
       {showLocations && !isOnActivity && (
         <div className="bg-[#0a0a15] rounded-lg border border-[#2a2a4e] p-3 space-y-1.5">
@@ -534,6 +540,7 @@ function HolderSanctuary() {
   const [loading, setLoading] = useState(true);
   const [interacting, setInteracting] = useState<string | null>(null);
   const [selectedMapLocation, setSelectedMapLocation] = useState<number | null>(null);
+  const [interactError, setInteractError] = useState<string | null>(null);
 
   const refreshState = useCallback(async () => {
     if (!address) return;
@@ -560,6 +567,7 @@ function HolderSanctuary() {
   const handleInteract = async (action: 'feed' | 'pet' | 'talk') => {
     if (!address || !companion || interacting) return;
     setInteracting(action);
+    setInteractError(null);
     try {
       const res = await fetch('/api/sanctuary/companion/interact', {
         method: 'POST',
@@ -576,6 +584,8 @@ function HolderSanctuary() {
         if (data.journal) {
           setJournal((prev) => [data.journal, ...prev].slice(0, 10));
         }
+      } else if (res.status === 429) {
+        setInteractError(data.error);
       }
     } catch {
       // silently fail
@@ -683,6 +693,7 @@ function HolderSanctuary() {
               onSendToActivity={handleSendToActivity}
               onCompleteActivity={handleCompleteActivity}
               interacting={interacting}
+              interactError={interactError}
             />
             <JournalPanel entries={journal} address={address} tokenId={companion.token_id} />
           </>

--- a/app/sanctuary/SanctuaryContent.tsx
+++ b/app/sanctuary/SanctuaryContent.tsx
@@ -372,28 +372,153 @@ function CompanionPanel({
   );
 }
 
-function JournalPanel({ entries }: { entries: JournalEntry[] }) {
+const ENTRY_TYPE_CONFIG: Record<string, { icon: string; label: string; color: string }> = {
+  activity: { icon: '🗺️', label: 'Activity', color: '#44ff88' },
+  interaction: { icon: '💫', label: 'Interaction', color: '#ff66aa' },
+  system: { icon: '⚙️', label: 'System', color: '#888' },
+  quest: { icon: '⚔️', label: 'Quest', color: '#ffd700' },
+  achievement: { icon: '🏆', label: 'Achievement', color: '#9966ff' },
+};
+
+function JournalEntryRow({ entry }: { entry: JournalEntry }) {
+  const config = ENTRY_TYPE_CONFIG[entry.entry_type] ?? { icon: '📜', label: entry.entry_type, color: '#666' };
+  const date = new Date(entry.created_at + 'Z');
+  const timeStr = date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  const dateStr = date.toLocaleDateString([], { month: 'short', day: 'numeric' });
+
+  return (
+    <div className="border-l-2 pl-2 py-1" style={{ borderColor: config.color + '60' }}>
+      <p className="text-white text-[8px]">{config.icon} {entry.content}</p>
+      <p className="text-gray-600 text-[6px] mt-0.5">
+        <span style={{ color: config.color }} className="opacity-70">{config.label}</span>
+        {' — '}{dateStr} {timeStr}
+      </p>
+    </div>
+  );
+}
+
+function JournalPanel({ entries, address, tokenId }: { entries: JournalEntry[]; address?: string; tokenId?: number }) {
+  const [expanded, setExpanded] = useState(false);
+  const [fullEntries, setFullEntries] = useState<JournalEntry[]>([]);
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [total, setTotal] = useState(0);
+  const [typeFilter, setTypeFilter] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [stats, setStats] = useState<Record<string, number> | null>(null);
+
+  const fetchJournal = useCallback(async (p: number, type: string | null) => {
+    if (!address || !tokenId) return;
+    setLoading(true);
+    try {
+      const params = new URLSearchParams({ address, token_id: String(tokenId), page: String(p), limit: '15' });
+      if (type) params.set('type', type);
+      if (p === 1) params.set('stats', 'true');
+      const res = await fetch(`/api/sanctuary/companion/journal?${params}`);
+      const data = await res.json();
+      if (data.success) {
+        setFullEntries(data.entries);
+        setPage(data.page);
+        setTotalPages(data.totalPages);
+        setTotal(data.total);
+        if (data.stats) setStats(data.stats.byType);
+      }
+    } catch { /* ignore */ }
+    setLoading(false);
+  }, [address, tokenId]);
+
+  const handleExpand = () => {
+    if (!expanded) {
+      setExpanded(true);
+      fetchJournal(1, null);
+    } else {
+      setExpanded(false);
+    }
+  };
+
+  const handleFilterChange = (type: string | null) => {
+    setTypeFilter(type);
+    setPage(1);
+    fetchJournal(1, type);
+  };
+
+  const displayEntries = expanded ? fullEntries : entries;
+
   return (
     <div className="pixel-card p-6">
-      <h3 className="text-[#ffd700] text-xs tracking-wider mb-3">JOURNAL</h3>
-      {entries.length === 0 ? (
-        <p className="text-gray-500 text-[8px]">No entries yet.</p>
-      ) : (
-        <div className="space-y-2 max-h-48 overflow-y-auto">
-          {entries.map((entry) => {
-            const typeIcon = entry.entry_type === 'activity' ? '🗺️'
-              : entry.entry_type === 'interaction' ? '💫'
-              : entry.entry_type === 'system' ? '⚙️'
-              : '📜';
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-[#ffd700] text-xs tracking-wider">JOURNAL</h3>
+        {address && tokenId && entries.length > 0 && (
+          <button
+            onClick={handleExpand}
+            className="text-[7px] text-[#9966ff] hover:text-[#bb88ff] transition-colors"
+          >
+            {expanded ? 'COLLAPSE' : 'VIEW FULL HISTORY'}
+          </button>
+        )}
+      </div>
+
+      {expanded && stats && (
+        <div className="flex flex-wrap gap-1 mb-3">
+          <button
+            onClick={() => handleFilterChange(null)}
+            className={`text-[7px] px-1.5 py-0.5 rounded border transition-colors ${
+              !typeFilter ? 'border-[#ffd700]/50 text-[#ffd700] bg-[#ffd700]/10' : 'border-[#2a2a4e] text-gray-500 hover:text-gray-300'
+            }`}
+          >
+            ALL ({total})
+          </button>
+          {Object.entries(ENTRY_TYPE_CONFIG).map(([type, config]) => {
+            const count = stats[type] ?? 0;
+            if (count === 0) return null;
             return (
-              <div key={entry.id} className="border-l-2 border-[#2a2a4e] pl-2">
-                <p className="text-white text-[8px]">{typeIcon} {entry.content}</p>
-                <p className="text-gray-600 text-[6px]">
-                  {entry.entry_type} — {new Date(entry.created_at).toLocaleDateString()}
-                </p>
-              </div>
+              <button
+                key={type}
+                onClick={() => handleFilterChange(type)}
+                className={`text-[7px] px-1.5 py-0.5 rounded border transition-colors ${
+                  typeFilter === type ? 'bg-white/5' : 'hover:text-gray-300'
+                }`}
+                style={{
+                  borderColor: typeFilter === type ? config.color + '80' : '#2a2a4e',
+                  color: typeFilter === type ? config.color : '#888',
+                }}
+              >
+                {config.icon} {config.label} ({count})
+              </button>
             );
           })}
+        </div>
+      )}
+
+      {displayEntries.length === 0 ? (
+        <p className="text-gray-500 text-[8px]">{loading ? 'Loading...' : 'No entries yet.'}</p>
+      ) : (
+        <div className={`space-y-2 overflow-y-auto ${expanded ? 'max-h-96' : 'max-h-48'}`}>
+          {displayEntries.map((entry) => (
+            <JournalEntryRow key={entry.id} entry={entry} />
+          ))}
+        </div>
+      )}
+
+      {expanded && totalPages > 1 && (
+        <div className="flex items-center justify-between mt-3 pt-2 border-t border-[#2a2a4e]">
+          <button
+            onClick={() => { const p = page - 1; setPage(p); fetchJournal(p, typeFilter); }}
+            disabled={page <= 1 || loading}
+            className="text-[7px] text-[#9966ff] disabled:text-gray-700 disabled:cursor-not-allowed"
+          >
+            PREV
+          </button>
+          <span className="text-gray-500 text-[7px]">
+            {page} / {totalPages}
+          </span>
+          <button
+            onClick={() => { const p = page + 1; setPage(p); fetchJournal(p, typeFilter); }}
+            disabled={page >= totalPages || loading}
+            className="text-[7px] text-[#9966ff] disabled:text-gray-700 disabled:cursor-not-allowed"
+          >
+            NEXT
+          </button>
         </div>
       )}
     </div>
@@ -559,7 +684,7 @@ function HolderSanctuary() {
               onCompleteActivity={handleCompleteActivity}
               interacting={interacting}
             />
-            <JournalPanel entries={journal} />
+            <JournalPanel entries={journal} address={address} tokenId={companion.token_id} />
           </>
         ) : (
           <div className="pixel-card p-6 md:col-span-2 text-center">

--- a/docs/SANCTUARY_CHAT_ARCH.md
+++ b/docs/SANCTUARY_CHAT_ARCH.md
@@ -1,0 +1,134 @@
+# ADR-002: Companion Chat Architecture
+
+**Status:** Proposed  
+**Date:** 2026-04-20  
+**Deciders:** Operator (InverseAltruism), Clarvis (executive function)  
+**Depends on:** ADR-001 (Star Sanctuary Architecture)
+
+---
+
+## Context
+
+Sanctuary companions need a lightweight chat system where holders can "talk" to their active Skrumpey. The companion should respond with personality derived from its NFT traits (constellation, aura, form, mood) and its bond/activity history from the journal.
+
+This ADR defines the minimal architecture for V1 chat. It should feel personalized without requiring heavy infrastructure or high ongoing costs.
+
+---
+
+## Decisions
+
+### D1. LLM Backend: Single-model, Server-side Only
+
+Chat completions run server-side via a single OpenRouter call per message. No streaming for V1 (simplifies rate-limiting and cost control). The model should be small and fast (Gemini Flash or equivalent, $0.05-0.15/1k tokens).
+
+**Rationale:** No client-side inference (too heavy for mobile wallets), no websocket complexity. A simple POST endpoint is sufficient for turn-based chat.
+
+### D2. Personality System: Template + Trait Injection
+
+Each chat request builds a system prompt from:
+1. **Base template** — Skrumpey persona (playful, curious, loyal)
+2. **Trait modifiers** — constellation/aura/mood adjust tone and vocabulary
+3. **Bond context** — high bond = more affectionate/open; low bond = shy/brief
+4. **Recent journal** — last 5 journal entries included for continuity
+
+Trait → personality mappings are static config (no DB, no LLM to generate them).
+
+```typescript
+// Example trait personality config
+const MOOD_CHAT_STYLE: Record<string, string> = {
+  happy: 'enthusiastic and bubbly, uses exclamation marks',
+  calm: 'thoughtful and measured, sometimes philosophical',
+  excited: 'energetic, talks fast, jumps between topics',
+  mysterious: 'cryptic, speaks in riddles, hints at secrets',
+};
+```
+
+**Rationale:** Deterministic personality from on-chain traits makes each companion feel unique without per-companion fine-tuning. Bond level as a dial ensures progression affects the relationship.
+
+### D3. Conversation Memory: Session-scoped, Not Persistent
+
+V1 chat maintains conversation history within a single browser session (React state). No server-side conversation persistence beyond journal entries. When the user closes the tab, conversation resets.
+
+**Rationale:** Persistent chat history adds table complexity, retention concerns, and cost (LLM context grows). V1 validates the feature; V1.5 can add persistence if engagement warrants it.
+
+### D4. Rate Limiting: Per-wallet Daily Cap
+
+- **15 messages/day** per wallet (matches interaction cap cadence)
+- Server enforces via simple counter in `sanctuary_chat_usage` table
+- Each chat exchange awards **+0.1 bond** and **+1 XP** (lower than explicit interactions since chat is passive)
+
+**Rationale:** Prevents runaway API costs. 15 messages ~ $0.01-0.03/day per active user at Flash-tier pricing.
+
+### D5. Database Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS sanctuary_chat_usage (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  wallet_address TEXT NOT NULL,
+  token_id INTEGER NOT NULL,
+  message_count INTEGER DEFAULT 0,
+  last_reset_date TEXT NOT NULL, -- YYYY-MM-DD, resets daily
+  created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE(wallet_address, token_id, last_reset_date)
+);
+
+CREATE INDEX idx_chat_usage_wallet ON sanctuary_chat_usage(wallet_address, last_reset_date);
+```
+
+No chat history table in V1. Journal entries serve as the persistent record of notable conversations.
+
+### D6. API Route
+
+```
+POST /api/sanctuary/companion/chat
+Body: { address, token_id, message, history: [{role, content}] }
+Response: { success, reply, bond_gained, xp_gained, daily_remaining }
+```
+
+History is sent from the client (session state) to maintain context without server storage. Server validates history length (max 20 turns) to cap token usage.
+
+### D7. Notable Reply → Journal
+
+If the companion's reply contains certain trigger phrases or if bond crosses a threshold during chat, a journal entry is auto-created:
+- Entry type: `interaction`
+- Content: Brief summary of the exchange
+- Metadata: `{ action: 'chat', topic_hint: '...' }`
+
+This bridges ephemeral chat into the persistent journal timeline.
+
+### D8. UI: Inline Chat Panel
+
+Chat replaces the current "Talk" interaction button with an expandable chat panel within the CompanionPanel. Not a separate page, not a modal.
+
+- Collapsed: shows last reply (if any)
+- Expanded: scrollable message list + input field
+- Companion avatar (mood emoji) next to each reply
+- Max visible history: 20 messages before auto-scroll
+
+---
+
+## Implementation Sequence
+
+1. `sanctuary_chat_usage` table + init SQL
+2. `lib/sanctuary/chatPersonality.ts` — trait→prompt builder
+3. `POST /api/sanctuary/companion/chat` — route with rate limit + LLM call
+4. `CompanionPanel` — inline chat UI component
+5. Integration test: mock LLM, verify rate limit + bond/XP award + journal trigger
+
+---
+
+## Cost Estimate
+
+At 100 active users, 10 messages/day average:
+- ~1000 requests/day
+- ~50k input tokens + 25k output tokens/day (short prompts, brief replies)
+- Gemini Flash: ~$0.05/day
+- Monthly: ~$1.50
+
+---
+
+## Open Questions
+
+1. **Model choice:** Gemini Flash vs Claude Haiku vs local Qwen? Flash is cheapest; Haiku has better personality range; local has zero marginal cost but higher latency.
+2. **Content moderation:** Should we filter user messages before sending to LLM? For V1, the closed community (NFT holders only) likely doesn't need heavy moderation.
+3. **Companion evolution:** Should chat topics influence trait evolution? Deferred to `[SANCTUARY_TRAIT_EVOLUTION]`.

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -5802,13 +5802,27 @@ export function switchCompanion(walletAddress: string, newTokenId: number): Sanc
   return txn();
 }
 
+const DAILY_INTERACTION_CAP = 15;
+const INTERACTION_BOND: Record<string, number> = { feed: 0.5, pet: 0.3, talk: 0.2 };
+const INTERACTION_XP: Record<string, number> = { feed: 3, pet: 2, talk: 2 };
+
+function getDailyInteractionCount(db: ReturnType<typeof getDatabase>, addr: string, tokenId: number): number {
+  const todayStart = new Date();
+  todayStart.setUTCHours(0, 0, 0, 0);
+  const result = db.prepare(`
+    SELECT COUNT(*) as count FROM sanctuary_journal
+    WHERE wallet_address = ? AND token_id = ? AND entry_type = 'interaction'
+      AND created_at >= ?
+  `).get(addr, tokenId, todayStart.toISOString().replace('T', ' ').slice(0, 19)) as { count: number };
+  return result.count;
+}
+
 export function interactWithCompanion(
   walletAddress: string, tokenId: number, action: 'feed' | 'pet' | 'talk'
-): { companion: SanctuaryCompanion; journal: SanctuaryJournalEntry } {
+): { companion: SanctuaryCompanion; journal: SanctuaryJournalEntry; dailyRemaining: number } {
   const db = getDatabase();
   const addr = walletAddress.toLowerCase();
 
-  const bondGain: Record<string, number> = { feed: 0.5, pet: 0.3, talk: 0.2 };
   const messages: Record<string, string> = {
     feed: 'Enjoyed a tasty cosmic treat. Bond strengthened!',
     pet: 'Received gentle pats. Feeling cozy and loved.',
@@ -5822,21 +5836,31 @@ export function interactWithCompanion(
 
     if (!comp) throw new Error('No active companion found');
 
+    const dailyCount = getDailyInteractionCount(db, addr, tokenId);
+    if (dailyCount >= DAILY_INTERACTION_CAP) {
+      throw new Error('Daily interaction limit reached. Come back tomorrow!');
+    }
+
+    const bondGain = INTERACTION_BOND[action];
+    const xpGain = INTERACTION_XP[action];
+
     db.prepare(`
       UPDATE sanctuary_companions
       SET bond_score = MIN(bond_score + ?, 100.0),
           total_interactions = total_interactions + 1,
           updated_at = CURRENT_TIMESTAMP
       WHERE id = ?
-    `).run(bondGain[action], comp.id);
+    `).run(bondGain, comp.id);
+
+    addUserXP(addr, xpGain);
 
     const journal = addJournalEntry(addr, tokenId, 'interaction', messages[action],
-      JSON.stringify({ action }));
+      JSON.stringify({ action, bond: bondGain, xp: xpGain }));
 
     const updated = db.prepare('SELECT * FROM sanctuary_companions WHERE id = ?')
       .get(comp.id) as SanctuaryCompanion;
 
-    return { companion: updated, journal };
+    return { companion: updated, journal, dailyRemaining: DAILY_INTERACTION_CAP - dailyCount - 1 };
   });
 
   return txn();
@@ -5945,14 +5969,25 @@ const ACTIVITY_DURATIONS: Record<string, number> = {
 };
 
 const ACTIVITY_BOND_REWARDS: Record<string, number> = {
+  'Dream Hollow': 0.8,
+  'Nebula Kitchen': 1.2,
   'Hot Springs': 2.0,
-  'Training Grounds': 3.0,
-  'Star Garden': 2.5,
-  'Cosmic Library': 3.5,
-  'Nebula Kitchen': 1.5,
-  'Dream Hollow': 1.0,
-  'Aura Forge': 5.0,
-  'Observatory': 4.0,
+  'Star Garden': 2.8,
+  'Training Grounds': 4.0,
+  'Observatory': 5.5,
+  'Cosmic Library': 6.5,
+  'Aura Forge': 9.0,
+};
+
+const ACTIVITY_XP_REWARDS: Record<string, number> = {
+  'Dream Hollow': 5,
+  'Nebula Kitchen': 8,
+  'Hot Springs': 12,
+  'Star Garden': 15,
+  'Training Grounds': 20,
+  'Observatory': 25,
+  'Cosmic Library': 30,
+  'Aura Forge': 40,
 };
 
 export function sendToActivity(
@@ -6034,6 +6069,7 @@ export function completeActivity(
       : comp.current_activity;
 
     const bondReward = ACTIVITY_BOND_REWARDS[activityName] ?? 1.0;
+    const xpReward = ACTIVITY_XP_REWARDS[activityName] ?? 5;
 
     db.prepare(`
       UPDATE sanctuary_companions
@@ -6045,9 +6081,11 @@ export function completeActivity(
       WHERE id = ?
     `).run(bondReward, comp.id);
 
+    addUserXP(addr, xpReward);
+
     const journal = addJournalEntry(addr, tokenId, 'activity',
-      `Returned from ${activityName} feeling refreshed! Bond +${bondReward.toFixed(1)}`,
-      JSON.stringify({ action: 'complete_activity', location_name: activityName, bond_reward: bondReward }));
+      `Returned from ${activityName} feeling refreshed! Bond +${bondReward.toFixed(1)}, XP +${xpReward}`,
+      JSON.stringify({ action: 'complete_activity', location_name: activityName, bond_reward: bondReward, xp_reward: xpReward }));
 
     const updated = db.prepare('SELECT * FROM sanctuary_companions WHERE id = ?')
       .get(comp.id) as SanctuaryCompanion;

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -5865,6 +5865,69 @@ export function getJournalEntries(walletAddress: string, tokenId: number, limit:
   return stmt.all(walletAddress.toLowerCase(), tokenId, limit) as SanctuaryJournalEntry[];
 }
 
+export function getJournalEntriesPaginated(
+  walletAddress: string, tokenId: number,
+  options: { page?: number; limit?: number; type?: string; before?: string }
+): { entries: SanctuaryJournalEntry[]; total: number; page: number; totalPages: number } {
+  const db = getDatabase();
+  const addr = walletAddress.toLowerCase();
+  const page = Math.max(1, options.page ?? 1);
+  const limit = Math.min(50, Math.max(1, options.limit ?? 20));
+  const offset = (page - 1) * limit;
+
+  const conditions = ['wallet_address = ?', 'token_id = ?'];
+  const params: (string | number)[] = [addr, tokenId];
+
+  if (options.type) {
+    conditions.push('entry_type = ?');
+    params.push(options.type);
+  }
+  if (options.before) {
+    conditions.push('created_at < ?');
+    params.push(options.before);
+  }
+
+  const where = conditions.join(' AND ');
+
+  const total = (db.prepare(`SELECT COUNT(*) as count FROM sanctuary_journal WHERE ${where}`).get(...params) as { count: number }).count;
+
+  const entries = db.prepare(`
+    SELECT * FROM sanctuary_journal WHERE ${where}
+    ORDER BY created_at DESC LIMIT ? OFFSET ?
+  `).all(...params, limit, offset) as SanctuaryJournalEntry[];
+
+  return { entries, total, page, totalPages: Math.ceil(total / limit) || 1 };
+}
+
+export interface JournalStats {
+  total: number;
+  byType: Record<string, number>;
+  firstEntry: string | null;
+  lastEntry: string | null;
+}
+
+export function getJournalStats(walletAddress: string, tokenId: number): JournalStats {
+  const db = getDatabase();
+  const addr = walletAddress.toLowerCase();
+
+  const total = (db.prepare(
+    'SELECT COUNT(*) as count FROM sanctuary_journal WHERE wallet_address = ? AND token_id = ?'
+  ).get(addr, tokenId) as { count: number }).count;
+
+  const typeCounts = db.prepare(
+    'SELECT entry_type, COUNT(*) as count FROM sanctuary_journal WHERE wallet_address = ? AND token_id = ? GROUP BY entry_type'
+  ).all(addr, tokenId) as { entry_type: string; count: number }[];
+
+  const byType: Record<string, number> = {};
+  for (const row of typeCounts) byType[row.entry_type] = row.count;
+
+  const range = db.prepare(
+    'SELECT MIN(created_at) as first_entry, MAX(created_at) as last_entry FROM sanctuary_journal WHERE wallet_address = ? AND token_id = ?'
+  ).get(addr, tokenId) as { first_entry: string | null; last_entry: string | null };
+
+  return { total, byType, firstEntry: range.first_entry, lastEntry: range.last_entry };
+}
+
 export function getSanctuaryMapLocations(): SanctuaryMapLocation[] {
   const db = getDatabase();
   return db.prepare('SELECT * FROM sanctuary_map_locations ORDER BY unlock_level, name').all() as SanctuaryMapLocation[];

--- a/lib/sanctuary/__tests__/db.test.ts
+++ b/lib/sanctuary/__tests__/db.test.ts
@@ -285,6 +285,77 @@ describe('Map Locations', () => {
   });
 });
 
+describe('Journal Pagination & Stats', () => {
+  let db: Database.Database;
+
+  beforeAll(() => {
+    db = createTestDb();
+    db.prepare('INSERT INTO sanctuary_companions (wallet_address, token_id, is_active) VALUES (?, ?, ?)').run('0xpager', 3, 1);
+
+    const types = ['system', 'interaction', 'activity', 'quest', 'achievement'];
+    const insert = db.prepare("INSERT INTO sanctuary_journal (wallet_address, token_id, entry_type, content, created_at) VALUES (?, ?, ?, ?, ?)");
+    for (let i = 0; i < 35; i++) {
+      const type = types[i % types.length];
+      const ts = `2026-04-${String(1 + i).padStart(2, '0')} 12:00:00`;
+      insert.run('0xpager', 3, type, `Entry ${i + 1}`, ts);
+    }
+  });
+
+  it('paginates journal entries', () => {
+    const page1 = db.prepare(
+      'SELECT * FROM sanctuary_journal WHERE wallet_address = ? AND token_id = ? ORDER BY created_at DESC LIMIT ? OFFSET ?'
+    ).all('0xpager', 3, 10, 0) as any[];
+    const page2 = db.prepare(
+      'SELECT * FROM sanctuary_journal WHERE wallet_address = ? AND token_id = ? ORDER BY created_at DESC LIMIT ? OFFSET ?'
+    ).all('0xpager', 3, 10, 10) as any[];
+
+    expect(page1.length).toBe(10);
+    expect(page2.length).toBe(10);
+    expect(page1[0].content).not.toBe(page2[0].content);
+  });
+
+  it('filters by entry_type', () => {
+    const quests = db.prepare(
+      "SELECT * FROM sanctuary_journal WHERE wallet_address = ? AND token_id = ? AND entry_type = ? ORDER BY created_at DESC"
+    ).all('0xpager', 3, 'quest') as any[];
+
+    expect(quests.length).toBe(7);
+    for (const q of quests) expect(q.entry_type).toBe('quest');
+  });
+
+  it('computes journal stats by type', () => {
+    const typeCounts = db.prepare(
+      'SELECT entry_type, COUNT(*) as count FROM sanctuary_journal WHERE wallet_address = ? AND token_id = ? GROUP BY entry_type'
+    ).all('0xpager', 3) as { entry_type: string; count: number }[];
+
+    const byType: Record<string, number> = {};
+    for (const row of typeCounts) byType[row.entry_type] = row.count;
+
+    expect(byType.system).toBe(7);
+    expect(byType.interaction).toBe(7);
+    expect(byType.activity).toBe(7);
+    expect(byType.quest).toBe(7);
+    expect(byType.achievement).toBe(7);
+  });
+
+  it('returns correct total count', () => {
+    const total = db.prepare(
+      'SELECT COUNT(*) as count FROM sanctuary_journal WHERE wallet_address = ? AND token_id = ?'
+    ).get('0xpager', 3) as { count: number };
+
+    expect(total.count).toBe(35);
+  });
+
+  it('computes first and last entry dates', () => {
+    const range = db.prepare(
+      'SELECT MIN(created_at) as first_entry, MAX(created_at) as last_entry FROM sanctuary_journal WHERE wallet_address = ? AND token_id = ?'
+    ).get('0xpager', 3) as { first_entry: string; last_entry: string };
+
+    expect(range.first_entry).toContain('2026-04-01');
+    expect(range.last_entry).toBeTruthy();
+  });
+});
+
 describe('Send to Activity', () => {
   let db: Database.Database;
 


### PR DESCRIPTION
## Summary
- **Journal System**: Paginated `/api/sanctuary/companion/journal` endpoint with type filters, stats aggregation, and enhanced UI with expandable full history view, type filter chips, and pagination
- **Balance Pass 1**: Daily interaction cap (15/day), XP rewards for interactions (feed=3, pet=2, talk=2) and activities (5-40 proportional to duration), rebalanced activity bond rewards so longer activities are more efficient
- **Chat Architecture**: ADR-002 proposing V1 companion chat — trait-derived personality, session-scoped memory, 15 msg/day rate limit, journal integration, ~$1.50/mo at 100 users

## Test plan
- [x] All 25 sanctuary DB tests pass (5 new pagination/stats tests)
- [x] TypeScript compilation clean (no new errors)
- [ ] Manual: verify journal pagination and type filters in browser
- [ ] Manual: verify daily interaction cap returns 429 after 15 interactions
- [ ] Manual: verify activities now award XP on completion


🤖 Generated with [Claude Code](https://claude.com/claude-code)