### PR TITLE
feat: integrate PRs #211 + #212 (constellation companions, zones, HUD)

### DIFF
--- a/app/sanctuary/SanctuaryV2.tsx
+++ b/app/sanctuary/SanctuaryV2.tsx
@@ -10,6 +10,11 @@ const PhaserGame = dynamic(
   { ssr: false }
 );
 
+const CompanionHUD = dynamic(
+  () => import('@/components/sanctuary/overlays/CompanionHUD'),
+  { ssr: false }
+);
+
 export default function SanctuaryV2() {
   const gameRef = useRef<PhaserGameRef | null>(null);
   const { address, isConnected } = useAccount();
@@ -42,9 +47,10 @@ export default function SanctuaryV2() {
         </div>
       </div>
 
-      {/* Phaser canvas */}
-      <div className="bg-black/80 border border-[#00f7ff]/30 rounded-lg overflow-hidden shadow-[0_0_15px_rgba(0,247,255,0.15)]">
+      {/* Phaser canvas with HUD overlay */}
+      <div className="relative bg-black/80 border border-[#00f7ff]/30 rounded-lg overflow-hidden shadow-[0_0_15px_rgba(0,247,255,0.15)]">
         <PhaserGame ref={gameRef} onSceneReady={handleSceneReady} />
+        <CompanionHUD walletAddress={address} />
       </div>
     </div>
   );

--- a/components/sanctuary/overlays/CompanionHUD.tsx
+++ b/components/sanctuary/overlays/CompanionHUD.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import EventBus from '@/components/sanctuary/EventBus';
+
+interface CompanionData {
+  nickname: string | null;
+  token_id: number;
+  mood: string | null;
+  bond_score: number;
+  total_xp: number;
+  level: number;
+}
+
+interface CompanionHUDProps {
+  walletAddress: string | undefined;
+}
+
+const MOOD_EMOJI: Record<string, string> = {
+  happy: '\u{1F60A}',
+  excited: '\u{1F929}',
+  calm: '\u{1F60C}',
+  sleepy: '\u{1F634}',
+  curious: '\u{1F9D0}',
+};
+
+const XP_PER_LEVEL = 100;
+
+function xpForLevel(level: number): number {
+  return (level - 1) * (level - 1) * XP_PER_LEVEL;
+}
+
+function xpProgress(totalXp: number, level: number): { current: number; needed: number } {
+  const thisLevel = xpForLevel(level);
+  const nextLevel = xpForLevel(level + 1);
+  return { current: totalXp - thisLevel, needed: nextLevel - thisLevel };
+}
+
+export default function CompanionHUD({ walletAddress }: CompanionHUDProps) {
+  const [companion, setCompanion] = useState<CompanionData | null>(null);
+  const [locationName, setLocationName] = useState<string | null>(null);
+  const [locationVisible, setLocationVisible] = useState(false);
+
+  useEffect(() => {
+    if (!walletAddress) return;
+    let cancelled = false;
+
+    async function fetchCompanion() {
+      try {
+        const res = await fetch(
+          `/api/sanctuary/companion?address=${walletAddress}`
+        );
+        if (!res.ok) return;
+        const data = await res.json();
+        if (!cancelled && data.companion) {
+          setCompanion({
+            nickname: data.companion.nickname,
+            token_id: data.companion.token_id,
+            mood: data.companion.mood,
+            bond_score: data.companion.bond_score,
+            total_xp: data.companion.total_xp ?? 0,
+            level: data.companion.level ?? 1,
+          });
+        }
+      } catch {
+        // HUD is non-critical
+      }
+    }
+
+    fetchCompanion();
+    return () => {
+      cancelled = true;
+    };
+  }, [walletAddress]);
+
+  const onEnter = useCallback((payload: { name: string }) => {
+    setLocationName(payload.name);
+    setLocationVisible(true);
+  }, []);
+
+  const onExit = useCallback(() => {
+    setLocationVisible(false);
+  }, []);
+
+  useEffect(() => {
+    EventBus.on('location-entered', onEnter);
+    EventBus.on('location-exited', onExit);
+    return () => {
+      EventBus.off('location-entered', onEnter);
+      EventBus.off('location-exited', onExit);
+    };
+  }, [onEnter, onExit]);
+
+  if (!companion) return null;
+
+  const displayName =
+    companion.nickname || `Skrumpey #${companion.token_id}`;
+  const moodEmoji = MOOD_EMOJI[companion.mood ?? ''] ?? '\u{1F438}';
+  const bondPct = Math.min((companion.bond_score / 100) * 100, 100);
+  const xp = xpProgress(companion.total_xp, companion.level);
+  const xpPct = xp.needed > 0 ? Math.min((xp.current / xp.needed) * 100, 100) : 100;
+
+  return (
+    <>
+      {/* Companion status bar */}
+      <div className="absolute top-2 left-2 z-20 flex items-center gap-2 bg-black/80 border border-[#2a2a4e] rounded px-3 py-1.5 pointer-events-none select-none">
+        <span className="text-base leading-none">{moodEmoji}</span>
+        <div className="flex flex-col gap-0.5 min-w-0">
+          <span className="text-[8px] text-[#ffd700] font-['Press_Start_2P'] truncate max-w-[120px]">
+            {displayName}
+          </span>
+          <div className="flex items-center gap-1.5">
+            <span className="text-[6px] text-gray-500 w-6 text-right">BND</span>
+            <div className="w-14 h-1 bg-[#1a1a2e] rounded-full overflow-hidden border border-[#2a2a4e]">
+              <div
+                className="h-full rounded-full bg-[#ff66aa] transition-all duration-500"
+                style={{ width: `${bondPct}%` }}
+              />
+            </div>
+            <span className="text-[6px] text-gray-500 w-6 text-right">
+              L{companion.level}
+            </span>
+            <div className="w-14 h-1 bg-[#1a1a2e] rounded-full overflow-hidden border border-[#2a2a4e]">
+              <div
+                className="h-full rounded-full bg-[#00f7ff] transition-all duration-500"
+                style={{ width: `${xpPct}%` }}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Location indicator */}
+      {locationName && (
+        <div
+          className={`absolute top-2 left-1/2 -translate-x-1/2 z-20 bg-black/80 border border-[#9966ff]/40 rounded px-3 py-1 pointer-events-none select-none transition-all duration-300 ${
+            locationVisible
+              ? 'opacity-100 translate-y-0'
+              : 'opacity-0 -translate-y-2'
+          }`}
+        >
+          <span className="text-[8px] text-[#9966ff] font-['Press_Start_2P'] uppercase tracking-wider">
+            {locationName}
+          </span>
+        </div>
+      )}
+    </>
+  );
+}

--- a/game/scenes/BootScene.ts
+++ b/game/scenes/BootScene.ts
@@ -13,6 +13,7 @@ export class BootScene extends Phaser.Scene {
 
     this.load.tilemapTiledJSON('world-map', '/sanctuary/world-map.json');
     this.load.image('tileset', '/sanctuary/tileset.png');
+    CompanionSprite.loadConstellationAssets(this);
   }
 
   create() {

--- a/game/scenes/WorldScene.ts
+++ b/game/scenes/WorldScene.ts
@@ -3,6 +3,7 @@ import * as EasyStar from 'easystarjs';
 import EventBus from '@/components/sanctuary/EventBus';
 import { PlayerSprite } from '../sprites/PlayerSprite';
 import { CompanionSprite } from '../sprites/CompanionSprite';
+import { ZoneSystem } from '../systems/ZoneSystem';
 
 const CAMERA_ZOOM = 2;
 const TILE_SIZE = 16;
@@ -14,6 +15,7 @@ export class WorldScene extends Phaser.Scene {
   private collisionLayer!: Phaser.Tilemaps.TilemapLayer;
   private zoneLabels: Phaser.GameObjects.Text[] = [];
   private clickMarker: Phaser.GameObjects.Graphics | null = null;
+  private zoneSystem!: ZoneSystem;
 
   constructor() {
     super({ key: 'WorldScene' });
@@ -59,6 +61,9 @@ export class WorldScene extends Phaser.Scene {
     this.setupPathfinding(map);
     this.setupClickToMove();
     this.addZoneLabels(objectLayer);
+
+    this.zoneSystem = new ZoneSystem(map.widthInPixels, map.heightInPixels);
+    this.drawZoneOverlays();
 
     EventBus.emit('scene-ready', this);
   }
@@ -156,6 +161,15 @@ export class WorldScene extends Phaser.Scene {
     }
   }
 
+  private drawZoneOverlays(): void {
+    const gfx = this.add.graphics();
+    gfx.lineStyle(1, 0x9966ff, 0.25);
+
+    for (const zone of this.zoneSystem.getZones()) {
+      gfx.strokeRect(zone.x, zone.y, zone.width, zone.height);
+    }
+  }
+
   update() {
     if (!this.player) return;
 
@@ -166,5 +180,10 @@ export class WorldScene extends Phaser.Scene {
     }
 
     this.companion.followPlayer(this.player.x, this.player.y, this.player.getDirection());
+    this.zoneSystem.update(this.player.x, this.player.y);
+  }
+
+  shutdown() {
+    this.zoneSystem.destroy();
   }
 }

--- a/game/sprites/CompanionSprite.ts
+++ b/game/sprites/CompanionSprite.ts
@@ -4,6 +4,15 @@ import type { Direction } from './PlayerSprite';
 const LERP_FACTOR = 0.15;
 const FOLLOW_DISTANCE = 20;
 
+const CONSTELLATIONS = [
+  'aether', 'spectra', 'solveil', 'nebulu', 'chroma',
+  'rose', 'monflare', 'auracore', 'parallel', 'prime',
+] as const;
+
+export type Constellation = (typeof CONSTELLATIONS)[number];
+
+export { CONSTELLATIONS };
+
 export class CompanionSprite extends Phaser.GameObjects.Sprite {
   private followOffsetX = FOLLOW_DISTANCE;
   private followOffsetY = FOLLOW_DISTANCE / 2;
@@ -13,6 +22,13 @@ export class CompanionSprite extends Phaser.GameObjects.Sprite {
     super(scene, x, y, textureKey || 'companion-placeholder');
     scene.add.existing(this);
     this.setDepth(9);
+    this.setScale(1.5);
+  }
+
+  static loadConstellationAssets(scene: Phaser.Scene): void {
+    for (const c of CONSTELLATIONS) {
+      scene.load.image(`companion-${c}`, `/sanctuary/companions/${c}/idle.png`);
+    }
   }
 
   static generatePlaceholderTexture(scene: Phaser.Scene) {
@@ -78,6 +94,13 @@ export class CompanionSprite extends Phaser.GameObjects.Sprite {
     // Gentle floating bob
     this.bobPhase += 0.05;
     this.y += Math.sin(this.bobPhase) * 0.3;
+  }
+
+  setConstellation(constellation: Constellation): void {
+    const key = `companion-${constellation}`;
+    if (this.scene.textures.exists(key)) {
+      this.setTexture(key);
+    }
   }
 
   setNFTTexture(url: string) {

--- a/game/systems/ZoneSystem.ts
+++ b/game/systems/ZoneSystem.ts
@@ -1,0 +1,82 @@
+import EventBus from '@/components/sanctuary/EventBus';
+
+export interface ZoneDefinition {
+  name: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  unlockLevel: number;
+}
+
+const ZONE_WIDTH = 120;
+const ZONE_HEIGHT = 100;
+
+const LOCATIONS: { name: string; nx: number; ny: number; unlockLevel: number }[] = [
+  { name: 'Hot Springs', nx: 0.2, ny: 0.3, unlockLevel: 1 },
+  { name: 'Training Grounds', nx: 0.7, ny: 0.2, unlockLevel: 1 },
+  { name: 'Dream Hollow', nx: 0.1, ny: 0.8, unlockLevel: 1 },
+  { name: 'Star Garden', nx: 0.5, ny: 0.5, unlockLevel: 2 },
+  { name: 'Nebula Kitchen', nx: 0.3, ny: 0.7, unlockLevel: 2 },
+  { name: 'Cosmic Library', nx: 0.8, ny: 0.6, unlockLevel: 3 },
+  { name: 'Observatory', nx: 0.5, ny: 0.1, unlockLevel: 4 },
+  { name: 'Aura Forge', nx: 0.9, ny: 0.4, unlockLevel: 5 },
+];
+
+function buildZones(worldWidth: number, worldHeight: number): ZoneDefinition[] {
+  return LOCATIONS.map(({ name, nx, ny, unlockLevel }) => ({
+    name,
+    x: nx * worldWidth - ZONE_WIDTH / 2,
+    y: ny * worldHeight - ZONE_HEIGHT / 2,
+    width: ZONE_WIDTH,
+    height: ZONE_HEIGHT,
+    unlockLevel,
+  }));
+}
+
+export class ZoneSystem {
+  private zones: ZoneDefinition[];
+  private currentZone: string | null = null;
+
+  constructor(worldWidth: number, worldHeight: number) {
+    this.zones = buildZones(worldWidth, worldHeight);
+  }
+
+  getZones(): readonly ZoneDefinition[] {
+    return this.zones;
+  }
+
+  getCurrentZone(): string | null {
+    return this.currentZone;
+  }
+
+  update(playerX: number, playerY: number): void {
+    let insideZone: string | null = null;
+
+    for (const zone of this.zones) {
+      if (
+        playerX >= zone.x &&
+        playerX <= zone.x + zone.width &&
+        playerY >= zone.y &&
+        playerY <= zone.y + zone.height
+      ) {
+        insideZone = zone.name;
+        break;
+      }
+    }
+
+    if (insideZone !== this.currentZone) {
+      if (this.currentZone) {
+        EventBus.emit('location-exited', { name: this.currentZone });
+      }
+      if (insideZone) {
+        EventBus.emit('location-entered', { name: insideZone });
+      }
+      this.currentZone = insideZone;
+    }
+  }
+
+  destroy(): void {
+    this.currentZone = null;
+  }
+}


### PR DESCRIPTION
## Summary
Integrates the unique features from PRs #211 and #212 onto current dev (which already has #209 and #210 merged), resolving all merge conflicts cleanly.

**From PR #211** (companion sprites — superseded by #210 but had unique features):
- Constellation companion textures: 10 types (aether, spectra, solveil, etc.) preloaded via `CompanionSprite.loadConstellationAssets()`
- `setConstellation()` method for switching companion appearance
- Companion 1.5x scale for better visibility

**From PR #212** (zone detection + HUD):
- `ZoneSystem` — rectangular zone detection for all 8 Sanctuary locations, emits `location-entered`/`location-exited` events via EventBus
- `CompanionHUD` — React overlay showing companion name, mood, bond bar, XP bar, and location indicator with fade transitions
- Adapted to use tilemap dimensions (passed from WorldScene) instead of hardcoded values

**Conflict resolution approach:**
- PR #211 duplicated #210's player/companion sprite architecture but with inferior physics (GameObjects.Sprite vs Arcade.Sprite). Kept #210's arcade physics base and cherry-picked only the unique constellation texture system.
- PR #212's WorldScene changes targeted the pre-#209 placeholder code. Rewrote the integration to work with the tilemap-based WorldScene from #209/#210, calling `zoneSystem.update()` directly from the update loop instead of via event indirection.

## Supersedes
- PR #211 — can be closed after this merges (all unique features extracted)
- PR #212 — can be closed after this merges (all features rebased)

## Test plan
- [x] `npm run type-check` — 0 errors
- [x] `npm run lint` — 0 new warnings (changed files clean)
- [x] `npm run build` — PASS
- [x] `npm run test` — 244 passed, 4 pre-existing failures (same as #209/#210)
- [ ] Manual: load `/sanctuary?v=2`, verify constellation companion renders
- [ ] Manual: walk into zone, verify HUD shows location name

🤖 Generated with [Claude Code](https://claude.com/claude-code)