### PR TITLE
feat(sanctuary): make RoomScene interactive with player, movement, exit trigger

### DIFF
--- a/game/__tests__/roomScene.test.ts
+++ b/game/__tests__/roomScene.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import { ROOMS } from '../config/worldLayout';
+import { ROOM_LAYOUTS, getRoomLayout } from '../config/roomLayouts';
+
+describe('Room layouts config', () => {
+  it('has an entry for every room key', () => {
+    for (const room of ROOMS) {
+      expect(ROOM_LAYOUTS[room]).toBeDefined();
+      expect(Array.isArray(ROOM_LAYOUTS[room].collision)).toBe(true);
+    }
+  });
+
+  it('getRoomLayout returns a layout for every room', () => {
+    for (const room of ROOMS) {
+      const layout = getRoomLayout(room);
+      expect(layout).toBeDefined();
+      expect(Array.isArray(layout.collision)).toBe(true);
+    }
+  });
+});
+
+describe('RoomScene gameplay wiring', () => {
+  const source = fs.readFileSync(
+    new URL('../scenes/RoomScene.ts', import.meta.url),
+    'utf-8',
+  );
+
+  it('spawns a PlayerSprite inside the room', () => {
+    expect(source).toContain('new PlayerSprite(this, spawnX, spawnY)');
+    expect(source).toContain('ROOM_H - 60');
+  });
+
+  it('spawns a CompanionSprite that follows the player', () => {
+    expect(source).toContain('new CompanionSprite(this');
+    expect(source).toContain('this.companion.followPlayer(');
+  });
+
+  it('uses per-room collision bodies inside a StaticGroup', () => {
+    expect(source).toContain('this.collisionGroup = this.physics.add.staticGroup()');
+    expect(source).toContain('this.collisionGroup.add(zone)');
+    expect(source).toContain('this.physics.add.collider(this.player, this.collisionGroup)');
+    expect(source).toContain("from '../config/roomLayouts'");
+  });
+
+  it('binds the camera to room bounds and follows the player', () => {
+    expect(source).toContain('cam.setBounds(0, 0, ROOM_W, ROOM_H)');
+    expect(source).toContain('cam.startFollow(this.player');
+  });
+
+  it('registers an exit trigger zone at the bottom center', () => {
+    expect(source).toContain('this.physics.add.overlap(this.player, zone');
+    expect(source).toContain('ROOM_W / 2');
+  });
+
+  it('supports keyboard-driven movement and pathfinding click-to-move', () => {
+    expect(source).toContain('this.player.handleKeyboardInput()');
+    expect(source).toContain('this.player.updatePathMovement()');
+    expect(source).toContain('EasyStar');
+  });
+});

--- a/game/config/roomLayouts.ts
+++ b/game/config/roomLayouts.ts
@@ -1,0 +1,24 @@
+import { ROOMS, type Rect, type RoomKey } from './worldLayout';
+
+export interface RoomLayout {
+  collision: Rect[];
+}
+
+// Per-room collision data is extracted by painting red masks on copies of the
+// room PNGs under public/sanctuary/ and running a room-layout variant of
+// scripts/extract_sanctuary_layout.mjs. Until that art pass is authored, each
+// room ships with an empty collision array so players can move freely inside.
+// Populate the maps below as each room is marked up.
+const EMPTY: Rect[] = [];
+
+export const ROOM_LAYOUTS: Record<RoomKey, RoomLayout> = ROOMS.reduce(
+  (acc, room) => {
+    acc[room] = { collision: EMPTY };
+    return acc;
+  },
+  {} as Record<RoomKey, RoomLayout>,
+);
+
+export function getRoomLayout(room: RoomKey): RoomLayout {
+  return ROOM_LAYOUTS[room] ?? { collision: EMPTY };
+}

--- a/game/scenes/RoomScene.ts
+++ b/game/scenes/RoomScene.ts
@@ -1,13 +1,31 @@
 import Phaser from 'phaser';
+import * as EasyStar from 'easystarjs';
 import EventBus from '@/components/sanctuary/EventBus';
-import type { RoomKey } from '../config/worldLayout';
+import { PlayerSprite } from '../sprites/PlayerSprite';
+import { CompanionSprite } from '../sprites/CompanionSprite';
+import { AnimationSystem } from '../systems/AnimationSystem';
+import { NAV_CELL, type RoomKey } from '../config/worldLayout';
+import { getRoomLayout } from '../config/roomLayouts';
 
 const ROOM_W = 1448;
 const ROOM_H = 1086;
+const SOUTHERN_SPAWN_Y = ROOM_H - 60;
+const EXIT_ZONE_W = 120;
+const EXIT_ZONE_H = 30;
 
 export class RoomScene extends Phaser.Scene {
   private room!: RoomKey;
   private returnTo!: { x: number; y: number };
+  private player!: PlayerSprite;
+  private companion!: CompanionSprite;
+  private animSystem!: AnimationSystem;
+  private finder!: EasyStar.js;
+  private navGrid: number[][] = [];
+  private gridW = 0;
+  private gridH = 0;
+  private collisionGroup!: Phaser.Physics.Arcade.StaticGroup;
+  private clickMarker: Phaser.GameObjects.Graphics | null = null;
+  private exiting = false;
 
   constructor() {
     super({ key: 'RoomScene' });
@@ -16,61 +34,164 @@ export class RoomScene extends Phaser.Scene {
   create(data: { room: RoomKey; returnTo: { x: number; y: number } }) {
     this.room = data.room;
     this.returnTo = data.returnTo;
+    this.exiting = false;
 
+    const bgKey = `room-bg-${this.room}`;
+    const bg = this.textures.exists(bgKey)
+      ? this.add.image(0, 0, bgKey)
+      : this.add.image(0, 0, 'room-placeholder');
+    bg.setOrigin(0, 0).setDisplaySize(ROOM_W, ROOM_H).setDepth(-10);
+
+    this.physics.world.setBounds(0, 0, ROOM_W, ROOM_H);
     const cam = this.cameras.main;
     cam.setBounds(0, 0, ROOM_W, ROOM_H);
     cam.setZoom(1);
-    cam.centerOn(ROOM_W / 2, ROOM_H / 2);
     cam.setBackgroundColor('#0a0015');
     cam.fadeIn(250, 0, 0, 0);
 
-    const bgKey = `room-bg-${this.room}`;
-    if (this.textures.exists(bgKey)) {
-      this.add.image(0, 0, bgKey).setOrigin(0, 0).setDisplaySize(ROOM_W, ROOM_H);
-    } else {
-      this.add.image(0, 0, 'room-placeholder').setOrigin(0, 0).setDisplaySize(ROOM_W, ROOM_H);
+    this.buildNavGrid();
+    this.createCollisionBodies();
+
+    const spawnX = ROOM_W / 2;
+    const spawnY = SOUTHERN_SPAWN_Y;
+
+    this.animSystem = new AnimationSystem(this);
+    this.player = new PlayerSprite(this, spawnX, spawnY);
+    this.companion = new CompanionSprite(this, spawnX + 20, spawnY + 10);
+    this.companion.setAnimationSystem(this.animSystem);
+
+    this.physics.add.collider(this.player, this.collisionGroup);
+    cam.startFollow(this.player, true, 0.1, 0.1);
+
+    this.setupPathfinder();
+    this.setupClickToMove();
+    this.setupExitZone();
+    this.setupHUD();
+
+    this.input.keyboard!.on('keydown-ESC', () => this.exit());
+    this.input.keyboard!.on('keydown-E', () => this.exit());
+  }
+
+  private buildNavGrid() {
+    this.gridW = Math.ceil(ROOM_W / NAV_CELL);
+    this.gridH = Math.ceil(ROOM_H / NAV_CELL);
+    this.navGrid = Array.from({ length: this.gridH }, () =>
+      Array.from({ length: this.gridW }, () => 0),
+    );
+    for (const rect of getRoomLayout(this.room).collision) {
+      const x0 = Math.max(0, Math.floor(rect.x / NAV_CELL));
+      const y0 = Math.max(0, Math.floor(rect.y / NAV_CELL));
+      const x1 = Math.min(this.gridW - 1, Math.floor((rect.x + rect.w - 1) / NAV_CELL));
+      const y1 = Math.min(this.gridH - 1, Math.floor((rect.y + rect.h - 1) / NAV_CELL));
+      for (let y = y0; y <= y1; y++) {
+        for (let x = x0; x <= x1; x++) this.navGrid[y][x] = 1;
+      }
     }
+  }
 
-    const screenW = this.scale.width;
-    const screenH = this.scale.height;
+  private createCollisionBodies() {
+    this.collisionGroup = this.physics.add.staticGroup();
+    for (const rect of getRoomLayout(this.room).collision) {
+      const zone = this.add.zone(rect.x + rect.w / 2, rect.y + rect.h / 2, rect.w, rect.h);
+      this.collisionGroup.add(zone);
+    }
+  }
 
-    const nameplate = this.add
-      .text(screenW / 2, 32, this.room.toUpperCase(), {
+  private setupPathfinder() {
+    this.finder = new EasyStar.js();
+    this.finder.setGrid(this.navGrid);
+    this.finder.setAcceptableTiles([0]);
+    this.finder.enableDiagonals();
+    this.finder.setIterationsPerCalculation(200);
+  }
+
+  private setupClickToMove() {
+    this.clickMarker = this.add.graphics().setDepth(5);
+    this.input.on('pointerdown', (pointer: Phaser.Input.Pointer) => {
+      if (pointer.rightButtonDown()) return;
+      const worldX = pointer.worldX;
+      const worldY = pointer.worldY;
+      const gx = Math.floor(worldX / NAV_CELL);
+      const gy = Math.floor(worldY / NAV_CELL);
+      if (gx < 0 || gy < 0 || gx >= this.gridW || gy >= this.gridH) return;
+      if (this.navGrid[gy][gx] === 1) return;
+
+      this.showClickMarker(worldX, worldY);
+
+      const pgx = Math.floor(this.player.x / NAV_CELL);
+      const pgy = Math.floor(this.player.y / NAV_CELL);
+      this.finder.findPath(pgx, pgy, gx, gy, (path) => {
+        if (path && path.length > 1) this.player.setPath(path);
+      });
+      this.finder.calculate();
+    });
+  }
+
+  private showClickMarker(x: number, y: number) {
+    if (!this.clickMarker) return;
+    this.clickMarker.clear();
+    this.clickMarker.lineStyle(1, 0xffd700, 0.9);
+    this.clickMarker.strokeCircle(x, y, 5);
+    this.tweens.add({
+      targets: this.clickMarker,
+      alpha: 0,
+      duration: 600,
+      onComplete: () => {
+        this.clickMarker?.setAlpha(1);
+        this.clickMarker?.clear();
+      },
+    });
+  }
+
+  private setupExitZone() {
+    const zoneCenterX = ROOM_W / 2;
+    const zoneCenterY = ROOM_H - EXIT_ZONE_H / 2;
+    const zone = this.add.zone(zoneCenterX, zoneCenterY, EXIT_ZONE_W, EXIT_ZONE_H);
+    this.physics.add.existing(zone, true);
+    this.physics.add.overlap(this.player, zone, () => this.exit());
+
+    const hint = this.add
+      .text(zoneCenterX, zoneCenterY - 28, '[E] EXIT', {
         fontFamily: '"Press Start 2P", monospace',
-        fontSize: '16px',
+        fontSize: '10px',
+        color: '#ff00ff',
+        stroke: '#000000',
+        strokeThickness: 3,
+        backgroundColor: 'rgba(26,0,51,0.75)',
+        padding: { x: 8, y: 4 },
+      })
+      .setOrigin(0.5, 1)
+      .setDepth(20);
+    void hint;
+  }
+
+  private setupHUD() {
+    const screenW = this.scale.width;
+    this.add
+      .text(screenW / 2, 16, this.room.toUpperCase(), {
+        fontFamily: '"Press Start 2P", monospace',
+        fontSize: '14px',
         color: '#ffd700',
         stroke: '#000000',
         strokeThickness: 4,
         backgroundColor: 'rgba(10,0,21,0.75)',
-        padding: { x: 14, y: 8 },
+        padding: { x: 12, y: 6 },
       })
       .setOrigin(0.5, 0)
       .setScrollFactor(0)
       .setDepth(100);
+  }
 
-    const exitBtn = this.add
-      .text(screenW / 2, screenH - 36, '< EXIT  [E]', {
-        fontFamily: '"Press Start 2P", monospace',
-        fontSize: '12px',
-        color: '#ff00ff',
-        stroke: '#000000',
-        strokeThickness: 3,
-        backgroundColor: 'rgba(26,0,51,0.85)',
-        padding: { x: 14, y: 8 },
-      })
-      .setOrigin(0.5, 1)
-      .setScrollFactor(0)
-      .setDepth(100)
-      .setInteractive({ useHandCursor: true });
-
-    exitBtn.on('pointerdown', () => this.exit());
-    this.input.keyboard!.on('keydown-ESC', () => this.exit());
-    this.input.keyboard!.on('keydown-E', () => this.exit());
-
-    void nameplate;
+  update() {
+    if (!this.player || this.exiting) return;
+    const keyboardActive = this.player.handleKeyboardInput();
+    if (!keyboardActive) this.player.updatePathMovement();
+    this.companion.followPlayer(this.player.x, this.player.y, this.player.getDirection());
   }
 
   private exit() {
+    if (this.exiting) return;
+    this.exiting = true;
     this.cameras.main.fadeOut(250, 0, 0, 0);
     this.time.delayedCall(260, () => {
       EventBus.emit('room-exit', { returnTo: this.returnTo });


### PR DESCRIPTION
## Summary
- Replace static RoomScene (bg + title + exit button) with real gameplay: PlayerSprite spawns at the southern entrance `(ROOM_W/2, ROOM_H-60)`, WASD + click-to-move drive it, the camera follows inside `1448x1086` bounds, and a CompanionSprite trails the player.
- Add an arcade-physics overlap trigger zone at the bottom center so walking south exits the room; the existing `E` / `ESC` shortcuts still work.
- Introduce `game/config/roomLayouts.ts` keyed by `RoomKey` so each room can own its collision rects. Ships with empty arrays today — rooms stay freely walkable until red-mask PNGs + a room-layout extractor variant land.

## Implementation notes
- `RoomScene` now builds a per-room nav grid, wires EasyStar click-to-move the same way `WorldScene` does, installs a `StaticGroup` of collision zones, and adds a `physics.add.collider(player, collisionGroup)` so rooms can enforce walls once data exists.
- Exit handling is idempotent via an `exiting` guard so repeated overlap ticks or double key-presses don't re-emit `room-exit`. `EventBus.emit('room-exit', ...)` still drives the WorldScene wake-up path unchanged.
- Companion uses a fresh `AnimationSystem` per scene; it defaults to the `companion-placeholder` texture already registered in `BootScene`.

## Test plan
- [x] `npm run type-check` — passes
- [x] `npm run lint` — no new errors in changed files (196 pre-existing problems unchanged)
- [x] `npm run test` — 8 new tests pass in `game/__tests__/roomScene.test.ts`; 4 pre-existing failures in `lib/sanctuary/__tests__/api-e2e.test.ts` are unrelated
- [x] `npm run build` — succeeds

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS (baseline 0 errors, overlay skipped — PROD lacks `phaser`/`easystarjs` node_modules so any `game/scenes` or `game/sprites` overlay would cascade-fail with missing-module errors that also apply to pre-existing files not yet deployed)
- **vitest run**: PASS (5 pre-existing failures in `api-e2e.test.ts` excluded; no new failures)
- Mirror restored byte-identical after validation.
- Overall: PASS (infrastructure gap documented — deploy step must `npm install` on PROD before these files are served)

🤖 Generated with [Claude Code](https://claude.com/claude-code)