### PR TITLE
feat: add companion picker to Sanctuary header

### DIFF
--- a/app/sanctuary/SanctuaryContent.tsx
+++ b/app/sanctuary/SanctuaryContent.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { useAccount } from 'wagmi';
 import SkrumpeyAccessGate from '@/components/SkrumpeyAccessGate';
 import { useSkrumpeyAccess } from '@/lib/hooks/useSkrumpeyAccess';
 import { useDAOAccess } from '@/lib/hooks/useDAOAccess';
+import { getWalletAuthHeader } from '@/lib/clientWalletAuth';
 
 interface Companion {
   token_id: number;
@@ -969,6 +970,244 @@ function StarBadge() {
   );
 }
 
+interface OwnedSkrumpey {
+  tokenId: number;
+  name: string;
+  image: string;
+  isStar: boolean;
+  constellation: string | null;
+  traits: Record<string, string>;
+  rarityRank: number | null;
+  rarityScore: number | null;
+}
+
+function CompanionPicker({
+  address,
+  activeTokenId,
+  onSelect,
+}: {
+  address: string;
+  activeTokenId: number | null;
+  onSelect: (tokenId: number) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [owned, setOwned] = useState<OwnedSkrumpey[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [switching, setSwitching] = useState<number | null>(null);
+  const [filter, setFilter] = useState<'all' | 'star'>('all');
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  const fetchOwned = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/sanctuary/companion/list-owned?address=${address}`);
+      const data = await res.json();
+      if (data.success) {
+        setOwned(data.owned ?? []);
+      } else {
+        setError(data.error ?? 'Failed to load');
+      }
+    } catch {
+      setError('Network error');
+    } finally {
+      setLoading(false);
+    }
+  }, [address]);
+
+  useEffect(() => {
+    if (open && owned.length === 0 && !loading) {
+      fetchOwned();
+    }
+  }, [open, owned.length, loading, fetchOwned]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleClick = (e: MouseEvent) => {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [open]);
+
+  const handleSelect = async (tokenId: number) => {
+    if (tokenId === activeTokenId || switching) return;
+    setSwitching(tokenId);
+    setError(null);
+    try {
+      const authHeader = await getWalletAuthHeader(address);
+      if (!authHeader) {
+        setError('Wallet signature required');
+        setSwitching(null);
+        return;
+      }
+      const endpoint = activeTokenId
+        ? '/api/sanctuary/companion/switch'
+        : '/api/sanctuary/companion/select';
+      const res = await fetch(endpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-wallet-auth': authHeader,
+        },
+        body: JSON.stringify({ walletAddress: address, tokenId }),
+      });
+      const data = await res.json();
+      if (data.success) {
+        onSelect(tokenId);
+        setOpen(false);
+      } else {
+        setError(data.error ?? 'Failed to switch');
+      }
+    } catch {
+      setError('Network error');
+    } finally {
+      setSwitching(null);
+    }
+  };
+
+  const filtered = useMemo(
+    () => (filter === 'star' ? owned.filter((s) => s.isStar) : owned),
+    [owned, filter]
+  );
+
+  const starCount = useMemo(() => owned.filter((s) => s.isStar).length, [owned]);
+
+  if (!open) {
+    return (
+      <button
+        onClick={() => setOpen(true)}
+        className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-[#9966ff]/15 border border-[#9966ff]/40 text-[#bb88ff] text-[8px] tracking-wider hover:bg-[#9966ff]/25 hover:border-[#9966ff]/60 transition-all"
+      >
+        <span>🔄</span>
+        <span>{activeTokenId ? 'SWITCH COMPANION' : 'SELECT COMPANION'}</span>
+      </button>
+    );
+  }
+
+  return (
+    <div ref={panelRef} className="pixel-card p-4 w-full max-w-2xl mx-auto">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-[#ffd700] text-[10px] tracking-wider">
+          {activeTokenId ? 'SWITCH COMPANION' : 'SELECT YOUR COMPANION'}
+        </h3>
+        <button
+          onClick={() => setOpen(false)}
+          className="text-gray-500 hover:text-gray-300 text-xs transition-colors"
+        >
+          ✕
+        </button>
+      </div>
+
+      {starCount > 0 && (
+        <div className="flex gap-2 mb-3">
+          <button
+            onClick={() => setFilter('all')}
+            className={`px-2 py-0.5 rounded text-[7px] tracking-wider border transition-all ${
+              filter === 'all'
+                ? 'bg-[#9966ff]/25 border-[#9966ff]/60 text-[#bb88ff]'
+                : 'bg-transparent border-[#2a2a4e] text-gray-500 hover:text-gray-400'
+            }`}
+          >
+            ALL ({owned.length})
+          </button>
+          <button
+            onClick={() => setFilter('star')}
+            className={`px-2 py-0.5 rounded text-[7px] tracking-wider border transition-all ${
+              filter === 'star'
+                ? 'bg-[#ffd700]/20 border-[#ffd700]/50 text-[#ffd700]'
+                : 'bg-transparent border-[#2a2a4e] text-gray-500 hover:text-gray-400'
+            }`}
+          >
+            ⭐ STARS ({starCount})
+          </button>
+        </div>
+      )}
+
+      {loading && (
+        <div className="flex items-center justify-center py-8">
+          <p className="text-[#ffd700] text-[9px] animate-pulse">SCANNING WALLET...</p>
+        </div>
+      )}
+
+      {error && (
+        <div className="text-center py-4">
+          <p className="text-red-400 text-[9px] mb-2">{error}</p>
+          <button
+            onClick={fetchOwned}
+            className="px-3 py-1 bg-[#9966ff]/20 border border-[#9966ff]/40 rounded text-[#9966ff] text-[8px] hover:bg-[#9966ff]/30 transition-colors"
+          >
+            RETRY
+          </button>
+        </div>
+      )}
+
+      {!loading && !error && filtered.length === 0 && (
+        <div className="text-center py-6">
+          <p className="text-gray-400 text-[9px]">
+            {filter === 'star' ? 'No Star Skrumpeys found' : 'No Skrumpeys found in wallet'}
+          </p>
+        </div>
+      )}
+
+      {!loading && !error && filtered.length > 0 && (
+        <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-2 max-h-[320px] overflow-y-auto pr-1">
+          {filtered.map((skrumpey) => {
+            const isActive = skrumpey.tokenId === activeTokenId;
+            const isSwitching = switching === skrumpey.tokenId;
+            return (
+              <button
+                key={skrumpey.tokenId}
+                onClick={() => handleSelect(skrumpey.tokenId)}
+                disabled={isActive || switching !== null}
+                className={`relative p-1.5 rounded-lg border-2 transition-all text-left group ${
+                  isActive
+                    ? 'border-[#ffd700] bg-[#ffd700]/10 shadow-[0_0_12px_rgba(255,215,0,0.2)]'
+                    : isSwitching
+                      ? 'border-[#9966ff] bg-[#9966ff]/10 animate-pulse'
+                      : 'border-[#2a2a4e] bg-[#0a0a15] hover:border-[#9966ff]/60 hover:bg-[#1a1a2e] cursor-pointer'
+                }`}
+              >
+                <div className="aspect-square rounded overflow-hidden mb-1 bg-[#0a0a15] border border-[#2a2a4e]">
+                  {skrumpey.image ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={skrumpey.image}
+                      alt={skrumpey.name}
+                      className="w-full h-full object-cover"
+                      loading="lazy"
+                    />
+                  ) : (
+                    <div className="w-full h-full flex items-center justify-center text-2xl">🐸</div>
+                  )}
+                </div>
+                <p className="text-[7px] text-gray-300 truncate">{skrumpey.name}</p>
+                {skrumpey.constellation && (
+                  <p className="text-[6px] text-[#9966ff] truncate">{skrumpey.constellation}</p>
+                )}
+                {skrumpey.isStar && (
+                  <span className="absolute top-0.5 right-0.5 text-[8px]" title="Star Skrumpey">⭐</span>
+                )}
+                {isActive && (
+                  <span className="absolute top-0.5 left-0.5 text-[6px] text-[#ffd700] font-bold">ACTIVE</span>
+                )}
+                {isSwitching && (
+                  <div className="absolute inset-0 flex items-center justify-center bg-black/60 rounded-lg">
+                    <span className="text-[8px] text-[#9966ff] animate-pulse">SWITCHING...</span>
+                  </div>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
 function HolderSanctuary() {
   const { address } = useAccount();
   const { hasAccess: hasStar } = useDAOAccess();
@@ -1006,6 +1245,11 @@ function HolderSanctuary() {
       .catch(() => setLoadError('Failed to load sanctuary data'))
       .finally(() => setLoading(false));
   }, [address, refreshState]);
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const handleCompanionSwitch = useCallback(async (_tokenId: number) => {
+    await refreshState();
+  }, [refreshState]);
 
   const handleInteract = async (action: 'feed' | 'pet' | 'talk') => {
     if (!address || !companion || interacting) return;
@@ -1134,7 +1378,16 @@ function HolderSanctuary() {
           SKRUMPEY SANCTUARY
         </h1>
         <p className="text-gray-400 text-[10px]">Your companion awaits</p>
-        {hasStar && <div className="mt-2"><StarBadge /></div>}
+        <div className="mt-2 flex items-center justify-center gap-3 flex-wrap">
+          {hasStar && <StarBadge />}
+          {address && (
+            <CompanionPicker
+              address={address}
+              activeTokenId={companion?.token_id ?? null}
+              onSelect={handleCompanionSwitch}
+            />
+          )}
+        </div>
       </div>
 
       <PublicWorldView
@@ -1161,11 +1414,18 @@ function HolderSanctuary() {
             <JournalPanel entries={journal} address={address} tokenId={companion.token_id} />
           </>
         ) : (
-          <div className="pixel-card p-6 md:col-span-2 text-center">
+          <div className="pixel-card p-6 md:col-span-2 text-center space-y-3">
             <p className="text-[#9966ff] text-xs mb-2">NO COMPANION SELECTED</p>
             <p className="text-gray-400 text-[8px]">
               Select a Skrumpey to begin your sanctuary journey.
             </p>
+            {address && (
+              <CompanionPicker
+                address={address}
+                activeTokenId={null}
+                onSelect={handleCompanionSwitch}
+              />
+            )}
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- Adds a `CompanionPicker` component to the Sanctuary header that lets users with multiple Skrumpeys switch between companions
- Fetches owned NFTs from `/api/sanctuary/companion/list-owned`, renders a filterable grid (all / stars only) with NFT images, constellation labels, and star badges
- Wires selection to `/api/sanctuary/companion/select` (first companion) or `/api/sanctuary/companion/switch` (subsequent), using wallet signature auth via `getWalletAuthHeader`
- Also displays inline in the "NO COMPANION SELECTED" empty state for first-time onboarding

## Test plan
- [ ] Connect wallet with multiple Skrumpeys, verify picker button appears in header
- [ ] Click "SELECT COMPANION" — grid loads with all owned NFTs
- [ ] Star filter button appears only when user holds Star Skrumpeys
- [ ] Select a companion — wallet signature prompt fires, state refreshes
- [ ] Switch to different companion — verify switch works and UI updates
- [ ] Test with single Skrumpey — picker still works for initial selection
- [ ] Test error states: network failure shows retry button, auth rejection shows error

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS (no errors from SanctuaryContent.tsx; pre-existing errors from sanctuary API routes missing from PROD mirror)
- **vitest run**: PASS (69 tests, 2 files)
Overall: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)