### PR TITLE
feat: Spawn Fox intro NPC with first-time welcome dialog

### DIFF
--- a/app/api/sanctuary/player-state/route.ts
+++ b/app/api/sanctuary/player-state/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getPlayerState, upsertPlayerVisit, markIntroCompleted } from '@/lib/db';
+import { verifyWalletAccess } from '@/lib/walletAuth';
+import { ethAddress, parseSearchParams, parseBody, formatZodError } from '@/lib/sanctuary/validation';
+
+const querySchema = z.object({
+  address: ethAddress,
+});
+
+const bodySchema = z.object({
+  address: ethAddress,
+  action: z.enum(['visit', 'complete-intro']),
+});
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const parsed = parseSearchParams(querySchema, searchParams);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { success: false, error: formatZodError(parsed.error) },
+        { status: 400 },
+      );
+    }
+
+    const state = getPlayerState(parsed.data.address);
+    return NextResponse.json({ success: true, state });
+  } catch (error) {
+    console.error('Sanctuary player-state GET error:', error);
+    return NextResponse.json(
+      { success: false, error: 'Failed to fetch player state' },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const parsed = parseBody(bodySchema, body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { success: false, error: formatZodError(parsed.error) },
+        { status: 400 },
+      );
+    }
+
+    const { address, action } = parsed.data;
+
+    const auth = await verifyWalletAccess(request, address);
+    if (!auth.valid) {
+      return NextResponse.json({ success: false, error: auth.error }, { status: 401 });
+    }
+
+    const state = action === 'complete-intro'
+      ? markIntroCompleted(address)
+      : upsertPlayerVisit(address);
+
+    return NextResponse.json({ success: true, state });
+  } catch (error) {
+    console.error('Sanctuary player-state POST error:', error);
+    return NextResponse.json(
+      { success: false, error: 'Failed to update player state' },
+      { status: 500 },
+    );
+  }
+}

--- a/app/sanctuary/SanctuaryV2.tsx
+++ b/app/sanctuary/SanctuaryV2.tsx
@@ -61,6 +61,11 @@ const TraitsOverlay = dynamic(
   { ssr: false }
 );
 
+const WelcomeDialog = dynamic(
+  () => import('@/components/sanctuary/overlays/WelcomeDialog'),
+  { ssr: false }
+);
+
 const DevMapEditor = dynamic(
   () => import('@/components/sanctuary/DevMapEditor'),
   { ssr: false }
@@ -144,6 +149,7 @@ export default function SanctuaryV2() {
         <QuestTracker walletAddress={address} tokenId={activeTokenId} />
         <JournalOverlay walletAddress={address} tokenId={activeTokenId} />
         <TraitsOverlay walletAddress={address} tokenId={activeTokenId} />
+        <WelcomeDialog walletAddress={address} />
         <ChatBubble />
         <ChatInput />
         {editMode && <DevMapEditor />}

--- a/components/sanctuary/overlays/QuestDialog.tsx
+++ b/components/sanctuary/overlays/QuestDialog.tsx
@@ -74,8 +74,7 @@ export default function QuestDialog({
 
   const handleNPCClick = useCallback(
     (payload: NPCClickPayload) => {
-      if (payload.npcId === 'quest-board') {
-        EventBus.emit('quest-board-open');
+      if (payload.npcId === 'spawn-fox') {
         return;
       }
       setNpc(payload);

--- a/components/sanctuary/overlays/WelcomeDialog.tsx
+++ b/components/sanctuary/overlays/WelcomeDialog.tsx
@@ -1,0 +1,297 @@
+'use client';
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import EventBus from '@/components/sanctuary/EventBus';
+import { getWalletAuthHeader } from '@/lib/clientWalletAuth';
+
+interface NPCClickPayload {
+  npcId: string;
+  npcName: string;
+  zone: string;
+  dialogue: string;
+  screenX: number;
+  screenY: number;
+}
+
+interface PlayerState {
+  wallet_address: string;
+  intro_completed: number;
+  first_visit_at: string;
+  last_visit_at: string;
+  total_visits: number;
+}
+
+const INTRO_PAGES: Array<{ title: string; body: string }> = [
+  {
+    title: 'Welcome to the Sanctuary',
+    body: "I'm Spawn Fox, the keeper of this Town Square. The stars have been waiting for a traveler like you. Let me show you the essentials before you wander.",
+  },
+  {
+    title: 'Moving around',
+    body: 'Use WASD or the arrow keys to walk. You can also click anywhere on the map to path-find there. Hold direction keys for steady movement — your companion will follow.',
+  },
+  {
+    title: 'Exploring rooms',
+    body: 'Doorways glow when you step near them. Press [E] to enter a room — Observatory, Hot Springs, Training Grounds, and more each have their own keeper and quests.',
+  },
+  {
+    title: 'Your companion',
+    body: 'Click your Skrumpey companion at any time to open the radial menu — feed, pet, talk, send on activities, or review its journal and traits. Hotkeys: [J] journal, [T] traits.',
+  },
+  {
+    title: 'Ready to begin',
+    body: "Come back to me any time if you need a reminder. The Sanctuary is yours to explore — may the stars guide you.",
+  },
+];
+
+const HELP_DIALOGUE = {
+  title: 'Need a reminder?',
+  body: 'WASD or click to move. [E] at doors to enter rooms. [J] journal, [T] traits. Click your companion for the radial menu. Safe travels.',
+};
+
+export default function WelcomeDialog({
+  walletAddress,
+}: {
+  walletAddress: string | undefined;
+}) {
+  const [visible, setVisible] = useState(false);
+  const [state, setState] = useState<PlayerState | null>(null);
+  const [page, setPage] = useState(0);
+  const [saving, setSaving] = useState(false);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const hasMarkedVisitRef = useRef(false);
+
+  const loadState = useCallback(async (): Promise<PlayerState | null> => {
+    if (!walletAddress) return null;
+    try {
+      const res = await fetch(
+        `/api/sanctuary/player-state?address=${walletAddress}`
+      );
+      const data = await res.json();
+      if (data.success) return data.state as PlayerState | null;
+    } catch {
+      // Non-critical
+    }
+    return null;
+  }, [walletAddress]);
+
+  useEffect(() => {
+    if (!walletAddress || hasMarkedVisitRef.current) return;
+    hasMarkedVisitRef.current = true;
+    let cancelled = false;
+
+    (async () => {
+      const authHeader = await getWalletAuthHeader(walletAddress);
+      if (!authHeader || cancelled) return;
+      try {
+        const res = await fetch('/api/sanctuary/player-state', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-wallet-auth': authHeader,
+          },
+          body: JSON.stringify({ address: walletAddress, action: 'visit' }),
+        });
+        const data = await res.json();
+        if (!cancelled && data.success) {
+          setState(data.state as PlayerState);
+          if (data.state && !data.state.intro_completed) {
+            setVisible(true);
+            setPage(0);
+          }
+        }
+      } catch {
+        // Non-critical
+      }
+    })();
+
+    return () => { cancelled = true; };
+  }, [walletAddress]);
+
+  const handleNPCClick = useCallback(
+    async (payload: NPCClickPayload) => {
+      if (payload.npcId !== 'spawn-fox') return;
+      const latest = await loadState();
+      if (latest) setState(latest);
+      setPage(0);
+      setVisible(true);
+    },
+    [loadState]
+  );
+
+  useEffect(() => {
+    EventBus.on('npc-clicked', handleNPCClick);
+    return () => {
+      EventBus.off('npc-clicked', handleNPCClick);
+    };
+  }, [handleNPCClick]);
+
+  const close = useCallback(() => {
+    setVisible(false);
+  }, []);
+
+  const finishIntro = useCallback(async () => {
+    if (!walletAddress) {
+      close();
+      return;
+    }
+    setSaving(true);
+    try {
+      const authHeader = await getWalletAuthHeader(walletAddress);
+      if (!authHeader) {
+        close();
+        return;
+      }
+      const res = await fetch('/api/sanctuary/player-state', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-wallet-auth': authHeader,
+        },
+        body: JSON.stringify({ address: walletAddress, action: 'complete-intro' }),
+      });
+      const data = await res.json();
+      if (data.success && data.state) setState(data.state as PlayerState);
+    } catch {
+      // Non-critical; close anyway
+    } finally {
+      setSaving(false);
+      close();
+    }
+  }, [walletAddress, close]);
+
+  useEffect(() => {
+    if (!visible) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        if (state?.intro_completed) close();
+      }
+    };
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && state?.intro_completed) close();
+    };
+    const timer = setTimeout(() => {
+      document.addEventListener('mousedown', handleClickOutside);
+      document.addEventListener('keydown', handleKey);
+    }, 50);
+    return () => {
+      clearTimeout(timer);
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleKey);
+    };
+  }, [visible, close, state?.intro_completed]);
+
+  if (!visible) return null;
+
+  const introDone = !!state?.intro_completed;
+  const currentPage = INTRO_PAGES[page] ?? INTRO_PAGES[0];
+  const isLastPage = page >= INTRO_PAGES.length - 1;
+
+  return (
+    <div className="absolute inset-0 z-50 pointer-events-none">
+      <div className="absolute inset-0 bg-black/40 pointer-events-auto" aria-hidden />
+      <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+        <div
+          ref={panelRef}
+          className="w-[min(440px,90vw)] pointer-events-auto
+            bg-black/95 border border-[#ffd700]/40 rounded-lg shadow-[0_0_24px_rgba(255,215,0,0.25)]"
+          role="dialog"
+          aria-label="Spawn Fox welcome"
+        >
+          <div className="flex items-center justify-between border-b border-[#ffd700]/20 px-4 py-3">
+            <div className="flex items-center gap-2">
+              <span className="text-lg" aria-hidden>🦊</span>
+              <div>
+                <h3 className="text-[#ffd700] font-['Press_Start_2P'] text-[10px]">
+                  Spawn Fox
+                </h3>
+                <span className="text-gray-500 text-[7px]">Town Square</span>
+              </div>
+            </div>
+            {introDone && (
+              <button
+                onClick={close}
+                className="text-gray-500 hover:text-white text-sm transition-colors"
+                aria-label="Close dialog"
+              >
+                ✕
+              </button>
+            )}
+          </div>
+
+          <div className="p-4 space-y-3 min-h-[120px]">
+            {!introDone ? (
+              <>
+                <h4 className="text-[#00f7ff] font-['Press_Start_2P'] text-[9px]">
+                  {currentPage.title}
+                </h4>
+                <p className="text-gray-200 text-[11px] leading-relaxed">
+                  {currentPage.body}
+                </p>
+                <div className="flex items-center gap-1 pt-1">
+                  {INTRO_PAGES.map((_, i) => (
+                    <span
+                      key={i}
+                      className={`h-1.5 w-4 rounded-full transition-colors ${
+                        i === page ? 'bg-[#ffd700]' : 'bg-[#ffd700]/20'
+                      }`}
+                    />
+                  ))}
+                </div>
+              </>
+            ) : (
+              <>
+                <h4 className="text-[#00f7ff] font-['Press_Start_2P'] text-[9px]">
+                  {HELP_DIALOGUE.title}
+                </h4>
+                <p className="text-gray-200 text-[11px] leading-relaxed">
+                  {HELP_DIALOGUE.body}
+                </p>
+              </>
+            )}
+          </div>
+
+          <div className="flex items-center justify-between border-t border-[#ffd700]/20 px-4 py-3">
+            {!introDone ? (
+              <>
+                <button
+                  onClick={() => setPage((p) => Math.max(0, p - 1))}
+                  disabled={page === 0}
+                  className="px-3 py-1.5 text-[8px] font-['Press_Start_2P'] text-gray-400 hover:text-white disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                >
+                  BACK
+                </button>
+                <span className="text-gray-600 text-[7px]">
+                  {page + 1} / {INTRO_PAGES.length}
+                </span>
+                {isLastPage ? (
+                  <button
+                    onClick={finishIntro}
+                    disabled={saving}
+                    className="px-3 py-1.5 text-[8px] font-['Press_Start_2P'] text-[#ffd700] bg-[#ffd700]/10 border border-[#ffd700]/40 rounded hover:bg-[#ffd700]/20 disabled:opacity-40 transition-colors"
+                  >
+                    {saving ? '...' : 'BEGIN'}
+                  </button>
+                ) : (
+                  <button
+                    onClick={() => setPage((p) => Math.min(INTRO_PAGES.length - 1, p + 1))}
+                    className="px-3 py-1.5 text-[8px] font-['Press_Start_2P'] text-[#ffd700] bg-[#ffd700]/10 border border-[#ffd700]/40 rounded hover:bg-[#ffd700]/20 transition-colors"
+                  >
+                    NEXT
+                  </button>
+                )}
+              </>
+            ) : (
+              <button
+                onClick={close}
+                className="ml-auto px-3 py-1.5 text-[8px] font-['Press_Start_2P'] text-[#ffd700] bg-[#ffd700]/10 border border-[#ffd700]/40 rounded hover:bg-[#ffd700]/20 transition-colors"
+              >
+                CLOSE
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/game/config/npcDefinitions.ts
+++ b/game/config/npcDefinitions.ts
@@ -1,4 +1,4 @@
-import { WORLD_WIDTH, WORLD_HEIGHT } from './worldLayout';
+import { WORLD_WIDTH, WORLD_HEIGHT, SPAWN } from './worldLayout';
 
 export interface NPCDefinition {
   id: string;
@@ -9,18 +9,20 @@ export interface NPCDefinition {
   dialogue: string;
   spriteColor: number;
   spriteFile?: string;
+  kind?: 'quest' | 'intro';
 }
 
 export const NPC_DEFINITIONS: NPCDefinition[] = [
   {
-    id: 'quest-board',
+    id: 'spawn-fox',
     name: 'Spawn Fox',
-    x: Math.round(0.5 * WORLD_WIDTH),
-    y: Math.round(0.48 * WORLD_HEIGHT) + 80,
+    x: SPAWN.x + 32,
+    y: SPAWN.y,
     zone: 'Town Square',
-    dialogue: 'View all available quests.',
+    dialogue: 'Welcome to the Sanctuary, traveler.',
     spriteColor: 0xffd700,
     spriteFile: 'Spawn_Fox_Sprite.png',
+    kind: 'intro',
   },
   {
     id: 'npc-hot-springs',

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -5766,6 +5766,11 @@ function initializeSanctuary(database: Database.Database): void {
     const sql = fs.readFileSync(v15Path, 'utf-8');
     database.exec(sql);
   }
+  const v16Path = path.join(process.cwd(), 'scripts', 'init-sanctuary-v1.6.sql');
+  if (fs.existsSync(v16Path)) {
+    const sql = fs.readFileSync(v16Path, 'utf-8');
+    database.exec(sql);
+  }
   const rateLimitPath = path.join(process.cwd(), 'scripts', 'init-sanctuary-rate-limits.sql');
   if (fs.existsSync(rateLimitPath)) {
     const sql = fs.readFileSync(rateLimitPath, 'utf-8');
@@ -6304,6 +6309,52 @@ export function getSanctuaryState(walletAddress: string): {
     : [];
 
   return { activeCompanion, companions, recentJournal };
+}
+
+export interface SanctuaryPlayerState {
+  wallet_address: string;
+  intro_completed: number;
+  first_visit_at: string;
+  last_visit_at: string;
+  total_visits: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export function getPlayerState(walletAddress: string): SanctuaryPlayerState | null {
+  const addr = walletAddress.toLowerCase();
+  const db = getDatabase();
+  const row = db
+    .prepare('SELECT * FROM sanctuary_player_state WHERE wallet_address = ?')
+    .get(addr) as SanctuaryPlayerState | undefined;
+  return row ?? null;
+}
+
+export function upsertPlayerVisit(walletAddress: string): SanctuaryPlayerState {
+  const addr = walletAddress.toLowerCase();
+  const db = getDatabase();
+  db.prepare(`
+    INSERT INTO sanctuary_player_state (wallet_address, intro_completed, total_visits)
+    VALUES (?, 0, 1)
+    ON CONFLICT(wallet_address) DO UPDATE SET
+      last_visit_at = CURRENT_TIMESTAMP,
+      total_visits = total_visits + 1,
+      updated_at = CURRENT_TIMESTAMP
+  `).run(addr);
+  return getPlayerState(addr) as SanctuaryPlayerState;
+}
+
+export function markIntroCompleted(walletAddress: string): SanctuaryPlayerState {
+  const addr = walletAddress.toLowerCase();
+  const db = getDatabase();
+  db.prepare(`
+    INSERT INTO sanctuary_player_state (wallet_address, intro_completed)
+    VALUES (?, 1)
+    ON CONFLICT(wallet_address) DO UPDATE SET
+      intro_completed = 1,
+      updated_at = CURRENT_TIMESTAMP
+  `).run(addr);
+  return getPlayerState(addr) as SanctuaryPlayerState;
 }
 
 // Expedition stubs — tables exist but functions not yet implemented

--- a/lib/sanctuary/__tests__/db.test.ts
+++ b/lib/sanctuary/__tests__/db.test.ts
@@ -41,6 +41,11 @@ function createTestDb(): Database.Database {
   );
   db.exec(sanctuarySql);
 
+  const v16Path = path.join(process.cwd(), 'scripts', 'init-sanctuary-v1.6.sql');
+  if (fs.existsSync(v16Path)) {
+    db.exec(fs.readFileSync(v16Path, 'utf-8'));
+  }
+
   db.prepare('INSERT INTO star_skrumpey_metadata (token_id, name, constellation, aura, form, mood) VALUES (?, ?, ?, ?, ?, ?)')
     .run(3, 'Star #3', 'aether', 'mystic', 'classic', 'happy');
   db.prepare('INSERT INTO star_skrumpey_metadata (token_id, name, constellation, aura, form, mood) VALUES (?, ?, ?, ?, ?, ?)')
@@ -434,5 +439,97 @@ describe('Send to Activity', () => {
     expect(rows.length).toBe(1);
     expect(rows[0].current_activity).toBe('exploring:Training Grounds');
     expect(rows[0].token_id).toBe(3);
+  });
+});
+
+describe('Sanctuary Player State (v1.6)', () => {
+  let db: Database.Database;
+
+  beforeAll(() => {
+    db = createTestDb();
+  });
+
+  it('creates sanctuary_player_state table', () => {
+    const tables = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='sanctuary_player_state'")
+      .all() as { name: string }[];
+    expect(tables.length).toBe(1);
+  });
+
+  it('upsert marks new visits with intro_completed=0 by default', () => {
+    db.prepare(`
+      INSERT INTO sanctuary_player_state (wallet_address, intro_completed, total_visits)
+      VALUES (?, 0, 1)
+      ON CONFLICT(wallet_address) DO UPDATE SET
+        last_visit_at = CURRENT_TIMESTAMP,
+        total_visits = total_visits + 1,
+        updated_at = CURRENT_TIMESTAMP
+    `).run('0xfresh');
+
+    const row = db
+      .prepare('SELECT * FROM sanctuary_player_state WHERE wallet_address = ?')
+      .get('0xfresh') as any;
+    expect(row).toBeTruthy();
+    expect(row.intro_completed).toBe(0);
+    expect(row.total_visits).toBe(1);
+  });
+
+  it('subsequent visits increment total_visits without resetting intro', () => {
+    const upsert = db.prepare(`
+      INSERT INTO sanctuary_player_state (wallet_address, intro_completed, total_visits)
+      VALUES (?, 0, 1)
+      ON CONFLICT(wallet_address) DO UPDATE SET
+        last_visit_at = CURRENT_TIMESTAMP,
+        total_visits = total_visits + 1,
+        updated_at = CURRENT_TIMESTAMP
+    `);
+    upsert.run('0xvisitor');
+    db.prepare('UPDATE sanctuary_player_state SET intro_completed = 1 WHERE wallet_address = ?')
+      .run('0xvisitor');
+    upsert.run('0xvisitor');
+    upsert.run('0xvisitor');
+
+    const row = db
+      .prepare('SELECT * FROM sanctuary_player_state WHERE wallet_address = ?')
+      .get('0xvisitor') as any;
+    expect(row.intro_completed).toBe(1);
+    expect(row.total_visits).toBe(3);
+  });
+
+  it('mark-intro-completed upserts idempotently', () => {
+    const mark = db.prepare(`
+      INSERT INTO sanctuary_player_state (wallet_address, intro_completed)
+      VALUES (?, 1)
+      ON CONFLICT(wallet_address) DO UPDATE SET
+        intro_completed = 1,
+        updated_at = CURRENT_TIMESTAMP
+    `);
+    mark.run('0xnewcomer');
+    mark.run('0xnewcomer');
+
+    const rows = db
+      .prepare('SELECT * FROM sanctuary_player_state WHERE wallet_address = ?')
+      .all('0xnewcomer') as any[];
+    expect(rows.length).toBe(1);
+    expect(rows[0].intro_completed).toBe(1);
+  });
+
+  it('different wallets have independent intro state', () => {
+    db.prepare(`
+      INSERT INTO sanctuary_player_state (wallet_address, intro_completed)
+      VALUES (?, 1)
+      ON CONFLICT(wallet_address) DO UPDATE SET intro_completed = 1
+    `).run('0xdone');
+
+    db.prepare(`
+      INSERT INTO sanctuary_player_state (wallet_address, intro_completed)
+      VALUES (?, 0)
+      ON CONFLICT(wallet_address) DO NOTHING
+    `).run('0xnew');
+
+    const done = db.prepare('SELECT intro_completed FROM sanctuary_player_state WHERE wallet_address = ?').get('0xdone') as any;
+    const fresh = db.prepare('SELECT intro_completed FROM sanctuary_player_state WHERE wallet_address = ?').get('0xnew') as any;
+    expect(done.intro_completed).toBe(1);
+    expect(fresh.intro_completed).toBe(0);
   });
 });

--- a/scripts/init-sanctuary-v1.6.sql
+++ b/scripts/init-sanctuary-v1.6.sql
@@ -1,0 +1,16 @@
+-- Star Sanctuary — V1.6 Schema: Per-wallet player state (intro dialog, tutorial flags)
+-- Run from lib/db.ts initializeSanctuary()
+
+-- Per-wallet persistent player state (not tied to any specific companion/token)
+CREATE TABLE IF NOT EXISTS sanctuary_player_state (
+  wallet_address TEXT PRIMARY KEY,
+  intro_completed INTEGER NOT NULL DEFAULT 0,
+  first_visit_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  last_visit_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  total_visits INTEGER NOT NULL DEFAULT 1,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_sanctuary_player_state_intro
+  ON sanctuary_player_state(wallet_address, intro_completed);


### PR DESCRIPTION
## Summary

- Place Spawn Fox NPC (`spawn-fox`) near the player spawn at (724, 700) in Town Square
- First-time-per-wallet welcome flow: 5-page intro teaching WASD/click-to-move, `[E]` to enter rooms, companion radial, and `[J]`/`[T]` hotkeys
- Return visits show a short help dialog
- Persists state in new `sanctuary_player_state` table (v1.6 migration) keyed by wallet
- New API: `GET/POST /api/sanctuary/player-state` (visit / complete-intro actions)
- QuestDialog now ignores `spawn-fox` clicks so WelcomeDialog owns them; quest board still opens from the QuestTracker HUD button

## Changes

- `scripts/init-sanctuary-v1.6.sql` — new table
- `lib/db.ts` — `getPlayerState`, `upsertPlayerVisit`, `markIntroCompleted`; wire v1.6 into `initializeSanctuary`
- `app/api/sanctuary/player-state/route.ts` — GET + POST with `x-wallet-auth` on writes
- `game/config/npcDefinitions.ts` — id renamed `quest-board` → `spawn-fox`, moved to `SPAWN.x + 32`, `SPAWN.y`, added optional `kind` field
- `components/sanctuary/overlays/WelcomeDialog.tsx` — new overlay; auto-opens on first visit per wallet, reopens on NPC click
- `components/sanctuary/overlays/QuestDialog.tsx` — skip `spawn-fox` clicks
- `app/sanctuary/SanctuaryV2.tsx` — mount `WelcomeDialog`
- `lib/sanctuary/__tests__/db.test.ts` — 5 new tests for player state

## Test plan

- [x] `npx vitest run lib/sanctuary/__tests__/db.test.ts` — 30 pass (5 new)
- [x] `npx tsc --noEmit` — clean
- [x] `eslint` — clean on all new/modified app-code files (test file matches pre-existing `any` style)
- [ ] Manual: connect fresh wallet → walk into sanctuary → intro auto-opens; step through pages → `BEGIN` closes and persists; reload → help dialog appears when clicking Spawn Fox

Depends on `[SWO_P0_NPC_REAL_SPRITES]` (already merged) for `Spawn_Fox_Sprite.png` pipeline.