### PR TITLE
feat: in-world chat bubbles for Sanctuary V2

### DIFF
--- a/app/sanctuary/SanctuaryV2.tsx
+++ b/app/sanctuary/SanctuaryV2.tsx
@@ -21,6 +21,21 @@ const CompanionMenu = dynamic(
   { ssr: false }
 );
 
+const MultiplayerBridge = dynamic(
+  () => import('@/components/sanctuary/overlays/MultiplayerBridge'),
+  { ssr: false }
+);
+
+const ChatInput = dynamic(
+  () => import('@/components/sanctuary/overlays/ChatInput'),
+  { ssr: false }
+);
+
+const ChatBubble = dynamic(
+  () => import('@/components/sanctuary/overlays/ChatBubble'),
+  { ssr: false }
+);
+
 const DevMapEditor = dynamic(
   () => import('@/components/sanctuary/DevMapEditor'),
   { ssr: false }
@@ -92,6 +107,15 @@ export default function SanctuaryV2() {
         <PhaserGame ref={gameRef} onSceneReady={handleSceneReady} />
         <CompanionHUD walletAddress={address} />
         <CompanionMenu walletAddress={address} tokenId={activeTokenId} onInteracted={handleInteracted} />
+        {address && (
+          <MultiplayerBridge
+            wallet={address}
+            displayName={address.slice(0, 6)}
+            companionTokenId={activeTokenId ?? -1}
+          />
+        )}
+        <ChatBubble />
+        <ChatInput />
         {editMode && <DevMapEditor />}
       </div>
     </div>

--- a/components/sanctuary/overlays/ChatBubble.tsx
+++ b/components/sanctuary/overlays/ChatBubble.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import { useEffect, useRef, useState, useCallback } from 'react';
+import EventBus from '@/components/sanctuary/EventBus';
+import { worldToScreen, cameraState } from '@/game/systems/CameraState';
+import type { RemotePlayer } from '@/lib/colyseus/types';
+
+const BUBBLE_LIFETIME = 8000;
+const FADE_DURATION = 1000;
+const BUBBLE_OFFSET_Y = -20;
+
+interface ActiveBubble {
+  id: number;
+  sessionId: string;
+  displayName: string;
+  text: string;
+  createdAt: number;
+}
+
+let bubbleIdCounter = 0;
+
+export default function ChatBubble() {
+  const [bubbles, setBubbles] = useState<ActiveBubble[]>([]);
+  const playerPositions = useRef(new Map<string, { x: number; y: number }>());
+  const localSessionId = useRef<string | null>(null);
+  const rafRef = useRef<number>(0);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const bubbleRefs = useRef(new Map<number, HTMLDivElement>());
+
+  const addBubble = useCallback(
+    (msg: { sessionId: string; displayName: string; text: string; isLocal: boolean }) => {
+      if (msg.isLocal) localSessionId.current = msg.sessionId;
+      const bubble: ActiveBubble = {
+        id: ++bubbleIdCounter,
+        sessionId: msg.sessionId,
+        displayName: msg.displayName,
+        text: msg.text,
+        createdAt: Date.now(),
+      };
+      setBubbles((prev) => {
+        const existing = prev.filter((b) => b.sessionId !== msg.sessionId);
+        return [...existing, bubble];
+      });
+    },
+    [],
+  );
+
+  useEffect(() => {
+    const handlePlayerAdd = (p: RemotePlayer) => {
+      playerPositions.current.set(p.sessionId, { x: p.x, y: p.y });
+    };
+    const handlePlayerUpdate = (p: RemotePlayer) => {
+      playerPositions.current.set(p.sessionId, { x: p.x, y: p.y });
+    };
+    const handlePlayerRemove = (sessionId: string) => {
+      playerPositions.current.delete(sessionId);
+      setBubbles((prev) => prev.filter((b) => b.sessionId !== sessionId));
+    };
+
+    EventBus.on('chat-message', addBubble);
+    EventBus.on('remote-player-add', handlePlayerAdd);
+    EventBus.on('remote-player-update', handlePlayerUpdate);
+    EventBus.on('remote-player-remove', handlePlayerRemove);
+
+    return () => {
+      EventBus.off('chat-message', addBubble);
+      EventBus.off('remote-player-add', handlePlayerAdd);
+      EventBus.off('remote-player-update', handlePlayerUpdate);
+      EventBus.off('remote-player-remove', handlePlayerRemove);
+    };
+  }, [addBubble]);
+
+  useEffect(() => {
+    const tick = () => {
+      const now = Date.now();
+
+      setBubbles((prev) => {
+        const alive = prev.filter((b) => now - b.createdAt < BUBBLE_LIFETIME);
+        if (alive.length !== prev.length) return alive;
+        return prev;
+      });
+
+      for (const [id, el] of bubbleRefs.current) {
+        const bubble = bubbles.find((b) => b.id === id);
+        if (!bubble || !el) continue;
+
+        let worldX: number;
+        let worldY: number;
+
+        if (bubble.sessionId === localSessionId.current) {
+          worldX = cameraState.localPlayerX;
+          worldY = cameraState.localPlayerY;
+        } else {
+          const pos = playerPositions.current.get(bubble.sessionId);
+          if (!pos) continue;
+          worldX = pos.x;
+          worldY = pos.y;
+        }
+
+        const screen = worldToScreen(worldX, worldY + BUBBLE_OFFSET_Y);
+        el.style.left = `${screen.x}px`;
+        el.style.top = `${screen.y}px`;
+
+        const age = now - bubble.createdAt;
+        const fadeStart = BUBBLE_LIFETIME - FADE_DURATION;
+        if (age > fadeStart) {
+          el.style.opacity = String(1 - (age - fadeStart) / FADE_DURATION);
+        } else {
+          el.style.opacity = '1';
+        }
+      }
+
+      rafRef.current = requestAnimationFrame(tick);
+    };
+
+    rafRef.current = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(rafRef.current);
+  }, [bubbles]);
+
+  const setBubbleRef = useCallback((id: number, el: HTMLDivElement | null) => {
+    if (el) {
+      bubbleRefs.current.set(id, el);
+    } else {
+      bubbleRefs.current.delete(id);
+    }
+  }, []);
+
+  if (bubbles.length === 0) return null;
+
+  return (
+    <div ref={containerRef} className="absolute inset-0 z-25 pointer-events-none overflow-hidden">
+      {bubbles.map((bubble) => (
+        <div
+          key={bubble.id}
+          ref={(el) => setBubbleRef(bubble.id, el)}
+          className="absolute -translate-x-1/2 -translate-y-full"
+          style={{ willChange: 'left, top, opacity' }}
+        >
+          <div className="relative max-w-[200px]">
+            <div
+              className="px-2 py-1.5 rounded-lg bg-[#0a0a1a]/95 border border-[#00f7ff]/20
+                          shadow-[0_0_6px_rgba(0,247,255,0.1)]"
+            >
+              <div className="text-[5px] text-[#00f7ff]/70 font-['Press_Start_2P'] mb-0.5 truncate">
+                {bubble.displayName}
+              </div>
+              <div className="text-[6px] text-white font-['Press_Start_2P'] break-words leading-relaxed">
+                {bubble.text}
+              </div>
+            </div>
+            <div
+              className="absolute left-1/2 -translate-x-1/2 -bottom-1 w-0 h-0
+                          border-l-[4px] border-l-transparent
+                          border-r-[4px] border-r-transparent
+                          border-t-[4px] border-t-[#0a0a1a]/95"
+            />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/components/sanctuary/overlays/ChatInput.tsx
+++ b/components/sanctuary/overlays/ChatInput.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useState, useCallback, useRef, useEffect } from 'react';
+import EventBus from '@/components/sanctuary/EventBus';
+
+const MAX_LENGTH = 100;
+
+export default function ChatInput() {
+  const [text, setText] = useState('');
+  const [focused, setFocused] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Enter' && !focused && inputRef.current) {
+        e.preventDefault();
+        inputRef.current.focus();
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [focused]);
+
+  const send = useCallback(() => {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    EventBus.emit('send-chat', trimmed);
+    setText('');
+  }, [text]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      e.stopPropagation();
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        send();
+      }
+      if (e.key === 'Escape') {
+        inputRef.current?.blur();
+      }
+    },
+    [send],
+  );
+
+  return (
+    <div className="absolute bottom-2 left-2 right-2 z-20 flex gap-2">
+      <input
+        ref={inputRef}
+        value={text}
+        onChange={(e) => setText(e.target.value.slice(0, MAX_LENGTH))}
+        onKeyDown={handleKeyDown}
+        onFocus={() => setFocused(true)}
+        onBlur={() => setFocused(false)}
+        placeholder={focused ? 'Type a message...' : 'Press Enter to chat'}
+        maxLength={MAX_LENGTH}
+        className={`
+          flex-1 px-3 py-1.5 rounded
+          bg-[#0a0a1a]/90 border text-xs text-white
+          font-['Press_Start_2P'] placeholder:text-gray-500
+          outline-none transition-all
+          ${focused
+            ? 'border-[#00f7ff]/60 shadow-[0_0_8px_rgba(0,247,255,0.2)]'
+            : 'border-[#00f7ff]/20 opacity-60 hover:opacity-80'
+          }
+        `}
+      />
+      {focused && text.trim() && (
+        <button
+          onClick={send}
+          className="px-3 py-1.5 rounded bg-[#00f7ff]/20 border border-[#00f7ff]/40
+                     text-[#00f7ff] text-xs font-['Press_Start_2P']
+                     hover:bg-[#00f7ff]/30 transition-all"
+        >
+          Send
+        </button>
+      )}
+    </div>
+  );
+}

--- a/components/sanctuary/overlays/MultiplayerBridge.tsx
+++ b/components/sanctuary/overlays/MultiplayerBridge.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { useMultiplayer } from '@/lib/colyseus/useMultiplayer';
+
+export default function MultiplayerBridge({
+  wallet,
+  displayName,
+  companionTokenId,
+}: {
+  wallet: string;
+  displayName: string;
+  companionTokenId: number;
+}) {
+  useMultiplayer({
+    wallet,
+    displayName,
+    companionTokenId,
+    constellation: '',
+    mood: 'idle',
+  });
+  return null;
+}

--- a/game/scenes/WorldScene.ts
+++ b/game/scenes/WorldScene.ts
@@ -16,6 +16,7 @@ import {
   type Door,
   type RoomKey,
 } from '../config/worldLayout';
+import { cameraState } from '../systems/CameraState';
 
 const CAMERA_ZOOM = 2;
 
@@ -303,6 +304,13 @@ export class WorldScene extends Phaser.Scene {
     this.companion.followPlayer(this.player.x, this.player.y, this.player.getDirection());
     this.otherPlayers.update(this.cameras.main);
     this.updateDoorDetection();
+
+    const cam = this.cameras.main;
+    cameraState.viewX = cam.worldView.x;
+    cameraState.viewY = cam.worldView.y;
+    cameraState.zoom = cam.zoom;
+    cameraState.localPlayerX = this.player.x;
+    cameraState.localPlayerY = this.player.y;
     if (this.currentDoor && Phaser.Input.Keyboard.JustDown(this.interactKey)) {
       this.enterDoor(this.currentDoor);
     }
@@ -312,6 +320,10 @@ export class WorldScene extends Phaser.Scene {
         y: Math.round(this.input.activePointer.worldY),
       });
     }
+  }
+
+  getLocalPlayerPosition(): { x: number; y: number } {
+    return { x: this.player.x, y: this.player.y };
   }
 
   shutdown() {

--- a/game/systems/CameraState.ts
+++ b/game/systems/CameraState.ts
@@ -1,0 +1,14 @@
+export const cameraState = {
+  viewX: 0,
+  viewY: 0,
+  zoom: 2,
+  localPlayerX: 0,
+  localPlayerY: 0,
+};
+
+export function worldToScreen(worldX: number, worldY: number): { x: number; y: number } {
+  return {
+    x: (worldX - cameraState.viewX) * cameraState.zoom,
+    y: (worldY - cameraState.viewY) * cameraState.zoom,
+  };
+}

--- a/lib/colyseus/types.ts
+++ b/lib/colyseus/types.ts
@@ -13,6 +13,12 @@ export interface RemotePlayer {
   currentLocation: string;
 }
 
+export interface ChatMessage {
+  sessionId: string;
+  displayName: string;
+  text: string;
+}
+
 export interface JoinRoomOptions {
   locationName: string;
   wallet: string;

--- a/lib/colyseus/useMultiplayer.ts
+++ b/lib/colyseus/useMultiplayer.ts
@@ -5,7 +5,7 @@ import type { Room } from 'colyseus.js';
 import { getStateCallbacks } from 'colyseus.js';
 import EventBus from '@/components/sanctuary/EventBus';
 import { joinLocationRoom, parsePlayer } from './client';
-import type { RemotePlayer, JoinRoomOptions } from './types';
+import type { RemotePlayer, JoinRoomOptions, ChatMessage } from './types';
 
 interface UseMultiplayerOptions {
   wallet: string;
@@ -22,6 +22,7 @@ interface MultiplayerState {
   currentLocation: string | null;
   sendPosition: (x: number, y: number, facing: string, isMoving: boolean) => void;
   sendMood: (mood: string) => void;
+  sendChat: (text: string) => void;
 }
 
 export function useMultiplayer(options: UseMultiplayerOptions): MultiplayerState {
@@ -45,6 +46,13 @@ export function useMultiplayer(options: UseMultiplayerOptions): MultiplayerState
 
   const sendMood = useCallback((mood: string) => {
     roomRef.current?.send('updateMood', { mood });
+  }, []);
+
+  const sendChat = useCallback((text: string) => {
+    const trimmed = text.slice(0, 100).trim();
+    if (trimmed && roomRef.current) {
+      roomRef.current.send('chat', { text: trimmed });
+    }
   }, []);
 
   useEffect(() => {
@@ -136,6 +144,15 @@ export function useMultiplayer(options: UseMultiplayerOptions): MultiplayerState
         );
         detachersRef.current.push(detachRemove);
 
+        room.onMessage('chat', (msg: ChatMessage) => {
+          EventBus.emit('chat-message', {
+            sessionId: msg.sessionId,
+            displayName: msg.displayName,
+            text: msg.text,
+            isLocal: msg.sessionId === room.sessionId,
+          });
+        });
+
         room.onLeave(() => {
           cleanupListeners();
           roomRef.current = null;
@@ -152,15 +169,24 @@ export function useMultiplayer(options: UseMultiplayerOptions): MultiplayerState
       leaveRoom();
     };
 
+    const handleSendChat = (text: string) => {
+      const trimmed = String(text || '').slice(0, 100).trim();
+      if (trimmed && roomRef.current) {
+        roomRef.current.send('chat', { text: trimmed });
+      }
+    };
+
     EventBus.on('location-entered', handleLocationEntered);
     EventBus.on('location-exited', handleLocationExited);
+    EventBus.on('send-chat', handleSendChat);
 
     return () => {
       EventBus.off('location-entered', handleLocationEntered);
       EventBus.off('location-exited', handleLocationExited);
+      EventBus.off('send-chat', handleSendChat);
       leaveRoom();
     };
   }, []);
 
-  return { players, isConnected, currentLocation, sendPosition, sendMood };
+  return { players, isConnected, currentLocation, sendPosition, sendMood, sendChat };
 }

--- a/server/colyseus/LocationRoom.ts
+++ b/server/colyseus/LocationRoom.ts
@@ -46,6 +46,18 @@ export class LocationRoom extends Room<{ state: LocationState }> {
       if (!player) return;
       player.equippedCosmetics = data.equippedCosmetics;
     });
+
+    this.onMessage('chat', (client: Client, data: { text: string }) => {
+      const player = this.state.players.get(client.sessionId);
+      if (!player) return;
+      const text = String(data.text || '').slice(0, 100).trim();
+      if (!text) return;
+      this.broadcast('chat', {
+        sessionId: client.sessionId,
+        displayName: player.displayName || player.wallet.slice(0, 6),
+        text,
+      });
+    });
   }
 
   onJoin(client: Client, options: JoinOptions) {


### PR DESCRIPTION
## Summary
- **ChatInput** overlay at bottom of game canvas — press Enter to focus, type up to 100 chars, Enter to send, Escape to blur
- **ChatBubble** overlay with world-to-screen positioned speech bubbles above players — doctrine-styled (#0a0a1a bg, rounded, Press Start 2P font), fades after 8 seconds
- **Colyseus chat broadcast** — server-side `chat` message handler in LocationRoom validates, trims to 100 chars, and broadcasts `{sessionId, displayName, text}` to all room clients
- **CameraState** shared module — WorldScene writes camera view + local player position each frame, ChatBubble reads via RAF for smooth bubble positioning
- **MultiplayerBridge** component — dynamically imported wrapper that calls `useMultiplayer` hook with SSR safety, wiring up Colyseus connection in SanctuaryV2

### Architecture
```
ChatInput → EventBus('send-chat') → useMultiplayer → Colyseus room.send('chat')
    ↓
LocationRoom.broadcast('chat') → room.onMessage('chat') → EventBus('chat-message')
    ↓
ChatBubble ← reads player positions from EventBus + CameraState for world→screen conversion
```

## Files Changed
| File | Change |
|------|--------|
| `server/colyseus/LocationRoom.ts` | Added `chat` message handler with validation and broadcast |
| `lib/colyseus/types.ts` | Added `ChatMessage` interface |
| `lib/colyseus/useMultiplayer.ts` | Added `sendChat`, `send-chat` EventBus listener, chat broadcast receiver |
| `game/systems/CameraState.ts` | **New** — shared camera/player state for world-to-screen conversion |
| `game/scenes/WorldScene.ts` | Write camera state each frame, added `getLocalPlayerPosition()` |
| `components/sanctuary/overlays/ChatInput.tsx` | **New** — bottom input bar |
| `components/sanctuary/overlays/ChatBubble.tsx` | **New** — positioned speech bubbles with RAF animation |
| `components/sanctuary/overlays/MultiplayerBridge.tsx` | **New** — SSR-safe hook wrapper |
| `app/sanctuary/SanctuaryV2.tsx` | Integrated all chat overlay components |

## Validation
- **tsc --noEmit**: PASS (0 errors)
- **eslint**: PASS (0 new errors, all warnings/errors are pre-existing)
- **vitest run**: 244 passed, 4 failed (all 4 pre-existing in api-e2e.test.ts)
- **npm run build**: PASS

## Mirror Validation (PROD)
- **tsc --noEmit**: SKIPPED — prerequisite directories (server/colyseus, game/scenes, lib/colyseus, components/sanctuary/overlays) from PRs #216–#217 not yet deployed to PROD mirror
- **vitest run**: SKIPPED — same reason
- Overall: N/A (dependent on prior PR deployments)

## Test plan
- [ ] Verify ChatInput renders at bottom of Sanctuary V2 game canvas
- [ ] Press Enter to focus input, type message, Enter to send
- [ ] Chat bubble appears above local player with correct styling
- [ ] Other players in same Colyseus room see the chat bubble
- [ ] Bubbles fade out after 8 seconds
- [ ] Bubbles follow player movement (world-to-screen tracking)
- [ ] Max 100 characters enforced (client and server)
- [ ] Only one bubble per player at a time (newest replaces oldest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)