### PR TITLE
feat: traits as overlay at Cosmic Library with hotkey T

### DIFF
--- a/app/sanctuary/SanctuaryContent.tsx
+++ b/app/sanctuary/SanctuaryContent.tsx
@@ -53,17 +53,6 @@ interface ChatMessage {
   created_at: string;
 }
 
-interface CompanionTrait {
-  trait_name: string;
-  trait_category: string;
-  progress: number;
-  threshold: number;
-  description: string;
-  unlocked: number;
-  unlocked_at: string | null;
-}
-
-
 interface LocationCompanions {
   location_name: string;
   count: number;
@@ -711,91 +700,6 @@ function ChatPanel({ address, tokenId, companion }: { address: string; tokenId: 
   );
 }
 
-const TRAIT_CATEGORY_CONFIG: Record<string, { icon: string; color: string }> = {
-  social: { icon: '💜', color: '#ff66aa' },
-  explorer: { icon: '🗺️', color: '#44ff88' },
-  gourmet: { icon: '🍽️', color: '#ff9944' },
-  scholar: { icon: '📚', color: '#66bbff' },
-  dreamer: { icon: '💭', color: '#9966ff' },
-  special: { icon: '⭐', color: '#ffd700' },
-};
-
-function TraitsPanel({ address, tokenId }: { address: string; tokenId: number }) {
-  const [traits, setTraits] = useState<CompanionTrait[]>([]);
-  const [expanded, setExpanded] = useState(false);
-
-  useEffect(() => {
-    fetch(`/api/sanctuary/traits?address=${address}&token_id=${tokenId}`)
-      .then((r) => r.json())
-      .then((data) => { if (data.success) setTraits(data.traits); })
-      .catch(() => {});
-  }, [address, tokenId]);
-
-  const unlocked = traits.filter((t) => t.unlocked);
-  const inProgress = traits.filter((t) => !t.unlocked);
-
-  return (
-    <div className="pixel-card p-4 space-y-3">
-      <div className="flex items-center justify-between">
-        <h3 className="text-[#ffd700] text-[9px] tracking-wider">EVOLVED TRAITS</h3>
-        <span className="text-gray-500 text-[7px]">{unlocked.length} unlocked</span>
-      </div>
-
-      {unlocked.length === 0 && inProgress.length === 0 && (
-        <div className="text-center py-4 space-y-2 bg-[#9966ff]/5 rounded-lg border border-[#9966ff]/15 px-3">
-          <p className="text-[#9966ff]/60 text-sm">✨</p>
-          <p className="text-[#9966ff]/80 text-[9px] font-bold tracking-wider">TRAITS AWAITING DISCOVERY</p>
-          <p className="text-gray-400 text-[8px]">
-            Feed, pet, and talk to your companion to unlock unique personality traits.
-          </p>
-          <p className="text-gray-600 text-[7px]">Each interaction brings you closer to revealing hidden abilities.</p>
-        </div>
-      )}
-
-      {unlocked.length > 0 && (
-        <div className="flex flex-wrap gap-1.5">
-          {unlocked.map((t) => {
-            const cat = TRAIT_CATEGORY_CONFIG[t.trait_category] ?? { icon: '✨', color: '#888' };
-            return (
-              <span key={t.trait_name} className="text-[7px] px-2 py-1 rounded-full border" style={{ borderColor: cat.color + '60', color: cat.color, backgroundColor: cat.color + '15' }}>
-                {cat.icon} {t.trait_name}
-              </span>
-            );
-          })}
-        </div>
-      )}
-
-      {inProgress.length > 0 && (
-        <>
-          <button onClick={() => setExpanded(!expanded)} className="text-gray-500 text-[7px] hover:text-white">
-            {expanded ? 'HIDE' : 'SHOW'} PROGRESS ({inProgress.length})
-          </button>
-          {expanded && (
-            <div className="space-y-1.5">
-              {inProgress.map((t) => {
-                const cat = TRAIT_CATEGORY_CONFIG[t.trait_category] ?? { icon: '✨', color: '#888' };
-                const pct = Math.min((t.progress / t.threshold) * 100, 100);
-                return (
-                  <div key={t.trait_name}>
-                    <div className="flex justify-between text-[7px] mb-0.5">
-                      <span className="text-gray-400">{cat.icon} {t.trait_name}</span>
-                      <span style={{ color: cat.color }}>{Math.round(t.progress)}/{t.threshold}</span>
-                    </div>
-                    <div className="h-1 bg-[#1a1a2e] rounded-full overflow-hidden border border-[#2a2a4e]">
-                      <div className="h-full rounded-full transition-all" style={{ width: `${pct}%`, backgroundColor: cat.color }} />
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          )}
-        </>
-      )}
-    </div>
-  );
-}
-
-
 function CompanionPicker({
   address,
   activeTokenId,
@@ -1267,7 +1171,6 @@ function HolderSanctuary() {
       {companion && address && (
         <div className="space-y-6">
           <ChatPanel address={address} tokenId={companion.token_id} companion={companion} />
-          <TraitsPanel address={address} tokenId={companion.token_id} />
         </div>
       )}
     </div>

--- a/app/sanctuary/SanctuaryV2.tsx
+++ b/app/sanctuary/SanctuaryV2.tsx
@@ -56,6 +56,11 @@ const JournalOverlay = dynamic(
   { ssr: false }
 );
 
+const TraitsOverlay = dynamic(
+  () => import('@/components/sanctuary/overlays/TraitsOverlay'),
+  { ssr: false }
+);
+
 const DevMapEditor = dynamic(
   () => import('@/components/sanctuary/DevMapEditor'),
   { ssr: false }
@@ -138,6 +143,7 @@ export default function SanctuaryV2() {
         <QuestBoard walletAddress={address} tokenId={activeTokenId} />
         <QuestTracker walletAddress={address} tokenId={activeTokenId} />
         <JournalOverlay walletAddress={address} tokenId={activeTokenId} />
+        <TraitsOverlay walletAddress={address} tokenId={activeTokenId} />
         <ChatBubble />
         <ChatInput />
         {editMode && <DevMapEditor />}

--- a/components/sanctuary/overlays/CompanionHUD.tsx
+++ b/components/sanctuary/overlays/CompanionHUD.tsx
@@ -95,6 +95,10 @@ export default function CompanionHUD({ walletAddress }: CompanionHUDProps) {
     EventBus.emit('journal-overlay-toggle');
   }, []);
 
+  const openTraits = useCallback(() => {
+    EventBus.emit('traits-overlay-toggle');
+  }, []);
+
   if (!companion) return null;
 
   const displayName =
@@ -143,6 +147,17 @@ export default function CompanionHUD({ walletAddress }: CompanionHUDProps) {
       >
         <span className="text-[10px] leading-none">📖</span>
         <span className="text-[6px] text-[#ffd700]/80 font-['Press_Start_2P']">[J]</span>
+      </button>
+
+      {/* Traits icon */}
+      <button
+        onClick={openTraits}
+        className="absolute bottom-2 left-16 z-20 flex items-center gap-1 bg-black/80 border border-[#6644aa]/60 rounded px-2 py-1 hover:bg-[#1a0f3a]/80 hover:border-[#9966ff]/60 transition-colors pointer-events-auto select-none"
+        aria-label="Open traits (T)"
+        title="Traits (T)"
+      >
+        <span className="text-[10px] leading-none">🌌</span>
+        <span className="text-[6px] text-[#9966ff]/80 font-['Press_Start_2P']">[T]</span>
       </button>
 
       {/* Location indicator */}

--- a/components/sanctuary/overlays/TraitsOverlay.tsx
+++ b/components/sanctuary/overlays/TraitsOverlay.tsx
@@ -1,0 +1,356 @@
+'use client';
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import EventBus from '@/components/sanctuary/EventBus';
+
+interface CompanionTrait {
+  trait_name: string;
+  trait_category: string;
+  progress: number;
+  threshold: number;
+  description: string;
+  unlocked: number;
+  unlocked_at: string | null;
+}
+
+interface CompanionMeta {
+  nickname: string | null;
+  constellation: string | null;
+  aura: string | null;
+  form: string | null;
+}
+
+interface TraitsOverlayProps {
+  walletAddress: string | undefined;
+  tokenId: number | null;
+}
+
+const TRAIT_CATEGORY_CONFIG: Record<string, { icon: string; label: string; color: string }> = {
+  social: { icon: '💜', label: 'Social', color: '#ff66aa' },
+  explorer: { icon: '🗺️', label: 'Explorer', color: '#44ff88' },
+  gourmet: { icon: '🍽️', label: 'Gourmet', color: '#ff9944' },
+  scholar: { icon: '📚', label: 'Scholar', color: '#66bbff' },
+  dreamer: { icon: '💭', label: 'Dreamer', color: '#9966ff' },
+  special: { icon: '⭐', label: 'Special', color: '#ffd700' },
+};
+
+const CONSTELLATION_TRIGGER_ZONE = 'Cosmic Library';
+
+function TraitRow({ trait }: { trait: CompanionTrait }) {
+  const cfg = TRAIT_CATEGORY_CONFIG[trait.trait_category] ?? { icon: '✨', label: trait.trait_category, color: '#888' };
+  const pct = trait.unlocked
+    ? 100
+    : Math.min((trait.progress / Math.max(trait.threshold, 1)) * 100, 100);
+  return (
+    <div
+      className="border-l-2 pl-2 py-1.5"
+      style={{ borderColor: cfg.color + (trait.unlocked ? '' : '60') }}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-[#f5e6b8] text-[8px] font-['Press_Start_2P']">
+          {cfg.icon} {trait.trait_name}
+        </span>
+        <span
+          className="text-[7px] font-['Press_Start_2P']"
+          style={{ color: cfg.color }}
+        >
+          {trait.unlocked
+            ? 'UNLOCKED'
+            : `${Math.round(trait.progress)}/${trait.threshold}`}
+        </span>
+      </div>
+      {trait.description && (
+        <p className="text-[#8a7a55] text-[7px] mt-0.5 leading-snug">
+          {trait.description}
+        </p>
+      )}
+      <div className="mt-1 h-1 bg-[#1a1a2e] rounded-full overflow-hidden border border-[#2a2a4e]">
+        <div
+          className="h-full rounded-full transition-all"
+          style={{ width: `${pct}%`, backgroundColor: cfg.color }}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default function TraitsOverlay({ walletAddress, tokenId }: TraitsOverlayProps) {
+  const [open, setOpen] = useState(false);
+  const [traits, setTraits] = useState<CompanionTrait[]>([]);
+  const [meta, setMeta] = useState<CompanionMeta | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [categoryFilter, setCategoryFilter] = useState<string | null>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const autoOpenedRef = useRef(false);
+
+  const close = useCallback(() => setOpen(false), []);
+
+  const fetchTraits = useCallback(async () => {
+    if (!walletAddress || tokenId === null) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const [traitsRes, companionRes] = await Promise.all([
+        fetch(
+          `/api/sanctuary/traits?address=${walletAddress}&token_id=${tokenId}`,
+        ),
+        fetch(`/api/sanctuary/companion?address=${walletAddress}`),
+      ]);
+      const traitsData = await traitsRes.json();
+      const companionData = await companionRes.json().catch(() => null);
+      if (traitsData.success) {
+        setTraits(traitsData.traits ?? []);
+      } else {
+        setError(traitsData.error ?? 'Failed to load traits');
+      }
+      if (companionData?.success && companionData.companion) {
+        setMeta({
+          nickname: companionData.companion.nickname ?? null,
+          constellation: companionData.companion.constellation ?? null,
+          aura: companionData.companion.aura ?? null,
+          form: companionData.companion.form ?? null,
+        });
+      }
+    } catch {
+      setError('Failed to load traits');
+    } finally {
+      setLoading(false);
+    }
+  }, [walletAddress, tokenId]);
+
+  useEffect(() => {
+    const handleOpen = () => {
+      setOpen(true);
+      setCategoryFilter(null);
+      fetchTraits();
+    };
+    const handleToggle = () => {
+      setOpen((prev) => {
+        if (!prev) {
+          setCategoryFilter(null);
+          fetchTraits();
+        }
+        return !prev;
+      });
+    };
+    const handleLocationEntered = (payload: { name: string }) => {
+      if (payload?.name === CONSTELLATION_TRIGGER_ZONE && !autoOpenedRef.current) {
+        autoOpenedRef.current = true;
+        setOpen(true);
+        setCategoryFilter(null);
+        fetchTraits();
+      }
+    };
+    const handleLocationExited = (payload: { name: string }) => {
+      if (payload?.name === CONSTELLATION_TRIGGER_ZONE) {
+        autoOpenedRef.current = false;
+      }
+    };
+    EventBus.on('traits-overlay-open', handleOpen);
+    EventBus.on('traits-overlay-toggle', handleToggle);
+    EventBus.on('location-entered', handleLocationEntered);
+    EventBus.on('location-exited', handleLocationExited);
+    return () => {
+      EventBus.off('traits-overlay-open', handleOpen);
+      EventBus.off('traits-overlay-toggle', handleToggle);
+      EventBus.off('location-entered', handleLocationEntered);
+      EventBus.off('location-exited', handleLocationExited);
+    };
+  }, [fetchTraits]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKey = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null;
+      const tag = target?.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || target?.isContentEditable) return;
+      if (e.key === 'Escape' || e.key === 't' || e.key === 'T') {
+        e.preventDefault();
+        close();
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [open, close]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        close();
+      }
+    };
+    const timer = setTimeout(() => {
+      document.addEventListener('mousedown', handleClickOutside);
+    }, 50);
+    return () => {
+      clearTimeout(timer);
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [open, close]);
+
+  if (!open) return null;
+
+  const unlocked = traits.filter((t) => t.unlocked);
+  const byCategoryCount: Record<string, number> = {};
+  for (const t of traits) {
+    byCategoryCount[t.trait_category] = (byCategoryCount[t.trait_category] ?? 0) + 1;
+  }
+
+  const filtered = categoryFilter
+    ? traits.filter((t) => t.trait_category === categoryFilter)
+    : traits;
+  const filteredUnlocked = filtered.filter((t) => t.unlocked);
+  const filteredInProgress = filtered.filter((t) => !t.unlocked);
+
+  return (
+    <div className="absolute inset-0 z-40 flex items-center justify-center pointer-events-none">
+      <div
+        ref={panelRef}
+        className="w-[22rem] max-h-[85%] flex flex-col pointer-events-auto
+          bg-[#0a0520] border-4 border-[#6644aa] rounded-sm
+          shadow-[inset_0_0_0_2px_#1a0f3a,0_0_25px_rgba(153,102,255,0.4)]
+          transition-all duration-200"
+        style={{
+          backgroundImage:
+            'linear-gradient(to bottom, rgba(153,102,255,0.06) 0%, rgba(0,0,0,0.2) 100%)',
+        }}
+      >
+        {/* Header */}
+        <div className="bg-[#1a0f3a] border-b-2 border-[#6644aa] px-3 py-2">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <span className="text-base">🌌</span>
+              <h3 className="text-[#9966ff] font-['Press_Start_2P'] text-[8px] tracking-wider">
+                TRAITS
+              </h3>
+              {traits.length > 0 && (
+                <span className="text-[#6a5a9a] text-[6px] font-['Press_Start_2P']">
+                  {unlocked.length}/{traits.length} UNLOCKED
+                </span>
+              )}
+            </div>
+            <button
+              onClick={close}
+              className="text-[#8a7aaa] hover:text-[#ffd700] text-sm transition-colors"
+              aria-label="Close traits"
+            >
+              ✕
+            </button>
+          </div>
+          {meta && (meta.constellation || meta.aura || meta.form) && (
+            <div className="mt-1.5 flex flex-wrap gap-1.5 text-[6px] font-['Press_Start_2P']">
+              {meta.constellation && (
+                <span className="px-1.5 py-0.5 rounded-sm border border-[#ffd700]/60 text-[#ffd700] bg-[#ffd700]/10">
+                  ⭐ {meta.constellation.toUpperCase()}
+                </span>
+              )}
+              {meta.aura && (
+                <span className="px-1.5 py-0.5 rounded-sm border border-[#00f7ff]/60 text-[#00f7ff] bg-[#00f7ff]/10">
+                  ◌ {meta.aura.toUpperCase()}
+                </span>
+              )}
+              {meta.form && (
+                <span className="px-1.5 py-0.5 rounded-sm border border-[#ff66aa]/60 text-[#ff66aa] bg-[#ff66aa]/10">
+                  ✦ {meta.form.toUpperCase()}
+                </span>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Category filters */}
+        {traits.length > 0 && (
+          <div className="flex flex-wrap gap-1 px-3 py-2 border-b-2 border-[#1a0f3a] bg-[#050310]">
+            <button
+              onClick={() => setCategoryFilter(null)}
+              className={`text-[7px] px-1.5 py-0.5 rounded-sm border transition-colors font-['Press_Start_2P'] ${
+                !categoryFilter
+                  ? 'border-[#9966ff]/60 text-[#9966ff] bg-[#9966ff]/10'
+                  : 'border-[#1a0f3a] text-[#6a5a9a] hover:text-[#c9b7ff]'
+              }`}
+            >
+              ALL ({traits.length})
+            </button>
+            {Object.entries(TRAIT_CATEGORY_CONFIG).map(([cat, cfg]) => {
+              const count = byCategoryCount[cat] ?? 0;
+              if (count === 0) return null;
+              const active = categoryFilter === cat;
+              return (
+                <button
+                  key={cat}
+                  onClick={() => setCategoryFilter(active ? null : cat)}
+                  className={`text-[7px] px-1.5 py-0.5 rounded-sm border transition-colors ${
+                    active ? 'bg-white/5' : 'hover:bg-white/5'
+                  }`}
+                  style={{
+                    borderColor: active ? cfg.color + '80' : '#1a0f3a',
+                    color: active ? cfg.color : '#6a5a9a',
+                  }}
+                >
+                  {cfg.icon} {cfg.label} ({count})
+                </button>
+              );
+            })}
+          </div>
+        )}
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto px-4 py-3 min-h-[200px]">
+          {error ? (
+            <div className="flex flex-col items-center gap-2 py-6">
+              <p className="text-red-400 text-[8px]">{error}</p>
+              <button
+                onClick={fetchTraits}
+                className="text-[7px] text-[#9966ff] hover:text-[#c9b7ff] transition-colors font-['Press_Start_2P']"
+              >
+                RETRY
+              </button>
+            </div>
+          ) : loading && traits.length === 0 ? (
+            <p className="text-[#6a5a9a] text-[8px] text-center py-6">Loading...</p>
+          ) : traits.length === 0 ? (
+            <div className="text-center py-6 space-y-1">
+              <p className="text-[#9966ff]/60 text-[14px]">✨</p>
+              <p className="text-[#9966ff]/80 text-[8px] font-['Press_Start_2P'] tracking-wider">
+                AWAITING DISCOVERY
+              </p>
+              <p className="text-[#8a7aaa] text-[7px] mt-1">
+                Feed, pet, and talk to your companion to unlock unique traits.
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {filteredUnlocked.length > 0 && (
+                <div className="space-y-1.5">
+                  <p className="text-[#ffd700] text-[7px] font-['Press_Start_2P'] tracking-wider">
+                    ✧ UNLOCKED ({filteredUnlocked.length})
+                  </p>
+                  {filteredUnlocked.map((t) => (
+                    <TraitRow key={t.trait_name} trait={t} />
+                  ))}
+                </div>
+              )}
+              {filteredInProgress.length > 0 && (
+                <div className="space-y-1.5">
+                  <p className="text-[#9966ff] text-[7px] font-['Press_Start_2P'] tracking-wider">
+                    ◌ IN PROGRESS ({filteredInProgress.length})
+                  </p>
+                  {filteredInProgress.map((t) => (
+                    <TraitRow key={t.trait_name} trait={t} />
+                  ))}
+                </div>
+              )}
+              {filtered.length === 0 && (
+                <p className="text-[#6a5a9a] text-[8px] text-center py-6">
+                  No traits in this category yet.
+                </p>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/game/scenes/RoomScene.ts
+++ b/game/scenes/RoomScene.ts
@@ -73,6 +73,9 @@ export class RoomScene extends Phaser.Scene {
     this.input.keyboard!.on('keydown-J', () => {
       EventBus.emit('journal-overlay-toggle');
     });
+    this.input.keyboard!.on('keydown-T', () => {
+      EventBus.emit('traits-overlay-toggle');
+    });
   }
 
   private buildNavGrid() {

--- a/game/scenes/WorldScene.ts
+++ b/game/scenes/WorldScene.ts
@@ -84,6 +84,10 @@ export class WorldScene extends Phaser.Scene {
       EventBus.emit('journal-overlay-toggle');
     });
 
+    this.input.keyboard!.on('keydown-T', () => {
+      EventBus.emit('traits-overlay-toggle');
+    });
+
     if (typeof window !== 'undefined') {
       const params = new URLSearchParams(window.location.search);
       if (params.get('edit') === '1') this.setEditorMode(true);


### PR DESCRIPTION
## Summary
- Replaces inline \`TraitsPanel\` card with a dedicated \`TraitsOverlay\` opened via hotkey **T**, ESC-to-close, click-outside, the HUD \`[T]\` icon, **or automatically on Cosmic Library zone entry**.
- Reuses existing \`/api/sanctuary/traits\` (personality traits + progress bars) and pulls constellation/aura/form info from \`/api/sanctuary/companion\`.
- Removes the old \`TraitsPanel\` from \`SanctuaryContent.tsx\` (V1) so traits only live in the V2 overlay.

## Changes
- \`components/sanctuary/overlays/TraitsOverlay.tsx\` — new book-styled modal (purple/cosmic palette). Shows constellation/aura/form badges, category filters, unlocked vs in-progress trait lists with per-trait progress bars.
- \`game/scenes/WorldScene.ts\` + \`RoomScene.ts\` — wire \`keydown-T\` → \`EventBus.emit('traits-overlay-toggle')\`.
- \`app/sanctuary/SanctuaryV2.tsx\` — mount \`<TraitsOverlay />\`.
- \`components/sanctuary/overlays/CompanionHUD.tsx\` — add \`[T]\` constellation icon button next to the journal book.
- \`app/sanctuary/SanctuaryContent.tsx\` — remove legacy \`TraitsPanel\`, its \`CompanionTrait\` interface, and the \`TRAIT_CATEGORY_CONFIG\`.

Auto-open uses a \`location-entered\` event listener (already emitted by \`ZoneSystem\` per CLAUDE.md patterns). A ref guard prevents re-opening if the user closes while still inside the zone; re-entering the zone re-arms the trigger.

## Mirror Validation (PROD)
- **tsc --noEmit** (baseline PROD): PASS
- **tsc --noEmit** (with overlay): pre-existing PROD divergence — the mirror branch does not ship Sanctuary V2 (missing \`phaser\` dep, \`@/components/sanctuary/EventBus\`, and \`game/scenes/*\`). All overlay errors trace to those missing base files, not to this PR's changes.
- **vitest run**: not run against mirror (same divergence — Sanctuary V2 tests don't exist in PROD tree yet).

Overall mirror diff is dominated by pre-existing PROD state; no new-only regressions attributable to this PR.

## Local validation
- \`npm run type-check\` — PASS (0 errors).
- \`npm run lint\` — PASS for all changed files; total repo error count unchanged (81 pre-existing).
- \`npm run build\` — PASS.
- \`npm run test\` — 270/274 pass. 4 failing are pre-existing \`lib/sanctuary/__tests__/api-e2e.test.ts\` failures unrelated to this change.

## Test plan
- [ ] Visit \`/sanctuary?v=2\` and confirm the \`[T]\` icon appears bottom-left.
- [ ] Press **T** on the world scene — overlay opens; press **T** or **ESC** or click outside — overlay closes.
- [ ] Walk player into the Cosmic Library zone — overlay auto-opens once, does not re-open until exit/re-entry.
- [ ] Verify constellation/aura/form badges render in header when companion has metadata.
- [ ] Verify trait list shows unlocked vs in-progress sections with per-trait progress bars.
- [ ] Confirm V1 \`/sanctuary\` no longer renders the TraitsPanel card under the chat panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)