### PR TITLE
feat: sanctuary map CSS background with luminous zone glows

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2607,3 +2607,127 @@ a,
   color: transparent;
   -webkit-text-fill-color: transparent;
 }
+
+/* ── Sanctuary World Map Background ── */
+/* 720×405 pixel-art constellation map with 8 luminous location zones */
+.sanctuary-map-bg {
+  background:
+    /* Hot Springs (0.2, 0.3) — amber */
+    radial-gradient(ellipse 14% 22% at 20% 30%, rgba(255, 165, 0, 0.18) 0%, rgba(255, 140, 0, 0.06) 50%, transparent 100%),
+    radial-gradient(circle 3% at 20% 30%, rgba(255, 180, 50, 0.25) 0%, transparent 100%),
+    /* Training Grounds (0.7, 0.2) — crimson */
+    radial-gradient(ellipse 12% 18% at 70% 20%, rgba(255, 68, 102, 0.16) 0%, rgba(200, 40, 60, 0.05) 50%, transparent 100%),
+    radial-gradient(circle 3% at 70% 20%, rgba(255, 80, 100, 0.22) 0%, transparent 100%),
+    /* Star Garden (0.5, 0.5) — teal */
+    radial-gradient(ellipse 16% 20% at 50% 50%, rgba(32, 214, 180, 0.16) 0%, rgba(0, 200, 167, 0.05) 50%, transparent 100%),
+    radial-gradient(circle 4% at 50% 50%, rgba(50, 230, 200, 0.22) 0%, transparent 100%),
+    /* Cosmic Library (0.8, 0.6) — violet */
+    radial-gradient(ellipse 13% 19% at 80% 60%, rgba(153, 102, 255, 0.16) 0%, rgba(130, 80, 220, 0.05) 50%, transparent 100%),
+    radial-gradient(circle 3% at 80% 60%, rgba(160, 110, 255, 0.22) 0%, transparent 100%),
+    /* Nebula Kitchen (0.3, 0.7) — warm orange */
+    radial-gradient(ellipse 13% 18% at 30% 70%, rgba(255, 123, 0, 0.15) 0%, rgba(220, 100, 0, 0.05) 50%, transparent 100%),
+    radial-gradient(circle 3% at 30% 70%, rgba(255, 140, 30, 0.20) 0%, transparent 100%),
+    /* Dream Hollow (0.1, 0.8) — lavender */
+    radial-gradient(ellipse 14% 20% at 10% 80%, rgba(136, 136, 255, 0.14) 0%, rgba(100, 100, 220, 0.04) 50%, transparent 100%),
+    radial-gradient(circle 3% at 10% 80%, rgba(150, 150, 255, 0.20) 0%, transparent 100%),
+    /* Aura Forge (0.9, 0.4) — magenta */
+    radial-gradient(ellipse 12% 18% at 90% 40%, rgba(255, 0, 255, 0.14) 0%, rgba(200, 0, 200, 0.04) 50%, transparent 100%),
+    radial-gradient(circle 3% at 90% 40%, rgba(255, 50, 255, 0.20) 0%, transparent 100%),
+    /* Observatory (0.5, 0.1) — cyan */
+    radial-gradient(ellipse 14% 22% at 50% 10%, rgba(0, 255, 255, 0.14) 0%, rgba(0, 200, 220, 0.04) 50%, transparent 100%),
+    radial-gradient(circle 3% at 50% 10%, rgba(0, 255, 255, 0.20) 0%, transparent 100%),
+    /* Subtle nebula wisps */
+    radial-gradient(ellipse 40% 30% at 35% 45%, rgba(153, 102, 255, 0.03) 0%, transparent 100%),
+    radial-gradient(ellipse 35% 40% at 65% 55%, rgba(0, 200, 180, 0.02) 0%, transparent 100%);
+  background-color: #0a0a1a;
+  position: relative;
+}
+
+/* Star field dots via pseudo-element */
+.sanctuary-map-bg::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  box-shadow:
+    /* Bright 2px stars */
+    144px 32px 0 0 rgba(255, 255, 255, 0.50),
+    360px 16px 0 0 rgba(200, 220, 255, 0.45),
+    540px 81px 0 0 rgba(255, 240, 200, 0.40),
+    72px 121px 0 0 rgba(220, 200, 255, 0.45),
+    648px 162px 0 0 rgba(200, 255, 255, 0.42),
+    252px 243px 0 0 rgba(255, 220, 180, 0.38),
+    468px 324px 0 0 rgba(255, 255, 255, 0.44),
+    108px 364px 0 0 rgba(200, 230, 255, 0.40),
+    612px 283px 0 0 rgba(255, 200, 220, 0.36),
+    324px 364px 0 0 rgba(220, 255, 220, 0.38),
+    /* Dim 1px stars — scattered */
+    36px 20px 0 -0.5px rgba(255, 255, 255, 0.25),
+    90px 56px 0 -0.5px rgba(200, 200, 255, 0.22),
+    180px 81px 0 -0.5px rgba(255, 255, 255, 0.20),
+    216px 12px 0 -0.5px rgba(255, 220, 200, 0.22),
+    288px 60px 0 -0.5px rgba(200, 255, 255, 0.18),
+    396px 44px 0 -0.5px rgba(255, 255, 255, 0.24),
+    432px 97px 0 -0.5px rgba(220, 220, 255, 0.20),
+    504px 36px 0 -0.5px rgba(255, 255, 255, 0.22),
+    576px 56px 0 -0.5px rgba(200, 240, 255, 0.18),
+    684px 24px 0 -0.5px rgba(255, 255, 255, 0.20),
+    18px 162px 0 -0.5px rgba(255, 230, 200, 0.22),
+    54px 202px 0 -0.5px rgba(200, 200, 255, 0.18),
+    126px 178px 0 -0.5px rgba(255, 255, 255, 0.24),
+    162px 227px 0 -0.5px rgba(220, 255, 220, 0.20),
+    234px 154px 0 -0.5px rgba(255, 255, 255, 0.22),
+    306px 194px 0 -0.5px rgba(200, 220, 255, 0.18),
+    342px 130px 0 -0.5px rgba(255, 255, 255, 0.20),
+    414px 178px 0 -0.5px rgba(255, 200, 255, 0.22),
+    486px 146px 0 -0.5px rgba(255, 255, 255, 0.18),
+    558px 210px 0 -0.5px rgba(200, 255, 200, 0.20),
+    594px 130px 0 -0.5px rgba(255, 255, 255, 0.24),
+    666px 194px 0 -0.5px rgba(220, 200, 255, 0.20),
+    30px 283px 0 -0.5px rgba(255, 255, 255, 0.22),
+    102px 308px 0 -0.5px rgba(200, 255, 255, 0.18),
+    198px 340px 0 -0.5px rgba(255, 255, 255, 0.20),
+    270px 268px 0 -0.5px rgba(255, 220, 200, 0.24),
+    378px 300px 0 -0.5px rgba(255, 255, 255, 0.18),
+    450px 268px 0 -0.5px rgba(200, 200, 255, 0.22),
+    522px 348px 0 -0.5px rgba(255, 255, 255, 0.20),
+    630px 308px 0 -0.5px rgba(220, 240, 255, 0.18),
+    702px 340px 0 -0.5px rgba(255, 255, 255, 0.22),
+    48px 380px 0 -0.5px rgba(200, 220, 255, 0.20),
+    168px 396px 0 -0.5px rgba(255, 255, 255, 0.18),
+    312px 388px 0 -0.5px rgba(255, 200, 220, 0.24),
+    564px 380px 0 -0.5px rgba(255, 255, 255, 0.20),
+    660px 396px 0 -0.5px rgba(200, 255, 200, 0.18),
+    708px 100px 0 -0.5px rgba(255, 255, 255, 0.22);
+}
+
+/* Subtle twinkling animation for a few star dots */
+@keyframes sanctuaryStarTwinkle {
+  0%, 100% { opacity: 0.6; }
+  50% { opacity: 1; }
+}
+
+.sanctuary-map-bg::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  animation: sanctuaryStarTwinkle 3s ease-in-out infinite;
+  box-shadow:
+    144px 32px 0 0.5px rgba(255, 255, 255, 0.30),
+    540px 81px 0 0.5px rgba(255, 240, 200, 0.25),
+    648px 162px 0 0.5px rgba(200, 255, 255, 0.28),
+    324px 364px 0 0.5px rgba(220, 255, 220, 0.22);
+}
+
+/* Faint constellation grid lines */
+.sanctuary-map-grid {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.06;
+  background:
+    linear-gradient(90deg, rgba(153, 102, 255, 0.4) 1px, transparent 1px),
+    linear-gradient(0deg, rgba(153, 102, 255, 0.4) 1px, transparent 1px);
+  background-size: 25% 33.33%;
+}

--- a/app/sanctuary/SanctuaryContent.tsx
+++ b/app/sanctuary/SanctuaryContent.tsx
@@ -78,14 +78,8 @@ function PublicWorldView({
       <h2 className="text-[#ffd700] text-sm tracking-wider mb-4">
         SANCTUARY WORLD MAP
       </h2>
-      <div className="relative w-full aspect-[16/9] bg-[#0a0a15] border-2 border-[#2a2a4e] rounded-lg overflow-hidden">
-        <div className="absolute inset-0 opacity-10">
-          <div className="absolute w-px h-full left-1/4 bg-[#9966ff]/30" />
-          <div className="absolute w-px h-full left-1/2 bg-[#9966ff]/30" />
-          <div className="absolute w-px h-full left-3/4 bg-[#9966ff]/30" />
-          <div className="absolute w-full h-px top-1/3 bg-[#9966ff]/30" />
-          <div className="absolute w-full h-px top-2/3 bg-[#9966ff]/30" />
-        </div>
+      <div className="sanctuary-map-bg relative w-full aspect-[16/9] border-2 border-[#2a2a4e] rounded-lg overflow-hidden">
+        <div className="sanctuary-map-grid" />
 
         {locations.map((loc) => {
           const locCompanions = companionMap.get(loc.name);


### PR DESCRIPTION
## Summary
- Adds `.sanctuary-map-bg` CSS class with procedural star-map background using layered radial gradients
- 8 luminous location zones positioned at DB `position_x/y` coordinates with doctrine accent colors:
  - Hot Springs (amber), Training Grounds (crimson), Star Garden (teal), Cosmic Library (violet), Nebula Kitchen (warm orange), Dream Hollow (lavender), Aura Forge (magenta), Observatory (cyan)
- ~50 scattered 1-2px star dots via `box-shadow` on `::before` pseudo-element
- Subtle twinkle animation on `::after` for select bright stars
- `.sanctuary-map-grid` class replaces inline grid overlay divs
- Updates `SanctuaryContent.tsx` to use new CSS classes instead of inline Tailwind + absolute divs

## Test plan
- [x] `npm run type-check` — PASS
- [x] `npm run lint` — no new errors (pre-existing only)
- [x] `npm run build` — PASS
- [x] `npm run test` — 128/128 PASS

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS
- **vitest run**: PASS (128/128)
Overall: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)