### PR TITLE
fix: wallet signature verification for Sanctuary POST routes

### DIFF
--- a/app/api/raffle/route.ts
+++ b/app/api/raffle/route.ts
@@ -467,14 +467,18 @@ export async function POST(request: NextRequest) {
           }
         }
         
+        // Server-side verification of bonus eligibility (H-1: don't trust client claims)
+        const verifiedDiscordBonus = discordBonus && socialConnections.hasDiscord;
+        const verifiedEngagementBonus = engagementBonus && socialConnections.hasX;
+
         // Enter raffle with total balance for proper entry calculation
         const entry = enterRaffle({
           raffleId,
           walletAddress,
           starCount,
           totalSkrumpeyBalance,
-          discordBonus,
-          engagementBonus,
+          discordBonus: verifiedDiscordBonus,
+          engagementBonus: verifiedEngagementBonus,
         });
         
         if (!entry) {

--- a/app/api/sanctuary/companion/complete-activity/route.ts
+++ b/app/api/sanctuary/companion/complete-activity/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { completeActivity } from '@/lib/db';
 import { isStarSkrumpeyId } from '@/lib/starSkrumpey';
+import { verifyWalletAccess } from '@/lib/walletAuth';
 
 export async function POST(request: NextRequest) {
   try {
@@ -12,6 +13,11 @@ export async function POST(request: NextRequest) {
         { success: false, error: 'address and token_id are required' },
         { status: 400 }
       );
+    }
+
+    const auth = await verifyWalletAccess(request, address);
+    if (!auth.valid) {
+      return NextResponse.json({ success: false, error: auth.error }, { status: 401 });
     }
 
     const isStar = isStarSkrumpeyId(token_id);

--- a/app/api/sanctuary/companion/interact/route.ts
+++ b/app/api/sanctuary/companion/interact/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { interactWithCompanion } from '@/lib/db';
 import { isStarSkrumpeyId } from '@/lib/starSkrumpey';
+import { verifyWalletAccess } from '@/lib/walletAuth';
 
 const VALID_ACTIONS = ['feed', 'pet', 'talk'] as const;
 
@@ -14,6 +15,11 @@ export async function POST(request: NextRequest) {
         { success: false, error: 'address, token_id, and action are required' },
         { status: 400 }
       );
+    }
+
+    const auth = await verifyWalletAccess(request, address);
+    if (!auth.valid) {
+      return NextResponse.json({ success: false, error: auth.error }, { status: 401 });
     }
 
     if (!VALID_ACTIONS.includes(action)) {

--- a/app/api/sanctuary/companion/send-to-activity/route.ts
+++ b/app/api/sanctuary/companion/send-to-activity/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { sendToActivity } from '@/lib/db';
+import { verifyWalletAccess } from '@/lib/walletAuth';
 
 export async function POST(request: NextRequest) {
   try {
@@ -11,6 +12,11 @@ export async function POST(request: NextRequest) {
         { success: false, error: 'address, token_id, and location_id are required' },
         { status: 400 }
       );
+    }
+
+    const auth = await verifyWalletAccess(request, address);
+    if (!auth.valid) {
+      return NextResponse.json({ success: false, error: auth.error }, { status: 401 });
     }
 
     const result = sendToActivity(address, token_id, location_id);

--- a/lib/cronAuth.ts
+++ b/lib/cronAuth.ts
@@ -13,10 +13,6 @@ export interface CronAuthResult {
  * - Production: requires CRON_SECRET and matching Authorization header.
  */
 export function validateCronSecret(request: Request, jobName: string): CronAuthResult {
-  if (process.env.NODE_ENV === 'development') {
-    return { valid: true };
-  }
-
   const cronSecret = process.env.CRON_SECRET;
   if (!cronSecret) {
     logger.error(`${jobName}: CRON_SECRET is not configured`);


### PR DESCRIPTION
## Summary
- **Sanctuary POST auth**: Added `verifyWalletAccess()` to `/companion/interact`, `/companion/send-to-activity`, and `/companion/complete-activity` — these previously accepted unverified wallet addresses from request bodies, allowing anyone to modify any wallet's companions
- **H-1 raffle bonuses**: Discord and engagement bonuses are now verified server-side via `checkSocialConnections()` instead of trusting client-claimed boolean flags
- **H-4 cron dev bypass**: Removed the `NODE_ENV === 'development'` shortcut that skipped auth entirely — cron endpoints now require `CRON_SECRET` in all environments

## Test plan
- [x] `npm run type-check` — PASS
- [x] `npm run lint` — PASS (0 new errors)
- [x] `npm run test` — PASS (128/128)
- [x] `npm run build` — PASS
- [ ] Verify Sanctuary companion interactions still work with wallet connected
- [ ] Verify raffle entry with/without Discord connection correctly awards/denies bonus
- [ ] Verify cron jobs work in production with CRON_SECRET set

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS (cronAuth only — sanctuary routes and raffle diverge between dev/main)
- **vitest run**: PASS (69/69)
- Note: Sanctuary routes don't exist in PROD mirror (main branch). Raffle file differs between dev/main branches. Only cronAuth.ts was directly testable against PROD.
Overall: PASS (partial — branch divergence)

## Files changed
| File | Change |
|------|--------|
| `app/api/sanctuary/companion/interact/route.ts` | Added `verifyWalletAccess()` |
| `app/api/sanctuary/companion/send-to-activity/route.ts` | Added `verifyWalletAccess()` |
| `app/api/sanctuary/companion/complete-activity/route.ts` | Added `verifyWalletAccess()` |
| `app/api/raffle/route.ts` | Server-side bonus verification |
| `lib/cronAuth.ts` | Removed dev-mode auth bypass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)