### PR TITLE
feat: player & companion sprites with WASD/click-to-move pathfinding

### DIFF
--- a/game/scenes/BootScene.ts
+++ b/game/scenes/BootScene.ts
@@ -1,5 +1,7 @@
 import Phaser from 'phaser';
 import EventBus from '@/components/sanctuary/EventBus';
+import { PlayerSprite } from '../sprites/PlayerSprite';
+import { CompanionSprite } from '../sprites/CompanionSprite';
 
 export class BootScene extends Phaser.Scene {
   constructor() {
@@ -8,9 +10,15 @@ export class BootScene extends Phaser.Scene {
 
   preload() {
     EventBus.emit('boot-progress', { phase: 'loading' });
+
+    this.load.image('map_bg', '/sanctuary/map_bg.png');
+    CompanionSprite.loadAssets(this);
   }
 
   create() {
+    PlayerSprite.generateTextures(this);
+    CompanionSprite.generateFallbackTexture(this);
+
     EventBus.emit('boot-progress', { phase: 'ready' });
     this.scene.start('WorldScene');
   }

--- a/game/scenes/WorldScene.ts
+++ b/game/scenes/WorldScene.ts
@@ -1,28 +1,70 @@
 import Phaser from 'phaser';
+import { js as EasyStarPathfinder } from 'easystarjs';
 import EventBus from '@/components/sanctuary/EventBus';
+import { PlayerSprite } from '../sprites/PlayerSprite';
+import { CompanionSprite } from '../sprites/CompanionSprite';
+
+const TILE_SIZE = 16;
+const WORLD_WIDTH = 1440;
+const WORLD_HEIGHT = 810;
+const GRID_COLS = Math.floor(WORLD_WIDTH / TILE_SIZE);
+const GRID_ROWS = Math.floor(WORLD_HEIGHT / TILE_SIZE);
 
 export class WorldScene extends Phaser.Scene {
+  private player!: PlayerSprite;
+  private companion!: CompanionSprite;
+  private walkGrid!: number[][];
+
   constructor() {
     super({ key: 'WorldScene' });
   }
 
   create() {
-    const { width, height } = this.scale;
+    const bg = this.add.image(WORLD_WIDTH / 2, WORLD_HEIGHT / 2, 'map_bg');
+    bg.setDisplaySize(WORLD_WIDTH, WORLD_HEIGHT);
+    bg.setDepth(0);
 
-    const title = this.add.text(width / 2, height / 2 - 40, 'SANCTUARY V2', {
-      fontFamily: '"Press Start 2P", monospace',
-      fontSize: '24px',
-      color: '#00f7ff',
-    });
-    title.setOrigin(0.5);
+    this.walkGrid = [];
+    for (let r = 0; r < GRID_ROWS; r++) {
+      const row: number[] = [];
+      for (let c = 0; c < GRID_COLS; c++) {
+        row.push(0);
+      }
+      this.walkGrid.push(row);
+    }
 
-    const subtitle = this.add.text(width / 2, height / 2 + 10, 'Phaser canvas active', {
-      fontFamily: 'monospace',
-      fontSize: '14px',
-      color: '#9966ff',
+    const pathfinder = new EasyStarPathfinder();
+    pathfinder.setGrid(this.walkGrid);
+    pathfinder.setAcceptableTiles([0]);
+    pathfinder.enableDiagonals();
+    pathfinder.setIterationsPerCalculation(1000);
+
+    this.player = new PlayerSprite(
+      this,
+      WORLD_WIDTH / 2,
+      WORLD_HEIGHT / 2,
+      pathfinder,
+    );
+
+    this.companion = new CompanionSprite(
+      this,
+      WORLD_WIDTH / 2 + -24,
+      WORLD_HEIGHT / 2 + 12,
+    );
+
+    this.cameras.main.setBounds(0, 0, WORLD_WIDTH, WORLD_HEIGHT);
+    this.cameras.main.startFollow(this.player, true, 0.1, 0.1);
+
+    this.input.on('pointerdown', (pointer: Phaser.Input.Pointer) => {
+      this.player.moveTo(pointer.worldX, pointer.worldY, this.walkGrid);
     });
-    subtitle.setOrigin(0.5);
 
     EventBus.emit('scene-ready', this);
+  }
+
+  update(time: number, delta: number) {
+    this.player.update(time, delta);
+    this.companion.followPlayer(this.player.x, this.player.y);
+    this.companion.update();
   }
 }

--- a/game/sprites/CompanionSprite.ts
+++ b/game/sprites/CompanionSprite.ts
@@ -1,0 +1,85 @@
+import Phaser from 'phaser';
+
+const FOLLOW_LERP = 0.15;
+const FOLLOW_OFFSET_X = -24;
+const FOLLOW_OFFSET_Y = 12;
+
+const CONSTELLATIONS = [
+  'aether', 'spectra', 'solveil', 'nebulu', 'chroma',
+  'rose', 'monflare', 'auracore', 'parallel', 'prime',
+] as const;
+
+export type Constellation = (typeof CONSTELLATIONS)[number];
+
+export { CONSTELLATIONS };
+
+export class CompanionSprite extends Phaser.GameObjects.Sprite {
+  private targetX: number;
+  private targetY: number;
+
+  constructor(scene: Phaser.Scene, x: number, y: number, constellation?: Constellation) {
+    const textureKey = constellation ? `companion-${constellation}` : 'companion-fallback';
+    super(scene, x, y, textureKey);
+
+    this.targetX = x;
+    this.targetY = y;
+
+    scene.add.existing(this);
+    this.setDepth(9);
+    this.setScale(1.5);
+  }
+
+  static loadAssets(scene: Phaser.Scene): void {
+    for (const c of CONSTELLATIONS) {
+      scene.load.image(`companion-${c}`, `/sanctuary/companions/${c}/idle.png`);
+    }
+  }
+
+  static generateFallbackTexture(scene: Phaser.Scene): void {
+    const size = 32;
+    const g = scene.make.graphics({ x: 0, y: 0 });
+
+    // Gold star shape
+    g.fillStyle(0xffd700);
+    const cx = size / 2;
+    const cy = size / 2;
+    const outerR = 12;
+    const innerR = 5;
+
+    g.beginPath();
+    for (let i = 0; i < 10; i++) {
+      const r = i % 2 === 0 ? outerR : innerR;
+      const angle = (i * Math.PI) / 5 - Math.PI / 2;
+      const px = cx + r * Math.cos(angle);
+      const py = cy + r * Math.sin(angle);
+      if (i === 0) g.moveTo(px, py);
+      else g.lineTo(px, py);
+    }
+    g.closePath();
+    g.fillPath();
+
+    // Inner glow
+    g.fillStyle(0xffee88);
+    g.fillCircle(cx, cy, 4);
+
+    g.generateTexture('companion-fallback', size, size);
+    g.destroy();
+  }
+
+  setConstellation(constellation: Constellation): void {
+    const key = `companion-${constellation}`;
+    if (this.scene.textures.exists(key)) {
+      this.setTexture(key);
+    }
+  }
+
+  followPlayer(playerX: number, playerY: number): void {
+    this.targetX = playerX + FOLLOW_OFFSET_X;
+    this.targetY = playerY + FOLLOW_OFFSET_Y;
+  }
+
+  update(): void {
+    this.x += (this.targetX - this.x) * FOLLOW_LERP;
+    this.y += (this.targetY - this.y) * FOLLOW_LERP;
+  }
+}

--- a/game/sprites/PlayerSprite.ts
+++ b/game/sprites/PlayerSprite.ts
@@ -1,0 +1,169 @@
+import Phaser from 'phaser';
+import { js as EasyStarPathfinder } from 'easystarjs';
+
+const TILE_SIZE = 16;
+const MOVE_SPEED = 120;
+
+type Direction = 'down' | 'up' | 'left' | 'right';
+
+const DIRECTIONS: Direction[] = ['down', 'up', 'left', 'right'];
+
+export class PlayerSprite extends Phaser.GameObjects.Sprite {
+  private cursors: Phaser.Types.Input.Keyboard.CursorKeys | null = null;
+  private wasdKeys: Record<string, Phaser.Input.Keyboard.Key> | null = null;
+  private pathfinder: EasyStarPathfinder;
+  private currentPath: { x: number; y: number }[] = [];
+  private pathIndex = 0;
+  private direction: Direction = 'down';
+  private moving = false;
+
+  constructor(scene: Phaser.Scene, x: number, y: number, pathfinder: EasyStarPathfinder) {
+    super(scene, x, y, 'player-down-0');
+    this.pathfinder = pathfinder;
+
+    scene.add.existing(this);
+    this.setDepth(10);
+
+    if (scene.input.keyboard) {
+      this.cursors = scene.input.keyboard.createCursorKeys();
+      this.wasdKeys = {
+        W: scene.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.W),
+        A: scene.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.A),
+        S: scene.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.S),
+        D: scene.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.D),
+      };
+    }
+  }
+
+  static generateTextures(scene: Phaser.Scene): void {
+    const g = scene.make.graphics({ x: 0, y: 0 });
+
+    for (const dir of DIRECTIONS) {
+      for (let frame = 0; frame < 2; frame++) {
+        g.clear();
+
+        // Body
+        g.fillStyle(0x00f7ff);
+        g.fillRect(3, 2, 10, 8);
+
+        // Head highlight
+        g.fillStyle(0x66ffff);
+        g.fillRect(5, 3, 6, 4);
+
+        // Direction indicator (gold arrow)
+        g.fillStyle(0xffd700);
+        if (dir === 'down') g.fillRect(6, 10, 4, 3);
+        else if (dir === 'up') g.fillRect(6, 0, 4, 3);
+        else if (dir === 'left') g.fillRect(1, 5, 3, 4);
+        else g.fillRect(12, 5, 3, 4);
+
+        // Feet (toggle for walk animation)
+        g.fillStyle(0x9966ff);
+        if (frame === 0) {
+          g.fillRect(4, 12, 3, 3);
+          g.fillRect(9, 12, 3, 3);
+        } else {
+          g.fillRect(3, 12, 3, 3);
+          g.fillRect(10, 12, 3, 3);
+        }
+
+        g.generateTexture(`player-${dir}-${frame}`, TILE_SIZE, TILE_SIZE);
+      }
+    }
+
+    g.destroy();
+
+    for (const dir of DIRECTIONS) {
+      scene.anims.create({
+        key: `walk-${dir}`,
+        frames: [
+          { key: `player-${dir}-0` },
+          { key: `player-${dir}-1` },
+        ],
+        frameRate: 6,
+        repeat: -1,
+      });
+    }
+  }
+
+  moveTo(worldX: number, worldY: number, grid: number[][]): void {
+    const gridCols = grid[0]?.length ?? 0;
+    const gridRows = grid.length;
+
+    const startCol = Phaser.Math.Clamp(Math.floor(this.x / TILE_SIZE), 0, gridCols - 1);
+    const startRow = Phaser.Math.Clamp(Math.floor(this.y / TILE_SIZE), 0, gridRows - 1);
+    const endCol = Phaser.Math.Clamp(Math.floor(worldX / TILE_SIZE), 0, gridCols - 1);
+    const endRow = Phaser.Math.Clamp(Math.floor(worldY / TILE_SIZE), 0, gridRows - 1);
+
+    if (startCol === endCol && startRow === endRow) return;
+
+    this.pathfinder.findPath(startCol, startRow, endCol, endRow, (path) => {
+      if (path && path.length > 1) {
+        this.currentPath = path.slice(1).map(p => ({
+          x: p.x * TILE_SIZE + TILE_SIZE / 2,
+          y: p.y * TILE_SIZE + TILE_SIZE / 2,
+        }));
+        this.pathIndex = 0;
+      }
+    });
+    this.pathfinder.calculate();
+  }
+
+  update(_time: number, delta: number): void {
+    const dt = delta / 1000;
+    let dx = 0;
+    let dy = 0;
+
+    const left = this.cursors?.left.isDown || this.wasdKeys?.A.isDown;
+    const right = this.cursors?.right.isDown || this.wasdKeys?.D.isDown;
+    const up = this.cursors?.up.isDown || this.wasdKeys?.W.isDown;
+    const down = this.cursors?.down.isDown || this.wasdKeys?.S.isDown;
+
+    if (left || right || up || down) {
+      this.currentPath = [];
+      this.pathIndex = 0;
+
+      if (left) dx -= 1;
+      if (right) dx += 1;
+      if (up) dy -= 1;
+      if (down) dy += 1;
+    } else if (this.pathIndex < this.currentPath.length) {
+      const target = this.currentPath[this.pathIndex];
+      const distX = target.x - this.x;
+      const distY = target.y - this.y;
+      const dist = Math.sqrt(distX * distX + distY * distY);
+
+      if (dist < 2) {
+        this.pathIndex++;
+      } else {
+        dx = distX / dist;
+        dy = distY / dist;
+      }
+    }
+
+    const len = Math.sqrt(dx * dx + dy * dy);
+    if (len > 0) {
+      const nx = (dx / len) * MOVE_SPEED * dt;
+      const ny = (dy / len) * MOVE_SPEED * dt;
+      this.x += nx;
+      this.y += ny;
+
+      if (Math.abs(dx) > Math.abs(dy)) {
+        this.direction = dx > 0 ? 'right' : 'left';
+      } else {
+        this.direction = dy > 0 ? 'down' : 'up';
+      }
+
+      if (!this.moving) {
+        this.moving = true;
+      }
+      this.play(`walk-${this.direction}`, true);
+    } else {
+      if (this.moving) {
+        this.moving = false;
+        this.stop();
+        this.setTexture(`player-${this.direction}-0`);
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@tanstack/react-query": "^5.90.12",
         "better-sqlite3": "^12.5.0",
+        "easystarjs": "^0.4.4",
         "ethers": "^6.16.0",
         "next": "^16.0.10",
         "phaser": "^3.90.0",
@@ -4236,6 +4237,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/easystarjs": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/easystarjs/-/easystarjs-0.4.4.tgz",
+      "integrity": "sha512-ZSt0TkB8xuIXRIrKsM3jkmk1/cZUtyvf0DqOXf6wuKq9slx9UA5kkLtiaWhtmOQFJFKdabbvXwk6RO0znghArQ==",
+      "license": "MIT",
+      "dependencies": {
+        "heap": "0.2.6"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.267",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz",
@@ -5527,6 +5537,11 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/heap": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.6.tgz",
+      "integrity": "sha512-MzzWcnfB1e4EG2vHi3dXHoBupmuXNZzx6pY6HldVS55JKKBoq3xOyzfSaZRkJp37HIhEYC78knabHff3zc4dQQ=="
     },
     "node_modules/hermes-estree": {
       "version": "0.25.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@tanstack/react-query": "^5.90.12",
     "better-sqlite3": "^12.5.0",
+    "easystarjs": "^0.4.4",
     "ethers": "^6.16.0",
     "next": "^16.0.10",
     "phaser": "^3.90.0",


### PR DESCRIPTION
## Summary
- Created `game/sprites/PlayerSprite.ts`: 16×16 procedurally-generated placeholder sprite with 4-direction walk animations, WASD/arrow key input, and EasyStar.js A* click-to-move pathfinding
- Created `game/sprites/CompanionSprite.ts`: follows player with lerp 0.15 interpolation, loads NFT constellation art (10 types) as static sprites with procedural gold-star fallback
- Updated `game/scenes/BootScene.ts` to preload map background and all companion sprites, generate placeholder textures
- Updated `game/scenes/WorldScene.ts` with full world setup: 1440×810 scrollable world, walkability grid, camera following player, pointer-click pathfinding

## Details
- **Player movement**: keyboard (arrows + WASD) overrides pathfinding; diagonal movement normalized; walk animation at 6fps
- **Pathfinding**: EasyStar.js with diagonal movement enabled, 1000 iterations/calc for instant path results
- **Companion**: trails player at (-24, +12) offset, smooth lerp follow, can switch constellation via `setConstellation()`
- **Camera**: follows player with 0.1 lerp, bounded to world extents

## Test plan
- [x] `npm run type-check` — PASS (0 errors)
- [x] `npm run lint` — PASS on changed files (0 new errors)
- [x] `npm run test` — 244 passed, 4 pre-existing failures
- [x] `npm run build` — PASS

## Mirror Validation (PROD)
- **tsc --noEmit**: 30 errors — all `Cannot find module 'phaser'/'easystarjs'` (PROD mirror lacks game deps from PR #208, not deployed yet). 0 new logic errors.
- **vitest run**: not run (game deps missing)
- Overall: PASS (pre-existing module-missing errors only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)