### PR TITLE
fix: add image-rendering-pixelated Tailwind utility

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,5 +1,10 @@
 @import "tailwindcss";
 
+@utility image-rendering-pixelated {
+  image-rendering: pixelated;
+  image-rendering: crisp-edges;
+}
+
 :root {
   /* Synthwave color palette */
   --background: #0a0a1a;


### PR DESCRIPTION
## Summary
- Adds `@utility image-rendering-pixelated` to `globals.css` so the Tailwind class referenced by CompanionSprite in `SanctuaryContent.tsx:336` is properly defined
- Sets both `image-rendering: pixelated` and `image-rendering: crisp-edges` for cross-browser support
- Without this utility, NFT fallback sprites render blurry instead of crisp pixel art

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS (0 new errors)
- **vitest run**: PASS (69 passed)
- Overall: PASS

## Test plan
- [x] `npm run type-check` — passes
- [x] `npm run lint` — no new errors
- [x] `npm run build` — succeeds
- [x] `npm run test` — 136 passed
- [ ] Visual check: load Sanctuary with a Star Skrumpey, verify companion sprite renders with crisp pixel edges

🤖 Generated with [Claude Code](https://claude.com/claude-code)