### PR TITLE
feat: zone detection system and companion HUD overlay

### DIFF
--- a/app/sanctuary/SanctuaryV2.tsx
+++ b/app/sanctuary/SanctuaryV2.tsx
@@ -10,6 +10,11 @@ const PhaserGame = dynamic(
   { ssr: false }
 );
 
+const CompanionHUD = dynamic(
+  () => import('@/components/sanctuary/overlays/CompanionHUD'),
+  { ssr: false }
+);
+
 export default function SanctuaryV2() {
   const gameRef = useRef<PhaserGameRef | null>(null);
   const { address, isConnected } = useAccount();
@@ -42,9 +47,10 @@ export default function SanctuaryV2() {
         </div>
       </div>
 
-      {/* Phaser canvas */}
-      <div className="bg-black/80 border border-[#00f7ff]/30 rounded-lg overflow-hidden shadow-[0_0_15px_rgba(0,247,255,0.15)]">
+      {/* Phaser canvas with HUD overlay */}
+      <div className="relative bg-black/80 border border-[#00f7ff]/30 rounded-lg overflow-hidden shadow-[0_0_15px_rgba(0,247,255,0.15)]">
         <PhaserGame ref={gameRef} onSceneReady={handleSceneReady} />
+        <CompanionHUD walletAddress={address} />
       </div>
     </div>
   );

--- a/components/sanctuary/overlays/CompanionHUD.tsx
+++ b/components/sanctuary/overlays/CompanionHUD.tsx
@@ -1,0 +1,151 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import EventBus from '@/components/sanctuary/EventBus';
+
+interface CompanionData {
+  nickname: string | null;
+  token_id: number;
+  mood: string | null;
+  bond_score: number;
+  total_xp: number;
+  level: number;
+}
+
+interface CompanionHUDProps {
+  walletAddress: string | undefined;
+}
+
+const MOOD_EMOJI: Record<string, string> = {
+  happy: '\u{1F60A}',
+  excited: '\u{1F929}',
+  calm: '\u{1F60C}',
+  sleepy: '\u{1F634}',
+  curious: '\u{1F9D0}',
+};
+
+const XP_PER_LEVEL = 100;
+
+function xpForLevel(level: number): number {
+  return (level - 1) * (level - 1) * XP_PER_LEVEL;
+}
+
+function xpProgress(totalXp: number, level: number): { current: number; needed: number } {
+  const thisLevel = xpForLevel(level);
+  const nextLevel = xpForLevel(level + 1);
+  return { current: totalXp - thisLevel, needed: nextLevel - thisLevel };
+}
+
+export default function CompanionHUD({ walletAddress }: CompanionHUDProps) {
+  const [companion, setCompanion] = useState<CompanionData | null>(null);
+  const [locationName, setLocationName] = useState<string | null>(null);
+  const [locationVisible, setLocationVisible] = useState(false);
+
+  useEffect(() => {
+    if (!walletAddress) return;
+    let cancelled = false;
+
+    async function fetchCompanion() {
+      try {
+        const res = await fetch(
+          `/api/sanctuary/companion?address=${walletAddress}`
+        );
+        if (!res.ok) return;
+        const data = await res.json();
+        if (!cancelled && data.companion) {
+          setCompanion({
+            nickname: data.companion.nickname,
+            token_id: data.companion.token_id,
+            mood: data.companion.mood,
+            bond_score: data.companion.bond_score,
+            total_xp: data.companion.total_xp ?? 0,
+            level: data.companion.level ?? 1,
+          });
+        }
+      } catch {
+        // silently ignore — HUD is non-critical
+      }
+    }
+
+    fetchCompanion();
+    return () => {
+      cancelled = true;
+    };
+  }, [walletAddress]);
+
+  const onEnter = useCallback((payload: { name: string }) => {
+    setLocationName(payload.name);
+    setLocationVisible(true);
+  }, []);
+
+  const onExit = useCallback(() => {
+    setLocationVisible(false);
+  }, []);
+
+  useEffect(() => {
+    EventBus.on('location-entered', onEnter);
+    EventBus.on('location-exited', onExit);
+    return () => {
+      EventBus.off('location-entered', onEnter);
+      EventBus.off('location-exited', onExit);
+    };
+  }, [onEnter, onExit]);
+
+  if (!companion) return null;
+
+  const displayName =
+    companion.nickname || `Skrumpey #${companion.token_id}`;
+  const moodEmoji = MOOD_EMOJI[companion.mood ?? ''] ?? '\u{1F438}';
+  const bondPct = Math.min((companion.bond_score / 100) * 100, 100);
+  const xp = xpProgress(companion.total_xp, companion.level);
+  const xpPct = xp.needed > 0 ? Math.min((xp.current / xp.needed) * 100, 100) : 100;
+
+  return (
+    <>
+      {/* Companion status bar — top-left overlay */}
+      <div className="absolute top-2 left-2 z-20 flex items-center gap-2 bg-black/80 border border-[#2a2a4e] rounded px-3 py-1.5 pointer-events-none select-none">
+        <span className="text-base leading-none">{moodEmoji}</span>
+        <div className="flex flex-col gap-0.5 min-w-0">
+          <span className="text-[8px] text-[#ffd700] font-['Press_Start_2P'] truncate max-w-[120px]">
+            {displayName}
+          </span>
+          <div className="flex items-center gap-1.5">
+            {/* Bond bar */}
+            <span className="text-[6px] text-gray-500 w-6 text-right">BND</span>
+            <div className="w-14 h-1 bg-[#1a1a2e] rounded-full overflow-hidden border border-[#2a2a4e]">
+              <div
+                className="h-full rounded-full bg-[#ff66aa] transition-all duration-500"
+                style={{ width: `${bondPct}%` }}
+              />
+            </div>
+            {/* XP bar */}
+            <span className="text-[6px] text-gray-500 w-6 text-right">
+              L{companion.level}
+            </span>
+            <div className="w-14 h-1 bg-[#1a1a2e] rounded-full overflow-hidden border border-[#2a2a4e]">
+              <div
+                className="h-full rounded-full bg-[#00f7ff] transition-all duration-500"
+                style={{ width: `${xpPct}%` }}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Location indicator — top-center overlay */}
+      {locationName && (
+        <div
+          className={`absolute top-2 left-1/2 -translate-x-1/2 z-20 bg-black/80 border border-[#9966ff]/40 rounded px-3 py-1 pointer-events-none select-none transition-all duration-300 ${
+            locationVisible
+              ? 'opacity-100 translate-y-0'
+              : 'opacity-0 -translate-y-2'
+          }`}
+        >
+          <span className="text-[8px] text-[#9966ff] font-['Press_Start_2P'] uppercase tracking-wider">
+            {locationName}
+          </span>
+        </div>
+      )}
+    </>
+  );
+}

--- a/game/scenes/WorldScene.ts
+++ b/game/scenes/WorldScene.ts
@@ -1,12 +1,17 @@
 import Phaser from 'phaser';
 import EventBus from '@/components/sanctuary/EventBus';
+import { ZoneSystem } from '@/game/systems/ZoneSystem';
 
 export class WorldScene extends Phaser.Scene {
+  private zoneSystem!: ZoneSystem;
+
   constructor() {
     super({ key: 'WorldScene' });
   }
 
   create() {
+    this.zoneSystem = new ZoneSystem();
+
     const { width, height } = this.scale;
 
     const title = this.add.text(width / 2, height / 2 - 40, 'SANCTUARY V2', {
@@ -23,6 +28,32 @@ export class WorldScene extends Phaser.Scene {
     });
     subtitle.setOrigin(0.5);
 
+    this.drawZoneOverlays();
+
+    EventBus.on('player-moved', this.onPlayerMoved, this);
+
     EventBus.emit('scene-ready', this);
+  }
+
+  private onPlayerMoved(pos: { x: number; y: number }): void {
+    this.zoneSystem.update(pos.x, pos.y);
+  }
+
+  private drawZoneOverlays(): void {
+    const gfx = this.add.graphics();
+    gfx.lineStyle(1, 0x9966ff, 0.25);
+
+    for (const zone of this.zoneSystem.getZones()) {
+      gfx.strokeRect(zone.x, zone.y, zone.width, zone.height);
+    }
+  }
+
+  update() {
+    // Zone checks are driven by player-moved events, not polling
+  }
+
+  shutdown() {
+    EventBus.off('player-moved', this.onPlayerMoved, this);
+    this.zoneSystem.destroy();
   }
 }

--- a/game/systems/ZoneSystem.ts
+++ b/game/systems/ZoneSystem.ts
@@ -1,0 +1,86 @@
+import EventBus from '@/components/sanctuary/EventBus';
+
+export interface ZoneDefinition {
+  name: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  unlockLevel: number;
+}
+
+const ZONE_WIDTH = 120;
+const ZONE_HEIGHT = 100;
+
+const GAME_WIDTH = 1024;
+const GAME_HEIGHT = 576;
+
+const LOCATIONS: { name: string; nx: number; ny: number; unlockLevel: number }[] = [
+  { name: 'Hot Springs', nx: 0.2, ny: 0.3, unlockLevel: 1 },
+  { name: 'Training Grounds', nx: 0.7, ny: 0.2, unlockLevel: 1 },
+  { name: 'Dream Hollow', nx: 0.1, ny: 0.8, unlockLevel: 1 },
+  { name: 'Star Garden', nx: 0.5, ny: 0.5, unlockLevel: 2 },
+  { name: 'Nebula Kitchen', nx: 0.3, ny: 0.7, unlockLevel: 2 },
+  { name: 'Cosmic Library', nx: 0.8, ny: 0.6, unlockLevel: 3 },
+  { name: 'Observatory', nx: 0.5, ny: 0.1, unlockLevel: 4 },
+  { name: 'Aura Forge', nx: 0.9, ny: 0.4, unlockLevel: 5 },
+];
+
+function buildZones(): ZoneDefinition[] {
+  return LOCATIONS.map(({ name, nx, ny, unlockLevel }) => ({
+    name,
+    x: nx * GAME_WIDTH - ZONE_WIDTH / 2,
+    y: ny * GAME_HEIGHT - ZONE_HEIGHT / 2,
+    width: ZONE_WIDTH,
+    height: ZONE_HEIGHT,
+    unlockLevel,
+  }));
+}
+
+export class ZoneSystem {
+  private zones: ZoneDefinition[];
+  private currentZone: string | null = null;
+
+  constructor() {
+    this.zones = buildZones();
+  }
+
+  getZones(): readonly ZoneDefinition[] {
+    return this.zones;
+  }
+
+  getCurrentZone(): string | null {
+    return this.currentZone;
+  }
+
+  update(playerX: number, playerY: number): void {
+    const entered = this.zones.find(
+      (z) =>
+        playerX >= z.x &&
+        playerX <= z.x + z.width &&
+        playerY >= z.y &&
+        playerY <= z.y + z.height
+    );
+
+    const newZone = entered?.name ?? null;
+
+    if (newZone === this.currentZone) return;
+
+    if (this.currentZone !== null) {
+      EventBus.emit('location-exited', { name: this.currentZone });
+    }
+
+    this.currentZone = newZone;
+
+    if (newZone !== null) {
+      EventBus.emit('location-entered', {
+        name: newZone,
+        unlockLevel: entered!.unlockLevel,
+      });
+    }
+  }
+
+  destroy(): void {
+    this.currentZone = null;
+  }
+}


### PR DESCRIPTION
## Summary
- **ZoneSystem** (`game/systems/ZoneSystem.ts`): Rectangular zone detection for all 8 Sanctuary locations. Tracks player position and emits `location-entered`/`location-exited` events via EventBus when the player enters/exits a zone.
- **CompanionHUD** (`components/sanctuary/overlays/CompanionHUD.tsx`): Compact overlay showing companion name, mood emoji, bond bar, and XP bar. Displays location name indicator with fade-in/out transition on zone entry/exit.
- **WorldScene** updated to instantiate ZoneSystem, draw subtle zone overlays, and listen for `player-moved` events.
- **SanctuaryV2** updated to render CompanionHUD as an overlay on the Phaser canvas (dynamic import, SSR-safe).

## Zone Definitions
8 zones (120x100px each) centered on DB-seeded location coordinates:
| Location | Center (norm) | Unlock Level |
|----------|--------------|-------------|
| Hot Springs | (0.2, 0.3) | 1 |
| Training Grounds | (0.7, 0.2) | 1 |
| Dream Hollow | (0.1, 0.8) | 1 |
| Star Garden | (0.5, 0.5) | 2 |
| Nebula Kitchen | (0.3, 0.7) | 2 |
| Cosmic Library | (0.8, 0.6) | 3 |
| Observatory | (0.5, 0.1) | 4 |
| Aura Forge | (0.9, 0.4) | 5 |

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS (all errors pre-existing — Phaser not installed in PROD mirror)
- **vitest run**: SKIP (PROD mirror lacks vitest config)
Overall: PASS (no new errors)

## Test plan
- [x] `npm run type-check` — 0 errors
- [x] `npm run lint` — 67 errors (all pre-existing)
- [x] `npm run test` — 244 passed, 4 failed (all pre-existing)
- [x] `npm run build` — success
- [ ] Manual: load `/sanctuary?v=2`, verify HUD displays companion status
- [ ] Manual: emit `player-moved` via EventBus, verify zone enter/exit events fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)