### PR TITLE
feat: themed NPC placed inside each sanctuary room

### DIFF
--- a/game/config/npcDefinitions.ts
+++ b/game/config/npcDefinitions.ts
@@ -1,4 +1,10 @@
-import { WORLD_WIDTH, WORLD_HEIGHT } from './worldLayout';
+import { WORLD_WIDTH, WORLD_HEIGHT, type RoomKey } from './worldLayout';
+
+export interface RoomPlacement {
+  room: RoomKey;
+  x: number;
+  y: number;
+}
 
 export interface NPCDefinition {
   id: string;
@@ -9,6 +15,7 @@ export interface NPCDefinition {
   dialogue: string;
   spriteColor: number;
   spriteFile?: string;
+  roomPlacement?: RoomPlacement;
 }
 
 export const NPC_DEFINITIONS: NPCDefinition[] = [
@@ -31,6 +38,7 @@ export const NPC_DEFINITIONS: NPCDefinition[] = [
     dialogue: 'The warm waters reveal hidden truths...',
     spriteColor: 0xff6644,
     spriteFile: 'Springs_Duck_Sprite.png',
+    roomPlacement: { room: 'Hot Springs', x: 640, y: 480 },
   },
   {
     id: 'npc-training-grounds',
@@ -41,6 +49,7 @@ export const NPC_DEFINITIONS: NPCDefinition[] = [
     dialogue: 'Strength is forged through perseverance.',
     spriteColor: 0x44aaff,
     spriteFile: 'Training_Wolf_Sprite.png',
+    roomPlacement: { room: 'Training Grounds', x: 800, y: 500 },
   },
   {
     id: 'npc-dream-hollow',
@@ -51,6 +60,7 @@ export const NPC_DEFINITIONS: NPCDefinition[] = [
     dialogue: 'Dreams shape reality, if you let them...',
     spriteColor: 0xcc66ff,
     spriteFile: 'Dream_Sheep_Sprite.png',
+    roomPlacement: { room: 'Dream Hollow', x: 620, y: 520 },
   },
   {
     id: 'npc-star-garden',
@@ -61,6 +71,7 @@ export const NPC_DEFINITIONS: NPCDefinition[] = [
     dialogue: 'Every star seed needs patience to bloom.',
     spriteColor: 0x66ff88,
     spriteFile: 'Garden_Ent_Sprite.png',
+    roomPlacement: { room: 'Star Garden', x: 724, y: 460 },
   },
   {
     id: 'npc-nebula-kitchen',
@@ -71,6 +82,7 @@ export const NPC_DEFINITIONS: NPCDefinition[] = [
     dialogue: 'Cosmic cuisine fuels the soul!',
     spriteColor: 0xffaa44,
     spriteFile: 'Kitchen_Bunny_Sprite.png',
+    roomPlacement: { room: 'Nebula Kitchen', x: 680, y: 500 },
   },
   {
     id: 'npc-cosmic-library',
@@ -81,6 +93,7 @@ export const NPC_DEFINITIONS: NPCDefinition[] = [
     dialogue: 'Knowledge is the oldest form of power.',
     spriteColor: 0x8866ff,
     spriteFile: 'Hollow_moth_Sprite.png',
+    roomPlacement: { room: 'Cosmic Library', x: 760, y: 480 },
   },
   {
     id: 'npc-observatory',
@@ -91,6 +104,7 @@ export const NPC_DEFINITIONS: NPCDefinition[] = [
     dialogue: 'The stars whisper secrets to those who listen.',
     spriteColor: 0xffffaa,
     spriteFile: 'Observatory_Owl_Sprite.png',
+    roomPlacement: { room: 'Observatory', x: 720, y: 440 },
   },
   {
     id: 'npc-aura-forge',
@@ -101,8 +115,17 @@ export const NPC_DEFINITIONS: NPCDefinition[] = [
     dialogue: 'Auras are shaped in fire and will.',
     spriteColor: 0xff4466,
     spriteFile: 'Aura_Golem_Sprite.png',
+    roomPlacement: { room: 'Aura Forge', x: 780, y: 500 },
   },
 ];
+
+export function getRoomNPCDefinitions(room: RoomKey): NPCDefinition[] {
+  return NPC_DEFINITIONS.filter((n) => n.roomPlacement?.room === room).map((n) => ({
+    ...n,
+    x: n.roomPlacement!.x,
+    y: n.roomPlacement!.y,
+  }));
+}
 
 export function npcSpriteTextureKey(id: string): string {
   return `npc-sprite-${id}`;

--- a/game/scenes/RoomScene.ts
+++ b/game/scenes/RoomScene.ts
@@ -3,9 +3,11 @@ import * as EasyStar from 'easystarjs';
 import EventBus from '@/components/sanctuary/EventBus';
 import { PlayerSprite } from '../sprites/PlayerSprite';
 import { CompanionSprite } from '../sprites/CompanionSprite';
+import { NPCManager } from '../sprites/NPCSprite';
 import { AnimationSystem } from '../systems/AnimationSystem';
 import { NAV_CELL, type RoomKey } from '../config/worldLayout';
 import { getRoomLayout } from '../config/roomLayouts';
+import { getRoomNPCDefinitions } from '../config/npcDefinitions';
 
 const ROOM_W = 1448;
 const ROOM_H = 1086;
@@ -26,6 +28,7 @@ export class RoomScene extends Phaser.Scene {
   private collisionGroup!: Phaser.Physics.Arcade.StaticGroup;
   private clickMarker: Phaser.GameObjects.Graphics | null = null;
   private exiting = false;
+  private npcManager: NPCManager | null = null;
 
   constructor() {
     super({ key: 'RoomScene' });
@@ -67,6 +70,7 @@ export class RoomScene extends Phaser.Scene {
     this.setupClickToMove();
     this.setupExitZone();
     this.setupHUD();
+    this.setupNPCs();
 
     this.input.keyboard!.on('keydown-ESC', () => this.exit());
     this.input.keyboard!.on('keydown-E', () => this.exit());
@@ -171,6 +175,12 @@ export class RoomScene extends Phaser.Scene {
     void hint;
   }
 
+  private setupNPCs() {
+    const defs = getRoomNPCDefinitions(this.room);
+    if (defs.length === 0) return;
+    this.npcManager = new NPCManager(this, defs);
+  }
+
   private setupHUD() {
     const screenW = this.scale.width;
     this.add
@@ -193,6 +203,7 @@ export class RoomScene extends Phaser.Scene {
     const keyboardActive = this.player.handleKeyboardInput();
     if (!keyboardActive) this.player.updatePathMovement();
     this.companion.followPlayer(this.player.x, this.player.y, this.player.getDirection());
+    this.npcManager?.update(this.time.now);
   }
 
   private exit() {
@@ -202,5 +213,10 @@ export class RoomScene extends Phaser.Scene {
     this.time.delayedCall(260, () => {
       EventBus.emit('room-exit', { returnTo: this.returnTo });
     });
+  }
+
+  shutdown() {
+    this.npcManager?.destroy();
+    this.npcManager = null;
   }
 }


### PR DESCRIPTION
## Summary
- Adds `roomPlacement: { room, x, y }` to `NPCDefinition` for each of the 8 themed NPCs (Springs Duck → Hot Springs, Observatory Owl → Observatory, Training Wolf → Training Grounds, Kitchen Bunny → Nebula Kitchen, Garden Ent → Star Garden, Hollow Moth → Cosmic Library, Dream Sheep → Dream Hollow, Aura Golem → Aura Forge).
- New helper `getRoomNPCDefinitions(room)` in `game/config/npcDefinitions.ts` returns that room's NPCs with their x/y remapped to in-room coordinates.
- `RoomScene.ts` instantiates `NPCManager` with the per-room definitions, drives its `update(time)` each frame, and tears it down on scene shutdown.

## Interactivity
Click-to-talk already wired globally: `NPCSprite` emits the existing `npc-clicked` EventBus event (consumed by `components/sanctuary/overlays/QuestDialog.tsx`). Rendering NPCs in `RoomScene` reuses that flow — no new handler code required. Hooks for future quest/minigame triggers are available via the existing `setQuestAvailable` / `setQuestIndicators` API on `NPCManager`.

## Test plan
- [x] `npm run type-check` → 0 errors
- [x] `npm run lint` → no new errors in changed files (baseline 67 pre-existing, unchanged)
- [x] `npm run build` → compiled successfully
- [x] `npm run test` → 270/274 pass (4 pre-existing `api-e2e` failures unrelated to this change)
- [ ] Manual: enter each of the 8 rooms, confirm the correct themed NPC appears, click to open dialog, `[E]`/`ESC` to exit

## Mirror Validation (PROD)
Skipped overlay: PROD mirror is behind dev — `/opt/star_world_order/PROD/game/` contains only `systems/`, missing `game/config/`, `game/scenes/`, and `game/sprites/` entirely. Overlaying just my two changed files would introduce many spurious "new" errors from unresolved imports (e.g., `./worldLayout`, `../sprites/NPCSprite`) that are structural to the dev branch, not caused by this PR. The soft baseline-diff gate in post-spawn can perform the proper full-branch comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)