### PR TITLE
feat: in-world companion radial menu with reaction animations

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -558,6 +558,38 @@ body::before {
   color: #44ff88;
 }
 
+@keyframes companionFloatUp {
+  0% { opacity: 1; transform: translateY(0); }
+  70% { opacity: 1; }
+  100% { opacity: 0; transform: translateY(-30px); }
+}
+
+.companion-floating-text {
+  animation: companionFloatUp 1.2s ease-out forwards;
+}
+
+.companion-reaction-sparkle {
+  position: relative;
+  width: 40px;
+  height: 40px;
+}
+
+.companion-reaction-bounce {
+  animation: sanctuaryHappyBounce 0.6s ease-in-out;
+}
+
+.companion-reaction-bubble {
+  animation: companionBubblePop 0.8s ease-out forwards;
+}
+
+@keyframes companionBubblePop {
+  0% { transform: scale(0); opacity: 0; }
+  40% { transform: scale(1.2); opacity: 1; }
+  60% { transform: scale(0.9); }
+  80% { transform: scale(1.05); opacity: 1; }
+  100% { transform: scale(1); opacity: 0; }
+}
+
 /* ============================================
    Cozy Gaming Station Loading Experience
    ============================================ */

--- a/app/sanctuary/SanctuaryV2.tsx
+++ b/app/sanctuary/SanctuaryV2.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, useCallback } from 'react';
+import { useRef, useState, useCallback, useEffect } from 'react';
 import dynamic from 'next/dynamic';
 import type { PhaserGameRef } from '@/components/sanctuary/PhaserGame';
 import { useAccount } from 'wagmi';
@@ -15,9 +15,41 @@ const CompanionHUD = dynamic(
   { ssr: false }
 );
 
+const CompanionMenu = dynamic(
+  () => import('@/components/sanctuary/overlays/CompanionMenu'),
+  { ssr: false }
+);
+
 export default function SanctuaryV2() {
   const gameRef = useRef<PhaserGameRef | null>(null);
   const { address, isConnected } = useAccount();
+  const [activeTokenId, setActiveTokenId] = useState<number | null>(null);
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  useEffect(() => {
+    if (!address) return;
+    let cancelled = false;
+
+    async function fetchActiveCompanion() {
+      try {
+        const res = await fetch(`/api/sanctuary/companion?address=${address}`);
+        if (!res.ok) return;
+        const data = await res.json();
+        if (!cancelled && data.companion) {
+          setActiveTokenId(data.companion.token_id);
+        }
+      } catch {
+        // Non-critical
+      }
+    }
+
+    fetchActiveCompanion();
+    return () => { cancelled = true; };
+  }, [address, refreshKey]);
+
+  const handleInteracted = useCallback(() => {
+    setRefreshKey((k) => k + 1);
+  }, []);
 
   const handleSceneReady = useCallback(() => {
     // Future: send wallet data to Phaser scene via EventBus
@@ -51,6 +83,7 @@ export default function SanctuaryV2() {
       <div className="relative bg-black/80 border border-[#00f7ff]/30 rounded-lg overflow-hidden shadow-[0_0_15px_rgba(0,247,255,0.15)]">
         <PhaserGame ref={gameRef} onSceneReady={handleSceneReady} />
         <CompanionHUD walletAddress={address} />
+        <CompanionMenu walletAddress={address} tokenId={activeTokenId} onInteracted={handleInteracted} />
       </div>
     </div>
   );

--- a/components/sanctuary/overlays/CompanionMenu.tsx
+++ b/components/sanctuary/overlays/CompanionMenu.tsx
@@ -1,0 +1,255 @@
+'use client';
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import EventBus from '@/components/sanctuary/EventBus';
+import { getWalletAuthHeader } from '@/lib/clientWalletAuth';
+
+type InteractAction = 'pet' | 'feed' | 'talk';
+
+interface MenuPosition {
+  x: number;
+  y: number;
+}
+
+interface FloatingText {
+  id: number;
+  text: string;
+  color: string;
+  x: number;
+  y: number;
+}
+
+interface ReactionEffect {
+  type: InteractAction;
+  x: number;
+  y: number;
+}
+
+const ACTIONS: { action: InteractAction; icon: string; label: string; angle: number }[] = [
+  { action: 'pet', icon: '🐾', label: 'Pet', angle: -90 },
+  { action: 'feed', icon: '🍎', label: 'Feed', angle: -210 },
+  { action: 'talk', icon: '💬', label: 'Talk', angle: -330 },
+];
+
+const RADIAL_DISTANCE = 56;
+
+let floatingId = 0;
+
+export default function CompanionMenu({
+  walletAddress,
+  tokenId,
+  onInteracted,
+}: {
+  walletAddress: string | undefined;
+  tokenId: number | null;
+  onInteracted?: () => void;
+}) {
+  const [menuPos, setMenuPos] = useState<MenuPosition | null>(null);
+  const [interacting, setInteracting] = useState<InteractAction | null>(null);
+  const [floatingTexts, setFloatingTexts] = useState<FloatingText[]>([]);
+  const [reaction, setReaction] = useState<ReactionEffect | null>(null);
+  const [visible, setVisible] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const openMenu = useCallback((payload: { screenX: number; screenY: number }) => {
+    setMenuPos({ x: payload.screenX, y: payload.screenY });
+    setVisible(true);
+  }, []);
+
+  const closeMenu = useCallback(() => {
+    setVisible(false);
+    setTimeout(() => setMenuPos(null), 200);
+  }, []);
+
+  useEffect(() => {
+    EventBus.on('companion-clicked', openMenu);
+    return () => {
+      EventBus.off('companion-clicked', openMenu);
+    };
+  }, [openMenu]);
+
+  useEffect(() => {
+    if (!visible) return;
+
+    const handleClick = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        closeMenu();
+      }
+    };
+
+    const timer = setTimeout(() => {
+      document.addEventListener('mousedown', handleClick);
+    }, 50);
+
+    return () => {
+      clearTimeout(timer);
+      document.removeEventListener('mousedown', handleClick);
+    };
+  }, [visible, closeMenu]);
+
+  const addFloatingText = useCallback((text: string, color: string, x: number, y: number) => {
+    const id = ++floatingId;
+    setFloatingTexts((prev) => [...prev, { id, text, color, x, y }]);
+    setTimeout(() => {
+      setFloatingTexts((prev) => prev.filter((ft) => ft.id !== id));
+    }, 1200);
+  }, []);
+
+  const triggerReaction = useCallback((action: InteractAction, x: number, y: number) => {
+    setReaction({ type: action, x, y });
+    setTimeout(() => setReaction(null), 800);
+  }, []);
+
+  const handleAction = useCallback(async (action: InteractAction) => {
+    if (!walletAddress || tokenId === null || interacting) return;
+
+    setInteracting(action);
+    const pos = menuPos!;
+
+    try {
+      const walletAuthHeader = await getWalletAuthHeader(walletAddress);
+      if (!walletAuthHeader) {
+        setInteracting(null);
+        return;
+      }
+
+      const res = await fetch('/api/sanctuary/companion/interact', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-wallet-auth': walletAuthHeader,
+        },
+        body: JSON.stringify({ walletAddress, token_id: tokenId, action }),
+      });
+
+      const data = await res.json();
+
+      if (data.success) {
+        triggerReaction(action, pos.x, pos.y);
+
+        const companion = data.companion;
+        if (companion) {
+          addFloatingText(`+${(companion.bond_gained ?? 2).toFixed(0)} Bond`, '#ff66aa', pos.x - 20, pos.y - 40);
+          addFloatingText(`+${companion.xp_gained ?? 5} XP`, '#ffd700', pos.x + 20, pos.y - 55);
+        } else {
+          addFloatingText('+2 Bond', '#ff66aa', pos.x - 20, pos.y - 40);
+          addFloatingText('+5 XP', '#ffd700', pos.x + 20, pos.y - 55);
+        }
+
+        EventBus.emit('companion-interacted', { action, companion: data.companion });
+        onInteracted?.();
+
+        if (data.companion?.mood) {
+          EventBus.emit('companion-mood', data.companion.mood);
+        }
+      }
+    } catch {
+      // Silently fail — in-world interaction shouldn't block gameplay
+    } finally {
+      setInteracting(null);
+      closeMenu();
+    }
+  }, [walletAddress, tokenId, interacting, menuPos, triggerReaction, addFloatingText, closeMenu, onInteracted]);
+
+  if (!menuPos) return null;
+
+  return (
+    <div ref={containerRef} className="absolute inset-0 z-30 pointer-events-none">
+      {/* Radial menu */}
+      <div
+        className={`absolute pointer-events-auto transition-all duration-200 ${
+          visible ? 'scale-100 opacity-100' : 'scale-50 opacity-0'
+        }`}
+        style={{ left: menuPos.x, top: menuPos.y, transform: 'translate(-50%, -50%)' }}
+      >
+        {/* Center indicator */}
+        <div className="absolute w-3 h-3 rounded-full bg-[#ffd700]/40 border border-[#ffd700]/60 -translate-x-1/2 -translate-y-1/2" />
+
+        {/* Action buttons */}
+        {ACTIONS.map(({ action, icon, label, angle }) => {
+          const rad = (angle * Math.PI) / 180;
+          const bx = Math.cos(rad) * RADIAL_DISTANCE;
+          const by = Math.sin(rad) * RADIAL_DISTANCE;
+          const isActive = interacting === action;
+
+          return (
+            <button
+              key={action}
+              onClick={() => handleAction(action)}
+              disabled={interacting !== null}
+              className={`
+                absolute w-12 h-12 -translate-x-1/2 -translate-y-1/2 rounded-full
+                flex flex-col items-center justify-center
+                bg-black/90 border-2 transition-all duration-150
+                ${isActive
+                  ? 'border-[#ffd700] shadow-[0_0_12px_rgba(255,215,0,0.5)] scale-110'
+                  : 'border-[#00f7ff]/50 hover:border-[#ffd700] hover:shadow-[0_0_8px_rgba(255,215,0,0.3)] hover:scale-110'
+                }
+                disabled:opacity-40 disabled:cursor-not-allowed
+              `}
+              style={{ left: bx, top: by }}
+            >
+              <span className="text-base leading-none">{isActive ? '⏳' : icon}</span>
+              <span className="text-[6px] text-gray-400 mt-0.5 font-['Press_Start_2P']">{label}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Reaction effects */}
+      {reaction && (
+        <div
+          className="absolute pointer-events-none -translate-x-1/2 -translate-y-1/2"
+          style={{ left: reaction.x, top: reaction.y }}
+        >
+          {reaction.type === 'pet' && (
+            <div className="companion-reaction-sparkle">
+              {['✨', '⭐', '💛', '✨'].map((s, i) => (
+                <span
+                  key={i}
+                  className="absolute text-sm animate-ping"
+                  style={{
+                    left: `${Math.cos((i * Math.PI) / 2) * 20}px`,
+                    top: `${Math.sin((i * Math.PI) / 2) * 20}px`,
+                    animationDelay: `${i * 100}ms`,
+                    animationDuration: '600ms',
+                  }}
+                >
+                  {s}
+                </span>
+              ))}
+            </div>
+          )}
+          {reaction.type === 'feed' && (
+            <div className="companion-reaction-bounce">
+              <span className="text-2xl inline-block animate-bounce">🍎</span>
+            </div>
+          )}
+          {reaction.type === 'talk' && (
+            <div className="companion-reaction-bubble">
+              <div className="bg-white/90 rounded-full px-2 py-1 text-sm border border-[#00f7ff]/40 shadow-[0_0_8px_rgba(0,247,255,0.3)] animate-pulse">
+                💬
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Floating text */}
+      {floatingTexts.map((ft) => (
+        <span
+          key={ft.id}
+          className="absolute text-xs font-['Press_Start_2P'] pointer-events-none companion-floating-text"
+          style={{
+            left: ft.x,
+            top: ft.y,
+            color: ft.color,
+            textShadow: `0 0 6px ${ft.color}`,
+          }}
+        >
+          {ft.text}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/game/scenes/WorldScene.ts
+++ b/game/scenes/WorldScene.ts
@@ -70,6 +70,7 @@ export class WorldScene extends Phaser.Scene {
 
     this.zoneSystem = new ZoneSystem(map.widthInPixels, map.heightInPixels);
     this.drawZoneOverlays();
+    this.setupCompanionClick();
 
     EventBus.emit('scene-ready', this);
   }
@@ -190,6 +191,18 @@ export class WorldScene extends Phaser.Scene {
     for (const zone of this.zoneSystem.getZones()) {
       gfx.strokeRect(zone.x, zone.y, zone.width, zone.height);
     }
+  }
+
+  private setupCompanionClick() {
+    this.companion.setInteractive({ useHandCursor: true });
+    this.companion.on('pointerdown', (pointer: Phaser.Input.Pointer) => {
+      const camera = this.cameras.main;
+      const canvas = this.game.canvas;
+      const screenX = (this.companion.x - camera.worldView.x) * camera.zoom + canvas.offsetLeft;
+      const screenY = (this.companion.y - camera.worldView.y) * camera.zoom + canvas.offsetTop;
+      EventBus.emit('companion-clicked', { screenX, screenY });
+      pointer.event.stopPropagation();
+    });
   }
 
   update() {


### PR DESCRIPTION
## Summary
- **New `CompanionMenu.tsx` overlay**: Radial menu appears on companion click/tap in V2 game world with Pet (🐾), Feed (🍎), Talk (💬) actions arranged in a circle
- **In-world reaction animations**: Sparkle particles on pet, bounce on feed, speech bubble on talk — plus floating "+2 Bond" / "+5 XP" reward text that fades upward
- **WorldScene companion click**: Companion sprite is now interactive; clicking it emits `companion-clicked` via EventBus with screen coordinates, preventing click-to-move interference
- **SanctuaryV2 wiring**: CompanionMenu integrated with active token ID fetching and HUD refresh on interaction

## Changes
| File | Change |
|------|--------|
| `components/sanctuary/overlays/CompanionMenu.tsx` | **New** — Radial menu with 3 actions, API calls, reaction effects, floating text |
| `game/scenes/WorldScene.ts` | Made companion sprite interactive, emits `companion-clicked` event |
| `app/sanctuary/SanctuaryV2.tsx` | Added CompanionMenu overlay, active token ID state, refresh on interact |
| `app/globals.css` | Added `companion-floating-text`, `companion-reaction-*` CSS animations |

## How it works
1. Player clicks companion sprite in V2 world → WorldScene emits `companion-clicked` with screen coords
2. CompanionMenu renders radial menu at click position with Pet/Feed/Talk buttons
3. On action: calls `/api/sanctuary/companion/interact` with wallet auth
4. Success triggers: reaction animation (sparkle/bounce/bubble) + floating reward text + mood update via EventBus
5. Menu dismisses on action completion or click-outside

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS (5 pre-existing errors excluded — missing PhaserGame/CompanionHUD/EventBus modules not deployed to PROD yet; all WorldScene errors from phaser not installed in PROD)
- **vitest run**: PASS (5 pre-existing failures, 208 passed — same as baseline)
- Overall: PASS

## Test plan
- [ ] Navigate to `/sanctuary?v=2` with connected wallet
- [ ] Click companion sprite in game world — radial menu should appear
- [ ] Click Pet → sparkle animation, floating "+2 Bond" / "+5 XP" text
- [ ] Click Feed → bounce animation with apple emoji
- [ ] Click Talk → bubble pop animation
- [ ] Click outside menu → menu dismisses
- [ ] Verify CompanionHUD updates after interaction
- [ ] Verify V1 sanctuary (`/sanctuary`) CompanionPanel still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)