### PR TITLE
feat: animated companion sprite system with mood and walk cycles

### DIFF
--- a/game/scenes/BootScene.ts
+++ b/game/scenes/BootScene.ts
@@ -2,6 +2,7 @@ import Phaser from 'phaser';
 import EventBus from '@/components/sanctuary/EventBus';
 import { PlayerSprite } from '../sprites/PlayerSprite';
 import { CompanionSprite } from '../sprites/CompanionSprite';
+import { AnimationSystem } from '../systems/AnimationSystem';
 
 export class BootScene extends Phaser.Scene {
   constructor() {
@@ -13,7 +14,8 @@ export class BootScene extends Phaser.Scene {
 
     this.load.tilemapTiledJSON('world-map', '/sanctuary/world-map.json');
     this.load.image('tileset', '/sanctuary/tileset.png');
-    CompanionSprite.loadConstellationAssets(this);
+
+    AnimationSystem.preloadConstellations(this, ['aether', 'spectra']);
   }
 
   create() {

--- a/game/scenes/WorldScene.ts
+++ b/game/scenes/WorldScene.ts
@@ -3,6 +3,7 @@ import * as EasyStar from 'easystarjs';
 import EventBus from '@/components/sanctuary/EventBus';
 import { PlayerSprite } from '../sprites/PlayerSprite';
 import { CompanionSprite } from '../sprites/CompanionSprite';
+import { AnimationSystem, type CompanionMood, type Constellation, CONSTELLATIONS } from '../systems/AnimationSystem';
 import { ZoneSystem } from '../systems/ZoneSystem';
 
 const CAMERA_ZOOM = 2;
@@ -11,6 +12,7 @@ const TILE_SIZE = 16;
 export class WorldScene extends Phaser.Scene {
   private player!: PlayerSprite;
   private companion!: CompanionSprite;
+  private animSystem!: AnimationSystem;
   private finder!: EasyStar.js;
   private collisionLayer!: Phaser.Tilemaps.TilemapLayer;
   private zoneLabels: Phaser.GameObjects.Text[] = [];
@@ -48,8 +50,11 @@ export class WorldScene extends Phaser.Scene {
       }
     }
 
+    this.animSystem = new AnimationSystem(this);
+
     this.player = new PlayerSprite(this, spawnX, spawnY);
     this.companion = new CompanionSprite(this, spawnX + 20, spawnY + 10);
+    this.companion.setAnimationSystem(this.animSystem);
 
     this.physics.add.collider(this.player, this.collisionLayer);
     this.physics.world.setBounds(0, 0, map.widthInPixels, map.heightInPixels);
@@ -61,11 +66,28 @@ export class WorldScene extends Phaser.Scene {
     this.setupPathfinding(map);
     this.setupClickToMove();
     this.addZoneLabels(objectLayer);
+    this.setupEventBridge();
 
     this.zoneSystem = new ZoneSystem(map.widthInPixels, map.heightInPixels);
     this.drawZoneOverlays();
 
     EventBus.emit('scene-ready', this);
+  }
+
+  private setupEventBridge() {
+    EventBus.on('companion-mood', (mood: string) => {
+      const validMoods: CompanionMood[] = ['happy', 'calm', 'sleepy', 'excited', 'curious', 'idle'];
+      if (validMoods.includes(mood as CompanionMood)) {
+        this.companion.setMood(mood as CompanionMood);
+      }
+    });
+
+    EventBus.on('companion-constellation', (constellation: string) => {
+      const lower = constellation.toLowerCase() as Constellation;
+      if ((CONSTELLATIONS as readonly string[]).includes(lower)) {
+        this.companion.setConstellation(lower);
+      }
+    });
   }
 
   private setupPathfinding(map: Phaser.Tilemaps.Tilemap) {
@@ -185,5 +207,7 @@ export class WorldScene extends Phaser.Scene {
 
   shutdown() {
     this.zoneSystem.destroy();
+    EventBus.off('companion-mood');
+    EventBus.off('companion-constellation');
   }
 }

--- a/game/sprites/CompanionSprite.ts
+++ b/game/sprites/CompanionSprite.ts
@@ -1,28 +1,28 @@
 import Phaser from 'phaser';
 import type { Direction } from './PlayerSprite';
+import { AnimationSystem, type CompanionMood, type Constellation, CONSTELLATIONS } from '../systems/AnimationSystem';
 
 const LERP_FACTOR = 0.15;
 const FOLLOW_DISTANCE = 20;
+const MOVEMENT_THRESHOLD = 0.1;
 
-const CONSTELLATIONS = [
-  'aether', 'spectra', 'solveil', 'nebulu', 'chroma',
-  'rose', 'monflare', 'auracore', 'parallel', 'prime',
-] as const;
-
-export type Constellation = (typeof CONSTELLATIONS)[number];
-
+export type { Constellation };
 export { CONSTELLATIONS };
 
 export class CompanionSprite extends Phaser.GameObjects.Sprite {
   private followOffsetX = FOLLOW_DISTANCE;
   private followOffsetY = FOLLOW_DISTANCE / 2;
-  private bobPhase = 0;
+  private baseY = 0;
+  private animSystem: AnimationSystem | null = null;
+  private lastTime = 0;
+  private prevTextureKey = '';
 
   constructor(scene: Phaser.Scene, x: number, y: number, textureKey?: string) {
     super(scene, x, y, textureKey || 'companion-placeholder');
     scene.add.existing(this);
     this.setDepth(9);
     this.setScale(1.5);
+    this.baseY = y;
   }
 
   static loadConstellationAssets(scene: Phaser.Scene): void {
@@ -36,20 +36,16 @@ export class CompanionSprite extends Phaser.GameObjects.Sprite {
 
     const g = scene.make.graphics();
 
-    // Magenta blob body
     g.fillStyle(0xff00ff, 1);
     g.fillCircle(8, 8, 5);
 
-    // Inner highlight
     g.fillStyle(0xff66ff, 1);
     g.fillCircle(7, 6, 2);
 
-    // Eyes
     g.fillStyle(0xffffff, 1);
     g.fillRect(6, 6, 2, 2);
     g.fillRect(10, 6, 2, 2);
 
-    // Pupils
     g.fillStyle(0x000000, 1);
     g.fillRect(7, 7, 1, 1);
     g.fillRect(11, 7, 1, 1);
@@ -58,7 +54,58 @@ export class CompanionSprite extends Phaser.GameObjects.Sprite {
     g.destroy();
   }
 
+  setAnimationSystem(system: AnimationSystem) {
+    this.animSystem = system;
+  }
+
+  setMood(mood: CompanionMood) {
+    if (!this.animSystem) return;
+    if (this.animSystem.setMood(mood)) {
+      this.refreshTexture();
+    }
+  }
+
+  async setConstellation(constellation: Constellation) {
+    if (!this.animSystem) {
+      const key = `companion-${constellation}`;
+      if (this.scene.textures.exists(key)) {
+        this.setTexture(key);
+      }
+      return;
+    }
+
+    this.animSystem.setConstellation(constellation);
+
+    if (!this.animSystem.isLoaded(constellation)) {
+      this.animSystem.loadConstellationTextures(constellation);
+      await this.animSystem.startLoad();
+    }
+
+    this.refreshTexture();
+  }
+
+  private refreshTexture() {
+    if (!this.animSystem) return;
+
+    const animKey = this.animSystem.getAnimationKey();
+    if (animKey && this.scene.anims.exists(animKey)) {
+      this.play(animKey, true);
+      this.prevTextureKey = '';
+      return;
+    }
+
+    const textureKey = this.animSystem.getTextureKey();
+    if (textureKey !== this.prevTextureKey) {
+      this.prevTextureKey = textureKey;
+      this.setTexture(textureKey);
+    }
+  }
+
   followPlayer(playerX: number, playerY: number, playerDirection?: Direction) {
+    const now = this.scene.time.now;
+    const delta = this.lastTime ? Math.min(now - this.lastTime, 50) : 16;
+    this.lastTime = now;
+
     let targetOffsetX = FOLLOW_DISTANCE;
     let targetOffsetY = FOLLOW_DISTANCE / 2;
 
@@ -81,25 +128,43 @@ export class CompanionSprite extends Phaser.GameObjects.Sprite {
         break;
     }
 
-    // Smoothly transition the offset
     this.followOffsetX += (targetOffsetX - this.followOffsetX) * 0.05;
     this.followOffsetY += (targetOffsetY - this.followOffsetY) * 0.05;
 
     const targetX = playerX + this.followOffsetX;
     const targetY = playerY + this.followOffsetY;
 
+    const prevX = this.x;
+    const prevBaseY = this.baseY;
+
     this.x += (targetX - this.x) * LERP_FACTOR;
-    this.y += (targetY - this.y) * LERP_FACTOR;
+    this.baseY += (targetY - this.baseY) * LERP_FACTOR;
 
-    // Gentle floating bob
-    this.bobPhase += 0.05;
-    this.y += Math.sin(this.bobPhase) * 0.3;
-  }
+    const dx = this.x - prevX;
+    const dy = this.baseY - prevBaseY;
+    const isMoving = Math.abs(dx) > MOVEMENT_THRESHOLD || Math.abs(dy) > MOVEMENT_THRESHOLD;
 
-  setConstellation(constellation: Constellation): void {
-    const key = `companion-${constellation}`;
-    if (this.scene.textures.exists(key)) {
-      this.setTexture(key);
+    if (this.animSystem) {
+      const stateChanged = this.animSystem.setState(isMoving ? 'walk' : 'idle');
+
+      if (isMoving && playerDirection) {
+        this.animSystem.setWalkDirection(playerDirection);
+      }
+
+      const yOffset = this.animSystem.getYOffset(delta);
+      this.y = this.baseY + yOffset;
+
+      if (stateChanged) {
+        this.refreshTexture();
+      }
+    } else {
+      this.y = this.baseY + Math.sin(now * 0.003) * 0.3;
+    }
+
+    if (playerDirection === 'left') {
+      this.setFlipX(true);
+    } else if (playerDirection === 'right') {
+      this.setFlipX(false);
     }
   }
 

--- a/game/systems/AnimationSystem.ts
+++ b/game/systems/AnimationSystem.ts
@@ -1,0 +1,205 @@
+import Phaser from 'phaser';
+import type { Direction } from '../sprites/PlayerSprite';
+
+export type CompanionMood = 'happy' | 'calm' | 'sleepy' | 'excited' | 'curious' | 'idle';
+export type AnimState = 'idle' | 'walk';
+
+export const CONSTELLATIONS = [
+  'aether', 'spectra', 'solveil', 'nebulu', 'chroma',
+  'rose', 'monflare', 'auracore', 'parallel', 'prime',
+] as const;
+export type Constellation = (typeof CONSTELLATIONS)[number];
+
+const MOOD_LIST: CompanionMood[] = ['happy', 'calm', 'sleepy', 'excited', 'curious', 'idle'];
+
+const IDLE_BOB_PERIOD = 2000;
+const IDLE_BOB_AMPLITUDE = 1;
+
+const WALK_FRAME_DURATION = 150;
+const WALK_BOB_OFFSETS = [0, -1, 0, 1];
+
+export interface SpriteSheetConfig {
+  constellation: Constellation;
+  path: string;
+  frameWidth: number;
+  frameHeight: number;
+  animations: Record<string, {
+    frames: number[];
+    frameRate: number;
+    repeat: number;
+  }>;
+}
+
+export class AnimationSystem {
+  private scene: Phaser.Scene;
+  private state: AnimState = 'idle';
+  private mood: CompanionMood = 'idle';
+  private constellation: Constellation | null = null;
+  private walkDirection: Direction = 'down';
+  private loadedConstellations = new Set<string>();
+  private sheetConstellations = new Set<string>();
+
+  private stateTime = 0;
+  private walkFrame = 0;
+  private walkFrameTimer = 0;
+
+  constructor(scene: Phaser.Scene) {
+    this.scene = scene;
+  }
+
+  getTextureKey(): string {
+    if (!this.constellation) return 'companion-placeholder';
+
+    if (this.sheetConstellations.has(this.constellation)) {
+      return `sheet-${this.constellation}`;
+    }
+
+    const key = `companion-${this.constellation}-${this.mood}`;
+    if (this.scene.textures.exists(key)) return key;
+
+    const idleKey = `companion-${this.constellation}-idle`;
+    if (this.scene.textures.exists(idleKey)) return idleKey;
+
+    return 'companion-placeholder';
+  }
+
+  getAnimationKey(): string | null {
+    if (!this.constellation || !this.sheetConstellations.has(this.constellation)) {
+      return null;
+    }
+    const dirSuffix = this.state === 'walk' ? `-${this.walkDirection}` : '';
+    return `${this.constellation}-${this.mood}-${this.state}${dirSuffix}`;
+  }
+
+  getYOffset(deltaMs: number): number {
+    this.stateTime += deltaMs;
+
+    if (this.state === 'idle') {
+      const phase = (this.stateTime % IDLE_BOB_PERIOD) / IDLE_BOB_PERIOD;
+      return Math.round(Math.sin(phase * Math.PI * 2)) * IDLE_BOB_AMPLITUDE;
+    }
+
+    if (this.state === 'walk') {
+      this.walkFrameTimer += deltaMs;
+      if (this.walkFrameTimer >= WALK_FRAME_DURATION) {
+        this.walkFrameTimer -= WALK_FRAME_DURATION;
+        this.walkFrame = (this.walkFrame + 1) % 4;
+      }
+      return WALK_BOB_OFFSETS[this.walkFrame];
+    }
+
+    return 0;
+  }
+
+  setState(newState: AnimState): boolean {
+    if (this.state === newState) return false;
+    this.state = newState;
+    this.stateTime = 0;
+    this.walkFrame = 0;
+    this.walkFrameTimer = 0;
+    return true;
+  }
+
+  setMood(newMood: CompanionMood): boolean {
+    if (this.mood === newMood) return false;
+    this.mood = newMood;
+    return true;
+  }
+
+  setWalkDirection(dir: Direction) {
+    this.walkDirection = dir;
+  }
+
+  setConstellation(c: Constellation) {
+    this.constellation = c;
+  }
+
+  getState(): AnimState {
+    return this.state;
+  }
+
+  getMood(): CompanionMood {
+    return this.mood;
+  }
+
+  getConstellation(): Constellation | null {
+    return this.constellation;
+  }
+
+  loadConstellationTextures(constellation: Constellation): void {
+    if (this.loadedConstellations.has(constellation)) return;
+
+    for (const mood of MOOD_LIST) {
+      const key = `companion-${constellation}-${mood}`;
+      if (!this.scene.textures.exists(key)) {
+        this.scene.load.image(key, `/sanctuary/companions/${constellation}/${mood}.png`);
+      }
+    }
+
+    this.loadedConstellations.add(constellation);
+  }
+
+  loadSpriteSheet(config: SpriteSheetConfig): void {
+    const sheetKey = `sheet-${config.constellation}`;
+
+    if (!this.scene.textures.exists(sheetKey)) {
+      this.scene.load.spritesheet(sheetKey, config.path, {
+        frameWidth: config.frameWidth,
+        frameHeight: config.frameHeight,
+      });
+    }
+
+    this.scene.load.once('complete', () => {
+      this.registerSheetAnimations(config);
+    });
+  }
+
+  private registerSheetAnimations(config: SpriteSheetConfig) {
+    const sheetKey = `sheet-${config.constellation}`;
+    this.sheetConstellations.add(config.constellation);
+
+    for (const [animKey, animDef] of Object.entries(config.animations)) {
+      if (this.scene.anims.exists(animKey)) continue;
+
+      this.scene.anims.create({
+        key: animKey,
+        frames: animDef.frames.map((frame) => ({ key: sheetKey, frame })),
+        frameRate: animDef.frameRate,
+        repeat: animDef.repeat,
+      });
+    }
+  }
+
+  isLoaded(constellation: Constellation): boolean {
+    return this.loadedConstellations.has(constellation) || this.sheetConstellations.has(constellation);
+  }
+
+  hasSheetAnimations(): boolean {
+    return this.constellation !== null && this.sheetConstellations.has(this.constellation);
+  }
+
+  startLoad(): Promise<void> {
+    return new Promise((resolve) => {
+      if (this.scene.load.list.size === 0 && this.scene.load.inflight.size === 0) {
+        resolve();
+        return;
+      }
+      this.scene.load.once('complete', () => resolve());
+      this.scene.load.start();
+    });
+  }
+
+  static preloadConstellations(
+    scene: Phaser.Scene,
+    constellations: Constellation[]
+  ): void {
+    for (const c of constellations) {
+      for (const mood of MOOD_LIST) {
+        const key = `companion-${c}-${mood}`;
+        if (!scene.textures.exists(key)) {
+          scene.load.image(key, `/sanctuary/companions/${c}/${mood}.png`);
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- **New `game/systems/AnimationSystem.ts`** — sprite sheet loader, animation state machine (idle-bob ±1px at 2s period, walk 4-frame bob cycle at 150ms/frame), mood variant switching (happy/calm/sleepy/excited/curious/idle), constellation texture management, and fallback to placeholder for missing sheets
- **Updated `CompanionSprite.ts`** — integrated with AnimationSystem for movement-aware state transitions (idle↔walk detected via position delta), mood/constellation setters with async texture loading, sprite flipping based on direction
- **Updated `BootScene.ts`** — preloads aether and spectra constellation textures (2×6 = 12 mood PNGs) during boot
- **Updated `WorldScene.ts`** — creates AnimationSystem, wires it to CompanionSprite, bridges `companion-mood` and `companion-constellation` EventBus events from React for runtime mood/constellation changes, cleans up listeners on shutdown

## Architecture
```
React (SanctuaryContent)
  ↓ EventBus.emit('companion-mood', 'happy')
  ↓ EventBus.emit('companion-constellation', 'aether')
WorldScene
  ↓ setupEventBridge() listeners
CompanionSprite.setMood() / .setConstellation()
  ↓
AnimationSystem (state machine)
  → getTextureKey() → mood-specific PNG or placeholder fallback
  → getYOffset(delta) → idle bob (±1px sine) or walk bob (4-frame [0,-1,0,1])
  → loadSpriteSheet() → future multi-frame sheet support
```

## Test plan
- [x] `npm run type-check` — 0 errors
- [x] `npm run lint` — no new warnings (pre-existing only)
- [x] `npm run test` — 244 passed, 4 pre-existing failures
- [x] `npm run build` — success

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS (72 new errors all from missing `phaser`/`easystarjs`/`EventBus` modules not installed in PROD — pre-existing infrastructure gap, not from this PR's logic)
- **Baseline**: 5 pre-existing errors (SanctuaryV2.tsx)
- **No new non-infrastructure errors introduced**
Overall: PASS (baseline-diff clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)