### PR TITLE
feat(sanctuary): render NPCs using real sprite PNGs instead of placeholders

### DIFF
--- a/game/config/npcDefinitions.ts
+++ b/game/config/npcDefinitions.ts
@@ -8,17 +8,19 @@ export interface NPCDefinition {
   zone: string;
   dialogue: string;
   spriteColor: number;
+  spriteFile?: string;
 }
 
 export const NPC_DEFINITIONS: NPCDefinition[] = [
   {
     id: 'quest-board',
-    name: 'Quest Board',
+    name: 'Spawn Fox',
     x: Math.round(0.5 * WORLD_WIDTH),
     y: Math.round(0.48 * WORLD_HEIGHT) + 80,
     zone: 'Town Square',
     dialogue: 'View all available quests.',
     spriteColor: 0xffd700,
+    spriteFile: 'Spawn_Fox_Sprite.png',
   },
   {
     id: 'npc-hot-springs',
@@ -28,6 +30,7 @@ export const NPC_DEFINITIONS: NPCDefinition[] = [
     zone: 'Hot Springs',
     dialogue: 'The warm waters reveal hidden truths...',
     spriteColor: 0xff6644,
+    spriteFile: 'Springs_Duck_Sprite.png',
   },
   {
     id: 'npc-training-grounds',
@@ -37,6 +40,7 @@ export const NPC_DEFINITIONS: NPCDefinition[] = [
     zone: 'Training Grounds',
     dialogue: 'Strength is forged through perseverance.',
     spriteColor: 0x44aaff,
+    spriteFile: 'Training_Wolf_Sprite.png',
   },
   {
     id: 'npc-dream-hollow',
@@ -46,6 +50,7 @@ export const NPC_DEFINITIONS: NPCDefinition[] = [
     zone: 'Dream Hollow',
     dialogue: 'Dreams shape reality, if you let them...',
     spriteColor: 0xcc66ff,
+    spriteFile: 'Dream_Sheep_Sprite.png',
   },
   {
     id: 'npc-star-garden',
@@ -55,6 +60,7 @@ export const NPC_DEFINITIONS: NPCDefinition[] = [
     zone: 'Star Garden',
     dialogue: 'Every star seed needs patience to bloom.',
     spriteColor: 0x66ff88,
+    spriteFile: 'Garden_Ent_Sprite.png',
   },
   {
     id: 'npc-nebula-kitchen',
@@ -64,6 +70,7 @@ export const NPC_DEFINITIONS: NPCDefinition[] = [
     zone: 'Nebula Kitchen',
     dialogue: 'Cosmic cuisine fuels the soul!',
     spriteColor: 0xffaa44,
+    spriteFile: 'Kitchen_Bunny_Sprite.png',
   },
   {
     id: 'npc-cosmic-library',
@@ -73,6 +80,7 @@ export const NPC_DEFINITIONS: NPCDefinition[] = [
     zone: 'Cosmic Library',
     dialogue: 'Knowledge is the oldest form of power.',
     spriteColor: 0x8866ff,
+    spriteFile: 'Hollow_moth_Sprite.png',
   },
   {
     id: 'npc-observatory',
@@ -82,6 +90,7 @@ export const NPC_DEFINITIONS: NPCDefinition[] = [
     zone: 'Observatory',
     dialogue: 'The stars whisper secrets to those who listen.',
     spriteColor: 0xffffaa,
+    spriteFile: 'Observatory_Owl_Sprite.png',
   },
   {
     id: 'npc-aura-forge',
@@ -91,5 +100,10 @@ export const NPC_DEFINITIONS: NPCDefinition[] = [
     zone: 'Aura Forge',
     dialogue: 'Auras are shaped in fire and will.',
     spriteColor: 0xff4466,
+    spriteFile: 'Aura_Golem_Sprite.png',
   },
 ];
+
+export function npcSpriteTextureKey(id: string): string {
+  return `npc-sprite-${id}`;
+}

--- a/game/scenes/BootScene.ts
+++ b/game/scenes/BootScene.ts
@@ -4,7 +4,7 @@ import { PlayerSprite } from '../sprites/PlayerSprite';
 import { CompanionSprite } from '../sprites/CompanionSprite';
 import { NPCSprite } from '../sprites/NPCSprite';
 import { AnimationSystem } from '../systems/AnimationSystem';
-import { NPC_DEFINITIONS } from '../config/npcDefinitions';
+import { NPC_DEFINITIONS, npcSpriteTextureKey } from '../config/npcDefinitions';
 import { ROOMS } from '../config/worldLayout';
 
 export class BootScene extends Phaser.Scene {
@@ -20,6 +20,12 @@ export class BootScene extends Phaser.Scene {
 
     for (const room of ROOMS) {
       this.load.image(`room-bg-${room}`, `/sanctuary/${encodeURI(room)}.png`);
+    }
+
+    for (const def of NPC_DEFINITIONS) {
+      if (def.spriteFile) {
+        this.load.image(npcSpriteTextureKey(def.id), `/sanctuary/${encodeURI(def.spriteFile)}`);
+      }
     }
 
     AnimationSystem.preloadConstellations(this, ['aether', 'spectra']);

--- a/game/sprites/NPCSprite.ts
+++ b/game/sprites/NPCSprite.ts
@@ -1,11 +1,14 @@
 import Phaser from 'phaser';
 import EventBus from '@/components/sanctuary/EventBus';
-import type { NPCDefinition } from '../config/npcDefinitions';
+import { npcSpriteTextureKey, type NPCDefinition } from '../config/npcDefinitions';
 
 const IDLE_BOB_SPEED = 0.002;
 const IDLE_BOB_AMPLITUDE = 1.5;
 const INDICATOR_BOB_SPEED = 0.004;
 const INDICATOR_BOB_AMPLITUDE = 3;
+
+const NPC_DISPLAY_HEIGHT = 32;
+const PLACEHOLDER_SCALE = 1.5;
 
 export class NPCSprite extends Phaser.GameObjects.Container {
   readonly npcId: string;
@@ -20,6 +23,7 @@ export class NPCSprite extends Phaser.GameObjects.Container {
   private hasQuest = false;
   private idleFrame = 0;
   private idleTimer = 0;
+  private indicatorBaseY: number;
 
   constructor(scene: Phaser.Scene, def: NPCDefinition) {
     super(scene, def.x, def.y);
@@ -30,12 +34,25 @@ export class NPCSprite extends Phaser.GameObjects.Container {
     this.dialogue = def.dialogue;
     this.baseY = def.y;
 
-    const textureKey = `npc-${def.id}`;
+    const realKey = npcSpriteTextureKey(def.id);
+    const realTex = scene.textures.get(realKey);
+    const hasReal = realTex && realTex.key !== '__MISSING';
+    const textureKey = hasReal ? realKey : `npc-${def.id}`;
     this.sprite = scene.add.sprite(0, 0, textureKey);
-    this.sprite.setScale(1.5);
+    if (hasReal) {
+      const src = realTex.getSourceImage() as { height?: number };
+      const h = src && typeof src.height === 'number' && src.height > 0 ? src.height : NPC_DISPLAY_HEIGHT;
+      this.sprite.setScale(NPC_DISPLAY_HEIGHT / h);
+    } else {
+      this.sprite.setScale(PLACEHOLDER_SCALE);
+    }
     this.add(this.sprite);
 
-    this.nameTag = scene.add.text(0, -14, def.name, {
+    const halfH = this.sprite.displayHeight / 2;
+    const nameTagY = -halfH - 2;
+    this.indicatorBaseY = nameTagY - 10;
+
+    this.nameTag = scene.add.text(0, nameTagY, def.name, {
       fontFamily: '"Press Start 2P", monospace',
       fontSize: '5px',
       color: '#ffffff',
@@ -46,7 +63,7 @@ export class NPCSprite extends Phaser.GameObjects.Container {
     this.nameTag.setOrigin(0.5, 1);
     this.add(this.nameTag);
 
-    this.indicator = scene.add.text(0, -22, '!', {
+    this.indicator = scene.add.text(0, this.indicatorBaseY, '!', {
       fontFamily: '"Press Start 2P", monospace',
       fontSize: '8px',
       color: '#ffd700',
@@ -58,7 +75,9 @@ export class NPCSprite extends Phaser.GameObjects.Container {
     this.indicator.setVisible(false);
     this.add(this.indicator);
 
-    this.setSize(24, 24);
+    const hitW = Math.max(24, this.sprite.displayWidth);
+    const hitH = Math.max(24, this.sprite.displayHeight);
+    this.setSize(hitW, hitH);
     this.setInteractive({ useHandCursor: true });
 
     this.on('pointerdown', (pointer: Phaser.Input.Pointer) => {
@@ -101,7 +120,7 @@ export class NPCSprite extends Phaser.GameObjects.Container {
 
     if (this.hasQuest) {
       const indicatorBob = Math.sin(time * INDICATOR_BOB_SPEED) * INDICATOR_BOB_AMPLITUDE;
-      this.indicator.setY(-22 + indicatorBob);
+      this.indicator.setY(this.indicatorBaseY + indicatorBob);
 
       const glow = 0.7 + 0.3 * Math.sin(time * 0.005);
       this.indicator.setAlpha(glow);


### PR DESCRIPTION
## Summary

NPC sprites (Spawn Fox, 8 room NPCs) now render as their hand-drawn PNGs instead of procedurally-generated colored-blob placeholders.

- Map each `NPCDefinition` to its sprite file via a new optional `spriteFile` field (`Spawn_Fox_Sprite.png`, `Springs_Duck_Sprite.png`, `Training_Wolf_Sprite.png`, `Dream_Sheep_Sprite.png`, `Garden_Ent_Sprite.png`, `Kitchen_Bunny_Sprite.png`, `Hollow_moth_Sprite.png`, `Observatory_Owl_Sprite.png`, `Aura_Golem_Sprite.png`).
- Preload the PNGs in `BootScene.preload()` under the key `npc-sprite-<id>` via a new `npcSpriteTextureKey` helper shared with `NPCSprite`.
- `NPCSprite` now prefers the real texture when loaded and falls back to the existing procedural placeholder texture when the PNG is missing, preserving the existing placeholder code path as a safety net.
- Real sprites are scaled to a uniform 32px display height (aspect-ratio preserving) so all NPCs have a consistent footprint despite the source PNGs being large character portraits. Hitbox size and name-tag/quest-indicator Y-offsets are derived from the resolved display dimensions so they sit just above taller characters instead of overlapping them.
- `quest-board` NPC name updated to `Spawn Fox` to match the sprite; id left unchanged so existing quest wiring still resolves.

## Files
- `game/config/npcDefinitions.ts` — added optional `spriteFile`, filenames for all 9 NPCs, exported `npcSpriteTextureKey`.
- `game/scenes/BootScene.ts` — preload each `spriteFile` under `npc-sprite-<id>`.
- `game/sprites/NPCSprite.ts` — prefer real texture, scale to 32px height, derive UI offsets + hitbox from sprite display size.

## Validation
- `npm run type-check` — PASS (0 errors)
- `npm run lint` — PASS for changed files (67 pre-existing errors in unrelated files untouched)
- `npm run test` — 252 passed / 4 pre-existing failures (unchanged baseline for this repo)
- `npm run build` — PASS

## Mirror Validation (PROD)
- **tsc --noEmit baseline (empty PROD `game/`)**: PASS (0 errors)
- **tsc --noEmit with full `game/` overlay**: 144 errors — all cascade from `Cannot find module 'phaser'` and `Cannot find module '@/components/sanctuary/EventBus'`. These are pre-existing PROD infrastructure gaps: PROD `package.json` does not yet list `phaser`, and PROD lacks `components/sanctuary/EventBus.ts`. None of the errors are specific to my diff — any game/* file in PROD would fail identically. Confirmed by overlaying unchanged baseline files: same error set.
- **vitest run game/__tests__/collision.test.ts on PROD overlay**: PASS (8/8)
- **Post-validation restore**: PROD restored byte-identically (tsc clean, 0 errors).

Overall: PASS (no NEW errors attributable to this diff).

## Test plan
- [ ] `/sanctuary` loads; each NPC renders as their hand-drawn sprite (not a colored blob).
- [ ] Name tag sits just above each NPC's head (not overlapping on tall sprites).
- [ ] Quest `!` indicator sits above the name tag when a quest is available.
- [ ] Clicking an NPC still fires `npc-clicked` with the correct dialogue.
- [ ] If a sprite PNG is missing, the NPC falls back to the placeholder blob instead of crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)