### PR TITLE
fix: add missing Star Garden door to DOORS array

### DIFF
--- a/game/config/worldLayout.ts
+++ b/game/config/worldLayout.ts
@@ -32,6 +32,7 @@ export const DOORS: Door[] = [
   { room: 'Observatory', x: 699, y: 159, w: 60, h: 73 },
   { room: 'Training Grounds', x: 1006, y: 220, w: 57, h: 69 },
   { room: 'Hot Springs', x: 295, y: 317, w: 86, h: 60 },
+  { room: 'Star Garden', x: 694, y: 480, w: 56, h: 68 },
   { room: 'Nebula Kitchen', x: 206, y: 564, w: 47, h: 71 },
   { room: 'Cosmic Library', x: 1047, y: 617, w: 54, h: 71 },
   { room: 'Aura Forge', x: 1270, y: 638, w: 65, h: 81 },


### PR DESCRIPTION
## Summary
- Adds the 8th door entry (`Star Garden`) to `DOORS` in `game/config/worldLayout.ts` — previously 7 entries for 8 rooms
- Door rect `(694, 480, 56, 68)` measured manually from `Sanctuary_map_marked.png`, positioned at the south entrance of the central gazebo building
- Root cause: `extract_sanctuary_layout.mjs` had no `Star Garden` in its `ROOM_CENTERS` map and no green blob was painted for it on the marked map

## Test plan
- [x] `npm run type-check` — PASS
- [x] `npm run lint` (changed file) — PASS
- [x] `npm run test` — 244 passed, 4 pre-existing failures
- [x] `npm run build` — PASS
- [ ] Visual: walk to the center gazebo in Sanctuary and verify the Star Garden door triggers room entry

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS (0 errors; file is new to PROD — `game/config/` dir doesn't exist in PROD yet)
- **vitest run**: PASS (208 passed, 5 pre-existing failures)
Overall: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)