### PR TITLE
security: SQLite rate limiting + wallet auth on all Sanctuary POST routes

### DIFF
--- a/app/api/sanctuary/companion/chat/route.ts
+++ b/app/api/sanctuary/companion/chat/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { chatWithCompanion, getCompanionChatHistory } from '@/lib/db';
+import { verifyWalletAccess } from '@/lib/walletAuth';
+import { applyRateLimit } from '@/lib/sanctuary/rateLimit';
 import { ethAddress, tokenId, paginationLimit, parseSearchParams, parseBody, formatZodError } from '@/lib/sanctuary/validation';
 
 const getSchema = z.object({
@@ -42,6 +44,14 @@ export async function POST(request: NextRequest) {
     }
 
     const { address, token_id: tid, message } = parsed.data;
+
+    const auth = await verifyWalletAccess(request, address);
+    if (!auth.valid) {
+      return NextResponse.json({ success: false, error: auth.error }, { status: 401 });
+    }
+
+    const rateLimited = applyRateLimit(address, 'companion/chat');
+    if (rateLimited) return rateLimited;
 
     if (!message) {
       return NextResponse.json({ success: false, error: 'Message cannot be empty' }, { status: 400 });

--- a/app/api/sanctuary/companion/complete-activity/route.ts
+++ b/app/api/sanctuary/companion/complete-activity/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { completeActivityV15 } from '@/lib/db';
 import { isStarSkrumpeyId } from '@/lib/starSkrumpey';
+import { verifyWalletAccess } from '@/lib/walletAuth';
+import { applyRateLimit } from '@/lib/sanctuary/rateLimit';
 import { ethAddress, tokenId, parseBody, formatZodError } from '@/lib/sanctuary/validation';
 
 const bodySchema = z.object({
@@ -22,6 +24,14 @@ export async function POST(request: NextRequest) {
     }
 
     const { address, token_id: tid } = parsed.data;
+
+    const auth = await verifyWalletAccess(request, address);
+    if (!auth.valid) {
+      return NextResponse.json({ success: false, error: auth.error }, { status: 401 });
+    }
+
+    const rateLimited = applyRateLimit(address, 'companion/complete-activity');
+    if (rateLimited) return rateLimited;
 
     const isStar = isStarSkrumpeyId(tid);
     const result = completeActivityV15(address, tid, { isStar });

--- a/app/api/sanctuary/companion/init/route.ts
+++ b/app/api/sanctuary/companion/init/route.ts
@@ -1,7 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { selectCompanion } from '@/lib/db';
+import { verifyWalletAccess } from '@/lib/walletAuth';
 import { verifyTokenOwnership } from '@/lib/skrumpeyOwnership';
+import { applyRateLimit } from '@/lib/sanctuary/rateLimit';
 import { ethAddress, tokenId, parseBody, formatZodError } from '@/lib/sanctuary/validation';
 
 const bodySchema = z.object({
@@ -22,6 +24,14 @@ export async function POST(request: NextRequest) {
     }
 
     const { address, token_id: tid } = parsed.data;
+
+    const auth = await verifyWalletAccess(request, address);
+    if (!auth.valid) {
+      return NextResponse.json({ success: false, error: auth.error }, { status: 401 });
+    }
+
+    const rateLimited = applyRateLimit(address, 'companion/init');
+    if (rateLimited) return rateLimited;
 
     const ownsToken = await verifyTokenOwnership(address, tid);
     if (!ownsToken) {

--- a/app/api/sanctuary/companion/interact/route.ts
+++ b/app/api/sanctuary/companion/interact/route.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { interactWithCompanionV15 } from '@/lib/db';
 import { isStarSkrumpeyId } from '@/lib/starSkrumpey';
 import { verifyWalletAccess } from '@/lib/walletAuth';
+import { applyRateLimit } from '@/lib/sanctuary/rateLimit';
 import { ethAddress, tokenId, interactAction, parseBody, formatZodError } from '@/lib/sanctuary/validation';
 
 const bodySchema = z.object({
@@ -36,6 +37,9 @@ export async function POST(request: NextRequest) {
         { status: 401 },
       );
     }
+
+    const rateLimited = applyRateLimit(resolvedAddress, 'companion/interact');
+    if (rateLimited) return rateLimited;
 
     const isStar = isStarSkrumpeyId(tid);
     const result = interactWithCompanionV15(resolvedAddress, tid, action, { isStar });

--- a/app/api/sanctuary/companion/select/route.ts
+++ b/app/api/sanctuary/companion/select/route.ts
@@ -4,6 +4,7 @@ import { selectCompanion, getStarSkrumpeyMetadata } from '@/lib/db';
 import { verifyWalletAccess } from '@/lib/walletAuth';
 import { verifyTokenOwnership } from '@/lib/skrumpeyOwnership';
 import { isStarSkrumpeyId } from '@/lib/starSkrumpey';
+import { applyRateLimit } from '@/lib/sanctuary/rateLimit';
 import { ethAddress, tokenId, parseBody, formatZodError } from '@/lib/sanctuary/validation';
 
 const bodySchema = z.object({
@@ -29,6 +30,9 @@ export async function POST(request: NextRequest) {
     if (!auth.valid) {
       return NextResponse.json({ success: false, error: auth.error }, { status: 401 });
     }
+
+    const rateLimited = applyRateLimit(walletAddress, 'companion/select');
+    if (rateLimited) return rateLimited;
 
     const ownsToken = await verifyTokenOwnership(walletAddress, tid);
     if (!ownsToken) {

--- a/app/api/sanctuary/companion/send-to-activity/route.ts
+++ b/app/api/sanctuary/companion/send-to-activity/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { sendToActivity } from '@/lib/db';
+import { verifyWalletAccess } from '@/lib/walletAuth';
+import { applyRateLimit } from '@/lib/sanctuary/rateLimit';
 import { ethAddress, tokenId, parseBody, formatZodError } from '@/lib/sanctuary/validation';
 
 const bodySchema = z.object({
@@ -22,6 +24,15 @@ export async function POST(request: NextRequest) {
     }
 
     const { address, token_id: tid, location_id } = parsed.data;
+
+    const auth = await verifyWalletAccess(request, address);
+    if (!auth.valid) {
+      return NextResponse.json({ success: false, error: auth.error }, { status: 401 });
+    }
+
+    const rateLimited = applyRateLimit(address, 'companion/send-to-activity');
+    if (rateLimited) return rateLimited;
+
     const result = sendToActivity(address, tid, location_id);
     return NextResponse.json({ success: true, ...result });
   } catch (error) {

--- a/app/api/sanctuary/companion/switch/route.ts
+++ b/app/api/sanctuary/companion/switch/route.ts
@@ -4,6 +4,7 @@ import { switchCompanion, getStarSkrumpeyMetadata } from '@/lib/db';
 import { verifyWalletAccess } from '@/lib/walletAuth';
 import { verifyTokenOwnership } from '@/lib/skrumpeyOwnership';
 import { isStarSkrumpeyId } from '@/lib/starSkrumpey';
+import { applyRateLimit } from '@/lib/sanctuary/rateLimit';
 import { ethAddress, tokenId, parseBody, formatZodError } from '@/lib/sanctuary/validation';
 
 const bodySchema = z.object({
@@ -29,6 +30,9 @@ export async function POST(request: NextRequest) {
     if (!auth.valid) {
       return NextResponse.json({ success: false, error: auth.error }, { status: 401 });
     }
+
+    const rateLimited = applyRateLimit(walletAddress, 'companion/switch');
+    if (rateLimited) return rateLimited;
 
     const ownsToken = await verifyTokenOwnership(walletAddress, tid);
     if (!ownsToken) {

--- a/app/api/sanctuary/quests/claim/route.ts
+++ b/app/api/sanctuary/quests/claim/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { claimSanctuaryQuestReward } from '@/lib/db';
+import { verifyWalletAccess } from '@/lib/walletAuth';
+import { applyRateLimit } from '@/lib/sanctuary/rateLimit';
 import { ethAddress, tokenId, parseBody, formatZodError } from '@/lib/sanctuary/validation';
 
 const bodySchema = z.object({
@@ -19,6 +21,15 @@ export async function POST(request: NextRequest) {
     }
 
     const { address, token_id: tid, quest_id } = parsed.data;
+
+    const auth = await verifyWalletAccess(request, address);
+    if (!auth.valid) {
+      return NextResponse.json({ success: false, error: auth.error }, { status: 401 });
+    }
+
+    const rateLimited = applyRateLimit(address, 'quests/claim');
+    if (rateLimited) return rateLimited;
+
     const result = claimSanctuaryQuestReward(address, tid, quest_id);
     return NextResponse.json({ success: true, ...result });
   } catch (error) {

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -5766,6 +5766,11 @@ function initializeSanctuary(database: Database.Database): void {
     const sql = fs.readFileSync(v15Path, 'utf-8');
     database.exec(sql);
   }
+  const rateLimitPath = path.join(process.cwd(), 'scripts', 'init-sanctuary-rate-limits.sql');
+  if (fs.existsSync(rateLimitPath)) {
+    const sql = fs.readFileSync(rateLimitPath, 'utf-8');
+    database.exec(sql);
+  }
   seedSanctuaryMapLocations(database);
   seedSanctuaryQuests(database);
   seedSkrumpeyMetadataFromCorpus(database);

--- a/lib/sanctuary/__tests__/api-e2e.test.ts
+++ b/lib/sanctuary/__tests__/api-e2e.test.ts
@@ -44,10 +44,17 @@ const star = vi.hoisted(() => ({
   checkStarOwnershipBatched: vi.fn(),
 }));
 
+const rateLimit = vi.hoisted(() => ({
+  applyRateLimit: vi.fn().mockReturnValue(null),
+  checkRateLimit: vi.fn().mockReturnValue({ allowed: true }),
+  recordRequest: vi.fn(),
+}));
+
 vi.mock('@/lib/db', () => db);
 vi.mock('@/lib/walletAuth', () => walletAuth);
 vi.mock('@/lib/skrumpeyOwnership', () => ownership);
 vi.mock('@/lib/starSkrumpey', () => star);
+vi.mock('@/lib/sanctuary/rateLimit', () => rateLimit);
 
 // ─── Route handler imports ──────────────────────────────────────────
 
@@ -260,6 +267,7 @@ describe('GET /api/sanctuary/quests', () => {
 
 describe('POST /api/sanctuary/quests/claim', () => {
   it('claims reward successfully', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: true });
     db.claimSanctuaryQuestReward.mockReturnValue({ xp_gained: 100, new_level: 2 });
     const res = await questClaimPOST(
       post('/api/sanctuary/quests/claim', { address: ALICE, token_id: TOKEN, quest_id: 1 }),
@@ -277,7 +285,16 @@ describe('POST /api/sanctuary/quests/claim', () => {
     expect(res.status).toBe(400);
   });
 
+  it('returns 401 when wallet auth fails', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: false, error: 'Missing auth' });
+    const res = await questClaimPOST(
+      post('/api/sanctuary/quests/claim', { address: ALICE, token_id: TOKEN, quest_id: 1 }),
+    );
+    expect(res.status).toBe(401);
+  });
+
   it('returns 404 when quest not found', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: true });
     db.claimSanctuaryQuestReward.mockImplementation(() => { throw new Error('Quest not found'); });
     const res = await questClaimPOST(
       post('/api/sanctuary/quests/claim', { address: ALICE, token_id: TOKEN, quest_id: 999 }),
@@ -286,6 +303,7 @@ describe('POST /api/sanctuary/quests/claim', () => {
   });
 
   it('returns 409 when quest not completed', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: true });
     db.claimSanctuaryQuestReward.mockImplementation(() => { throw new Error('Quest not completed yet'); });
     const res = await questClaimPOST(
       post('/api/sanctuary/quests/claim', { address: ALICE, token_id: TOKEN, quest_id: 1 }),
@@ -294,6 +312,7 @@ describe('POST /api/sanctuary/quests/claim', () => {
   });
 
   it('returns 409 when already claimed', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: true });
     db.claimSanctuaryQuestReward.mockImplementation(() => { throw new Error('Reward already claimed'); });
     const res = await questClaimPOST(
       post('/api/sanctuary/quests/claim', { address: ALICE, token_id: TOKEN, quest_id: 1 }),
@@ -343,6 +362,7 @@ describe('GET /api/sanctuary/companion', () => {
 
 describe('POST /api/sanctuary/companion/init', () => {
   it('initializes companion when token owned', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: true });
     ownership.verifyTokenOwnership.mockResolvedValue(true);
     db.selectCompanion.mockReturnValue({ token_id: TOKEN, is_active: 1 });
     const res = await initPOST(
@@ -360,7 +380,16 @@ describe('POST /api/sanctuary/companion/init', () => {
     expect(res.status).toBe(400);
   });
 
+  it('returns 401 when wallet auth fails', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: false, error: 'Missing auth' });
+    const res = await initPOST(
+      post('/api/sanctuary/companion/init', { address: ALICE, token_id: TOKEN }),
+    );
+    expect(res.status).toBe(401);
+  });
+
   it('returns 403 when token not owned', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: true });
     ownership.verifyTokenOwnership.mockResolvedValue(false);
     const res = await initPOST(
       post('/api/sanctuary/companion/init', { address: ALICE, token_id: TOKEN }),
@@ -561,6 +590,7 @@ describe('GET /api/sanctuary/companion/chat', () => {
 
 describe('POST /api/sanctuary/companion/chat', () => {
   it('sends chat message and gets reply', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: true });
     db.chatWithCompanion.mockReturnValue({ reply: 'Hello traveler!', mood_change: 0.5 });
     const res = await chatPOST(
       post('/api/sanctuary/companion/chat', { address: ALICE, token_id: TOKEN, message: 'Hi there' }),
@@ -577,7 +607,16 @@ describe('POST /api/sanctuary/companion/chat', () => {
     expect(res.status).toBe(400);
   });
 
+  it('returns 401 when wallet auth fails', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: false, error: 'Invalid signature' });
+    const res = await chatPOST(
+      post('/api/sanctuary/companion/chat', { address: ALICE, token_id: TOKEN, message: 'hi' }),
+    );
+    expect(res.status).toBe(401);
+  });
+
   it('returns 400 for whitespace-only message', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: true });
     const res = await chatPOST(
       post('/api/sanctuary/companion/chat', { address: ALICE, token_id: TOKEN, message: '   ' }),
     );
@@ -587,6 +626,7 @@ describe('POST /api/sanctuary/companion/chat', () => {
   });
 
   it('truncates message to 500 chars', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: true });
     db.chatWithCompanion.mockReturnValue({ reply: 'ok' });
     const longMsg = 'x'.repeat(600);
     await chatPOST(
@@ -597,6 +637,7 @@ describe('POST /api/sanctuary/companion/chat', () => {
   });
 
   it('returns 404 when no active companion', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: true });
     db.chatWithCompanion.mockImplementation(() => { throw new Error('No active companion found'); });
     const res = await chatPOST(
       post('/api/sanctuary/companion/chat', { address: ALICE, token_id: TOKEN, message: 'hi' }),
@@ -684,6 +725,7 @@ describe('POST /api/sanctuary/companion/interact', () => {
 
 describe('POST /api/sanctuary/companion/send-to-activity', () => {
   it('sends companion to activity', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: true });
     db.sendToActivity.mockReturnValue({ activity: 'exploring', started_at: '2026-01-01' });
     const res = await sendActivityPOST(
       post('/api/sanctuary/companion/send-to-activity', { address: ALICE, token_id: TOKEN, location_id: '1' }),
@@ -700,7 +742,16 @@ describe('POST /api/sanctuary/companion/send-to-activity', () => {
     expect(res.status).toBe(400);
   });
 
+  it('returns 401 when wallet auth fails', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: false, error: 'Expired' });
+    const res = await sendActivityPOST(
+      post('/api/sanctuary/companion/send-to-activity', { address: ALICE, token_id: TOKEN, location_id: '1' }),
+    );
+    expect(res.status).toBe(401);
+  });
+
   it('returns 404 when no active companion', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: true });
     db.sendToActivity.mockImplementation(() => { throw new Error('No active companion'); });
     const res = await sendActivityPOST(
       post('/api/sanctuary/companion/send-to-activity', { address: ALICE, token_id: TOKEN, location_id: '1' }),
@@ -709,6 +760,7 @@ describe('POST /api/sanctuary/companion/send-to-activity', () => {
   });
 
   it('returns 404 when location not found', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: true });
     db.sendToActivity.mockImplementation(() => { throw new Error('Location not found'); });
     const res = await sendActivityPOST(
       post('/api/sanctuary/companion/send-to-activity', { address: ALICE, token_id: TOKEN, location_id: '999' }),
@@ -717,6 +769,7 @@ describe('POST /api/sanctuary/companion/send-to-activity', () => {
   });
 
   it('returns 409 when already on activity', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: true });
     db.sendToActivity.mockImplementation(() => { throw new Error('Companion is already on an activity'); });
     const res = await sendActivityPOST(
       post('/api/sanctuary/companion/send-to-activity', { address: ALICE, token_id: TOKEN, location_id: '1' }),
@@ -731,6 +784,7 @@ describe('POST /api/sanctuary/companion/send-to-activity', () => {
 
 describe('POST /api/sanctuary/companion/complete-activity', () => {
   it('completes activity with star bonus', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: true });
     star.isStarSkrumpeyId.mockReturnValue(true);
     db.completeActivityV15.mockReturnValue({ xp_gained: 50, rewards: [] });
     const res = await completeActivityPOST(
@@ -749,7 +803,16 @@ describe('POST /api/sanctuary/companion/complete-activity', () => {
     expect(res.status).toBe(400);
   });
 
+  it('returns 401 when wallet auth fails', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: false, error: 'Bad sig' });
+    const res = await completeActivityPOST(
+      post('/api/sanctuary/companion/complete-activity', { address: ALICE, token_id: TOKEN }),
+    );
+    expect(res.status).toBe(401);
+  });
+
   it('returns 409 when no activity to complete', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: true });
     star.isStarSkrumpeyId.mockReturnValue(false);
     db.completeActivityV15.mockReturnValue(null);
     const res = await completeActivityPOST(
@@ -818,6 +881,7 @@ describe('GET /api/sanctuary/companion/journal', () => {
 
 describe('Flow: init → interact → journal', () => {
   it('walks through companion lifecycle', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: true });
     ownership.verifyTokenOwnership.mockResolvedValue(true);
     db.selectCompanion.mockReturnValue({ token_id: TOKEN, is_active: 1, bond_score: 0 });
     const initRes = await initPOST(
@@ -851,6 +915,7 @@ describe('Flow: init → interact → journal', () => {
 
 describe('Flow: send to activity → complete activity', () => {
   it('sends companion then completes', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: true });
     db.sendToActivity.mockReturnValue({ activity: 'exploring', location: 'Hot Springs' });
     const sendRes = await sendActivityPOST(
       post('/api/sanctuary/companion/send-to-activity', { address: ALICE, token_id: TOKEN, location_id: '1' }),
@@ -874,6 +939,7 @@ describe('Flow: send to activity → complete activity', () => {
 
 describe('Flow: chat conversation', () => {
   it('sends message then retrieves history', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: true });
     db.chatWithCompanion.mockReturnValue({ reply: 'Hello traveler!' });
     const sendRes = await chatPOST(
       post('/api/sanctuary/companion/chat', { address: ALICE, token_id: TOKEN, message: 'Hi friend' }),

--- a/lib/sanctuary/__tests__/rateLimit.test.ts
+++ b/lib/sanctuary/__tests__/rateLimit.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import Database from 'better-sqlite3';
+import fs from 'fs';
+import path from 'path';
+import { WALLETS } from './fixtures';
+
+let testDb: Database.Database;
+
+vi.mock('@/lib/db', () => ({
+  getDatabase: () => testDb,
+}));
+
+import { checkRateLimit, recordRequest, applyRateLimit } from '../rateLimit';
+
+function createRateLimitDb(): Database.Database {
+  const db = new Database(':memory:');
+  db.pragma('journal_mode = WAL');
+  const sql = fs.readFileSync(
+    path.join(process.cwd(), 'scripts', 'init-sanctuary-rate-limits.sql'),
+    'utf-8',
+  );
+  db.exec(sql);
+  return db;
+}
+
+describe('SQLite Rate Limiter', () => {
+  beforeEach(() => {
+    testDb = createRateLimitDb();
+  });
+
+  it('allows requests under the limit', () => {
+    const result = checkRateLimit(WALLETS.alice, 'companion/chat');
+    expect(result.allowed).toBe(true);
+  });
+
+  it('records requests and counts them', () => {
+    for (let i = 0; i < 5; i++) {
+      recordRequest(WALLETS.alice, 'companion/chat');
+    }
+    const count = testDb
+      .prepare('SELECT COUNT(*) as count FROM sanctuary_rate_limits WHERE wallet_address = ?')
+      .get(WALLETS.alice) as { count: number };
+    expect(count.count).toBe(5);
+  });
+
+  it('blocks requests at the limit', () => {
+    for (let i = 0; i < 30; i++) {
+      recordRequest(WALLETS.alice, 'companion/chat');
+    }
+    const result = checkRateLimit(WALLETS.alice, 'companion/chat');
+    expect(result.allowed).toBe(false);
+    expect(result.retryAfter).toBeGreaterThan(0);
+  });
+
+  it('isolates limits per endpoint', () => {
+    for (let i = 0; i < 10; i++) {
+      recordRequest(WALLETS.alice, 'companion/init');
+    }
+    const initCheck = checkRateLimit(WALLETS.alice, 'companion/init');
+    expect(initCheck.allowed).toBe(false);
+
+    const chatCheck = checkRateLimit(WALLETS.alice, 'companion/chat');
+    expect(chatCheck.allowed).toBe(true);
+  });
+
+  it('isolates limits per wallet', () => {
+    for (let i = 0; i < 10; i++) {
+      recordRequest(WALLETS.alice, 'companion/init');
+    }
+    const aliceCheck = checkRateLimit(WALLETS.alice, 'companion/init');
+    expect(aliceCheck.allowed).toBe(false);
+
+    const bobCheck = checkRateLimit(WALLETS.bob, 'companion/init');
+    expect(bobCheck.allowed).toBe(true);
+  });
+
+  it('allows requests after window expires', () => {
+    const nowSec = Math.floor(Date.now() / 1000);
+    const oldTimestamp = nowSec - 120;
+
+    for (let i = 0; i < 10; i++) {
+      testDb
+        .prepare('INSERT INTO sanctuary_rate_limits (wallet_address, endpoint, created_at) VALUES (?, ?, ?)')
+        .run(WALLETS.alice, 'companion/init', oldTimestamp);
+    }
+
+    const result = checkRateLimit(WALLETS.alice, 'companion/init');
+    expect(result.allowed).toBe(true);
+  });
+
+  it('returns null from applyRateLimit when allowed', () => {
+    const result = applyRateLimit(WALLETS.alice, 'companion/chat');
+    expect(result).toBeNull();
+  });
+
+  it('returns 429 response from applyRateLimit when blocked', () => {
+    for (let i = 0; i < 30; i++) {
+      recordRequest(WALLETS.alice, 'companion/chat');
+    }
+    const result = applyRateLimit(WALLETS.alice, 'companion/chat');
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(429);
+  });
+
+  it('returns allowed for unknown endpoints', () => {
+    const result = checkRateLimit(WALLETS.alice, 'unknown/endpoint');
+    expect(result.allowed).toBe(true);
+  });
+});

--- a/lib/sanctuary/rateLimit.ts
+++ b/lib/sanctuary/rateLimit.ts
@@ -1,0 +1,83 @@
+import { getDatabase } from '@/lib/db';
+import { NextResponse } from 'next/server';
+
+interface RateLimitConfig {
+  maxRequests: number;
+  windowSeconds: number;
+}
+
+const LIMITS: Record<string, RateLimitConfig> = {
+  'companion/init': { maxRequests: 10, windowSeconds: 60 },
+  'companion/select': { maxRequests: 10, windowSeconds: 60 },
+  'companion/switch': { maxRequests: 10, windowSeconds: 60 },
+  'companion/interact': { maxRequests: 20, windowSeconds: 60 },
+  'companion/send-to-activity': { maxRequests: 10, windowSeconds: 60 },
+  'companion/complete-activity': { maxRequests: 10, windowSeconds: 60 },
+  'companion/chat': { maxRequests: 30, windowSeconds: 60 },
+  'quests/claim': { maxRequests: 10, windowSeconds: 60 },
+};
+
+let cleanupCounter = 0;
+
+export function checkRateLimit(
+  walletAddress: string,
+  endpoint: string,
+): { allowed: boolean; retryAfter?: number } {
+  const config = LIMITS[endpoint];
+  if (!config) return { allowed: true };
+
+  const db = getDatabase();
+  const nowSec = Math.floor(Date.now() / 1000);
+  const windowStart = nowSec - config.windowSeconds;
+
+  cleanupCounter++;
+  if (cleanupCounter >= 50) {
+    cleanupCounter = 0;
+    db.prepare(
+      'DELETE FROM sanctuary_rate_limits WHERE created_at < ?',
+    ).run(nowSec - 300);
+  }
+
+  const result = db.prepare(
+    'SELECT COUNT(*) as count FROM sanctuary_rate_limits WHERE wallet_address = ? AND endpoint = ? AND created_at >= ?',
+  ).get(walletAddress, endpoint, windowStart) as { count: number };
+
+  if (result.count >= config.maxRequests) {
+    const oldest = db.prepare(
+      'SELECT created_at FROM sanctuary_rate_limits WHERE wallet_address = ? AND endpoint = ? AND created_at >= ? ORDER BY created_at ASC LIMIT 1',
+    ).get(walletAddress, endpoint, windowStart) as { created_at: number } | undefined;
+
+    const retryAfter = oldest
+      ? Math.max(1, oldest.created_at + config.windowSeconds - nowSec)
+      : config.windowSeconds;
+
+    return { allowed: false, retryAfter };
+  }
+
+  return { allowed: true };
+}
+
+export function recordRequest(walletAddress: string, endpoint: string): void {
+  const db = getDatabase();
+  db.prepare(
+    'INSERT INTO sanctuary_rate_limits (wallet_address, endpoint, created_at) VALUES (?, ?, ?)',
+  ).run(walletAddress, endpoint, Math.floor(Date.now() / 1000));
+}
+
+export function applyRateLimit(
+  walletAddress: string,
+  endpoint: string,
+): NextResponse | null {
+  const check = checkRateLimit(walletAddress, endpoint);
+  if (!check.allowed) {
+    return NextResponse.json(
+      { success: false, error: 'Too many requests. Please try again later.' },
+      {
+        status: 429,
+        headers: { 'Retry-After': String(check.retryAfter) },
+      },
+    );
+  }
+  recordRequest(walletAddress, endpoint);
+  return null;
+}

--- a/scripts/init-sanctuary-rate-limits.sql
+++ b/scripts/init-sanctuary-rate-limits.sql
@@ -1,0 +1,13 @@
+-- Star Sanctuary — Rate Limits (SQLite-backed)
+-- Run from lib/db.ts initializeSanctuary()
+-- H-3: Persistent rate-limit counters instead of in-memory
+
+CREATE TABLE IF NOT EXISTS sanctuary_rate_limits (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  wallet_address TEXT NOT NULL,
+  endpoint TEXT NOT NULL,
+  created_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_sanctuary_rate_limits_lookup
+  ON sanctuary_rate_limits(wallet_address, endpoint, created_at);


### PR DESCRIPTION
## Summary

- **H-3**: SQLite-backed rate-limit counters (`sanctuary_rate_limits` table) replacing in-memory storage. Configurable per-endpoint limits (10–30 req/min) with automatic cleanup of expired entries.
- **M-1**: Rate limiting applied to all 8 Sanctuary write endpoints: init, select, switch, interact, send-to-activity, complete-activity, chat, quests/claim.
- **PR #204 gap**: Added `verifyWalletAccess` wallet signature verification to 5 previously unprotected POST routes (init, send-to-activity, complete-activity, chat, quests/claim). All 8 Sanctuary POST routes now require wallet auth.

### Files changed

| File | Change |
|------|--------|
| `scripts/init-sanctuary-rate-limits.sql` | New: rate-limit table schema |
| `lib/sanctuary/rateLimit.ts` | New: SQLite-backed rate limiter (check, record, apply) |
| `lib/db.ts` | Load rate-limit SQL in `initializeSanctuary()` |
| `app/api/sanctuary/companion/init/route.ts` | +wallet auth, +rate limit |
| `app/api/sanctuary/companion/send-to-activity/route.ts` | +wallet auth, +rate limit |
| `app/api/sanctuary/companion/complete-activity/route.ts` | +wallet auth, +rate limit |
| `app/api/sanctuary/companion/chat/route.ts` | +wallet auth, +rate limit |
| `app/api/sanctuary/quests/claim/route.ts` | +wallet auth, +rate limit |
| `app/api/sanctuary/companion/interact/route.ts` | +rate limit (already had auth) |
| `app/api/sanctuary/companion/select/route.ts` | +rate limit (already had auth) |
| `app/api/sanctuary/companion/switch/route.ts` | +rate limit (already had auth) |
| `lib/sanctuary/__tests__/rateLimit.test.ts` | New: 9 tests for rate limiter |
| `lib/sanctuary/__tests__/api-e2e.test.ts` | Updated: wallet auth mocks + 401 test cases |

### Rate limit configuration

| Endpoint | Max requests | Window |
|----------|-------------|--------|
| companion/chat | 30 | 60s |
| companion/interact | 20 | 60s |
| companion/init, select, switch | 10 | 60s |
| companion/send-to-activity, complete-activity | 10 | 60s |
| quests/claim | 10 | 60s |

## Test plan

- [x] `npm run type-check` — PASS
- [x] `npm run lint` — PASS (no new warnings)
- [x] `npm run test` — 244/248 pass (4 pre-existing failures, 0 new)
- [x] `npm run build` — PASS
- [x] Rate limiter unit tests (9/9 pass): allows, blocks, per-wallet isolation, per-endpoint isolation, window expiry, 429 response

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS (0 errors, 0 pre-existing errors)
- **vitest run**: PASS (2 pre-existing failures excluded, 0 new failures)
Overall: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)