### PR TITLE
fix: local chat echo + dedup server roundtrip in useMultiplayer

### DIFF
--- a/lib/colyseus/__tests__/chatDedup.test.ts
+++ b/lib/colyseus/__tests__/chatDedup.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ECHO_DEDUP_WINDOW_MS,
+  findEchoIndex,
+  LOCAL_ONLY_SESSION_ID,
+  pruneExpiredEchoes,
+  type PendingEcho,
+} from '../chatDedup';
+
+describe('chatDedup', () => {
+  describe('pruneExpiredEchoes', () => {
+    it('keeps entries within the dedup window', () => {
+      const now = 10_000;
+      const pending: PendingEcho[] = [
+        { text: 'a', sessionId: 's1', timestamp: now - 500 },
+        { text: 'b', sessionId: 's1', timestamp: now - 1999 },
+      ];
+      expect(pruneExpiredEchoes(pending, now)).toHaveLength(2);
+    });
+
+    it('drops entries older than the dedup window', () => {
+      const now = 10_000;
+      const pending: PendingEcho[] = [
+        { text: 'old', sessionId: 's1', timestamp: now - 3000 },
+        { text: 'fresh', sessionId: 's1', timestamp: now - 100 },
+      ];
+      const result = pruneExpiredEchoes(pending, now);
+      expect(result).toHaveLength(1);
+      expect(result[0].text).toBe('fresh');
+    });
+
+    it('treats exactly-window-old entries as expired', () => {
+      const now = 10_000;
+      const pending: PendingEcho[] = [
+        { text: 'edge', sessionId: 's1', timestamp: now - ECHO_DEDUP_WINDOW_MS },
+      ];
+      expect(pruneExpiredEchoes(pending, now)).toHaveLength(0);
+    });
+  });
+
+  describe('findEchoIndex', () => {
+    const now = 10_000;
+    const pending: PendingEcho[] = [
+      { text: 'hello', sessionId: 'sessA', timestamp: now - 100 },
+      { text: 'world', sessionId: 'sessA', timestamp: now - 200 },
+    ];
+
+    it('finds matching text + sessionId within window', () => {
+      const idx = findEchoIndex(
+        pending,
+        { text: 'hello', sessionId: 'sessA' },
+        now,
+      );
+      expect(idx).toBe(0);
+    });
+
+    it('returns -1 when text differs', () => {
+      const idx = findEchoIndex(
+        pending,
+        { text: 'unsent', sessionId: 'sessA' },
+        now,
+      );
+      expect(idx).toBe(-1);
+    });
+
+    it('returns -1 when sessionId differs', () => {
+      const idx = findEchoIndex(
+        pending,
+        { text: 'hello', sessionId: 'sessB' },
+        now,
+      );
+      expect(idx).toBe(-1);
+    });
+
+    it('returns -1 when match is outside the window', () => {
+      const stale: PendingEcho[] = [
+        { text: 'hello', sessionId: 'sessA', timestamp: now - 5000 },
+      ];
+      const idx = findEchoIndex(stale, { text: 'hello', sessionId: 'sessA' }, now);
+      expect(idx).toBe(-1);
+    });
+  });
+
+  describe('local echo simulation', () => {
+    // Simulates the useMultiplayer flow: local echo recorded on send,
+    // then the server roundtrips its own copy back; the second emission
+    // must be deduplicated within the dedup window.
+    it('deduplicates server echo that matches recent local send', () => {
+      const sendTime = 10_000;
+      const pending: PendingEcho[] = [];
+
+      pending.push({ text: 'gm', sessionId: 'sessA', timestamp: sendTime });
+
+      const arriveTime = sendTime + 250;
+      const idx = findEchoIndex(
+        pending,
+        { text: 'gm', sessionId: 'sessA' },
+        arriveTime,
+      );
+      expect(idx).toBe(0);
+
+      pending.splice(idx, 1);
+      expect(pending).toHaveLength(0);
+    });
+
+    it('does not deduplicate server echo arriving after the window', () => {
+      const sendTime = 10_000;
+      const pending: PendingEcho[] = [
+        { text: 'gm', sessionId: 'sessA', timestamp: sendTime },
+      ];
+
+      const arriveTime = sendTime + ECHO_DEDUP_WINDOW_MS + 1;
+      const idx = findEchoIndex(
+        pending,
+        { text: 'gm', sessionId: 'sessA' },
+        arriveTime,
+      );
+      expect(idx).toBe(-1);
+    });
+
+    it('still allows local echo when no room is connected (uses local sessionId)', () => {
+      // When disconnected, the hook tags echoes with LOCAL_ONLY_SESSION_ID.
+      // No server echo will ever arrive with that sessionId, so dedup never
+      // matches and the local bubble persists for its full lifetime.
+      const now = 10_000;
+      const pending: PendingEcho[] = [
+        { text: 'hi', sessionId: LOCAL_ONLY_SESSION_ID, timestamp: now },
+      ];
+
+      const idx = findEchoIndex(
+        pending,
+        { text: 'hi', sessionId: 'realServerSessionId' },
+        now + 100,
+      );
+      expect(idx).toBe(-1);
+    });
+  });
+});

--- a/lib/colyseus/chatDedup.ts
+++ b/lib/colyseus/chatDedup.ts
@@ -1,0 +1,30 @@
+export interface PendingEcho {
+  text: string;
+  sessionId: string;
+  timestamp: number;
+}
+
+export const ECHO_DEDUP_WINDOW_MS = 2000;
+export const LOCAL_ONLY_SESSION_ID = 'local';
+
+export function pruneExpiredEchoes(
+  pending: PendingEcho[],
+  now: number,
+  windowMs: number = ECHO_DEDUP_WINDOW_MS,
+): PendingEcho[] {
+  return pending.filter((e) => now - e.timestamp < windowMs);
+}
+
+export function findEchoIndex(
+  pending: PendingEcho[],
+  msg: { text: string; sessionId: string },
+  now: number,
+  windowMs: number = ECHO_DEDUP_WINDOW_MS,
+): number {
+  return pending.findIndex(
+    (e) =>
+      e.text === msg.text &&
+      e.sessionId === msg.sessionId &&
+      now - e.timestamp < windowMs,
+  );
+}

--- a/lib/colyseus/useMultiplayer.ts
+++ b/lib/colyseus/useMultiplayer.ts
@@ -5,6 +5,12 @@ import type { Room } from 'colyseus.js';
 import { getStateCallbacks } from 'colyseus.js';
 import EventBus from '@/components/sanctuary/EventBus';
 import { joinLocationRoom, parsePlayer } from './client';
+import {
+  findEchoIndex,
+  LOCAL_ONLY_SESSION_ID,
+  pruneExpiredEchoes,
+  type PendingEcho,
+} from './chatDedup';
 import type { RemotePlayer, JoinRoomOptions, ChatMessage } from './types';
 
 interface UseMultiplayerOptions {
@@ -32,6 +38,7 @@ export function useMultiplayer(options: UseMultiplayerOptions): MultiplayerState
   const roomRef = useRef<Room | null>(null);
   const detachersRef = useRef<Array<() => void>>([]);
   const optionsRef = useRef(options);
+  const pendingLocalEchoesRef = useRef<PendingEcho[]>([]);
 
   useEffect(() => {
     optionsRef.current = options;
@@ -50,8 +57,28 @@ export function useMultiplayer(options: UseMultiplayerOptions): MultiplayerState
 
   const sendChat = useCallback((text: string) => {
     const trimmed = text.slice(0, 100).trim();
-    if (trimmed && roomRef.current) {
-      roomRef.current.send('chat', { text: trimmed });
+    if (!trimmed) return;
+
+    const opts = optionsRef.current;
+    const room = roomRef.current;
+    const sessionId = room?.sessionId ?? LOCAL_ONLY_SESSION_ID;
+    const now = Date.now();
+
+    pendingLocalEchoesRef.current = pruneExpiredEchoes(
+      pendingLocalEchoesRef.current,
+      now,
+    );
+    pendingLocalEchoesRef.current.push({ text: trimmed, sessionId, timestamp: now });
+
+    EventBus.emit('chat-message', {
+      sessionId,
+      displayName: opts.displayName,
+      text: trimmed,
+      isLocal: true,
+    });
+
+    if (room) {
+      room.send('chat', { text: trimmed });
     }
   }, []);
 
@@ -145,11 +172,28 @@ export function useMultiplayer(options: UseMultiplayerOptions): MultiplayerState
         detachersRef.current.push(detachRemove);
 
         room.onMessage('chat', (msg: ChatMessage) => {
+          const isLocal = msg.sessionId === room.sessionId;
+          if (isLocal) {
+            const now = Date.now();
+            pendingLocalEchoesRef.current = pruneExpiredEchoes(
+              pendingLocalEchoesRef.current,
+              now,
+            );
+            const idx = findEchoIndex(
+              pendingLocalEchoesRef.current,
+              { text: msg.text, sessionId: msg.sessionId },
+              now,
+            );
+            if (idx !== -1) {
+              pendingLocalEchoesRef.current.splice(idx, 1);
+              return;
+            }
+          }
           EventBus.emit('chat-message', {
             sessionId: msg.sessionId,
             displayName: msg.displayName,
             text: msg.text,
-            isLocal: msg.sessionId === room.sessionId,
+            isLocal,
           });
         });
 
@@ -171,8 +215,28 @@ export function useMultiplayer(options: UseMultiplayerOptions): MultiplayerState
 
     const handleSendChat = (text: string) => {
       const trimmed = String(text || '').slice(0, 100).trim();
-      if (trimmed && roomRef.current) {
-        roomRef.current.send('chat', { text: trimmed });
+      if (!trimmed) return;
+
+      const opts = optionsRef.current;
+      const room = roomRef.current;
+      const sessionId = room?.sessionId ?? LOCAL_ONLY_SESSION_ID;
+      const now = Date.now();
+
+      pendingLocalEchoesRef.current = pruneExpiredEchoes(
+        pendingLocalEchoesRef.current,
+        now,
+      );
+      pendingLocalEchoesRef.current.push({ text: trimmed, sessionId, timestamp: now });
+
+      EventBus.emit('chat-message', {
+        sessionId,
+        displayName: opts.displayName,
+        text: trimmed,
+        isLocal: true,
+      });
+
+      if (room) {
+        room.send('chat', { text: trimmed });
       }
     };
 


### PR DESCRIPTION
## Summary
- Chat messages vanished silently when no Colyseus room was joined — the only path to the `chat-message` EventBus event went through `room.onMessage('chat')`. Even when connected there was a perceptible delay before the bubble appeared because the message had to roundtrip through the server.
- `sendChat` / `handleSendChat` now emit a local `chat-message` immediately with `isLocal: true` and queue the entry in `pendingLocalEchoesRef`. When the server echoes the same text + sessionId back within 2s, the echo is dedup'd so the bubble does not flicker. If no room is connected the local sessionId placeholder (`'local'`) is used and no server echo is ever expected.
- Pure dedup helpers (`pruneExpiredEchoes`, `findEchoIndex`) live in `lib/colyseus/chatDedup.ts` with regression tests in `lib/colyseus/__tests__/chatDedup.test.ts`.

## Files changed
- `lib/colyseus/useMultiplayer.ts` — local-echo + dedup integration
- `lib/colyseus/chatDedup.ts` — pure dedup helpers
- `lib/colyseus/__tests__/chatDedup.test.ts` — 10 unit tests

## Test plan
- [x] `npm run type-check` — 0 errors
- [x] `npm run lint` — no new errors in changed files (pre-existing repo errors unrelated)
- [x] `npm run test` — new file 10/10 pass; 4 pre-existing api-e2e failures unchanged
- [x] `npm run build` — succeeds
- [ ] Manual: open Sanctuary V2 with Colyseus server stopped, type chat → bubble appears
- [ ] Manual: open Sanctuary V2 with Colyseus server running, type chat → bubble appears immediately, server echo does not duplicate it

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS (0 new errors; baseline 0)
- **vitest run**: PASS (218/223 vs baseline 208/213; +10 new tests pass; same 5 pre-existing failures)
Overall: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)