### PR TITLE
feat(sanctuary): Quest Board as central quest aggregator with door navigation

### DIFF
--- a/components/sanctuary/overlays/QuestBoard.tsx
+++ b/components/sanctuary/overlays/QuestBoard.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import EventBus from '@/components/sanctuary/EventBus';
 import { getWalletAuthHeader } from '@/lib/clientWalletAuth';
+import { getQuestSource, type QuestSource } from '@/game/config/questSourceMap';
 
 interface Quest {
   id: number;
@@ -22,20 +23,53 @@ interface Quest {
   } | null;
 }
 
-type TabFilter = 'all' | 'daily' | 'weekly' | 'seasonal';
+interface NPCClickPayload {
+  npcId: string;
+  npcName: string;
+  zone: string;
+  dialogue: string;
+  screenX: number;
+  screenY: number;
+}
+
+type TabFilter = 'all' | 'room' | 'daily' | 'weekly';
 
 const QUEST_TYPE_BADGE: Record<string, { label: string; color: string }> = {
   daily: { label: 'DAILY', color: '#44ff88' },
   weekly: { label: 'WEEKLY', color: '#66bbff' },
-  seasonal: { label: 'SEASONAL', color: '#ffd700' },
+  seasonal: { label: 'SEASON', color: '#ffd700' },
 };
 
 const TABS: { key: TabFilter; label: string }[] = [
   { key: 'all', label: 'ALL' },
+  { key: 'room', label: 'ROOM' },
   { key: 'daily', label: 'DAILY' },
   { key: 'weekly', label: 'WEEKLY' },
-  { key: 'seasonal', label: 'SEASON' },
 ];
+
+interface QuestWithSource extends Quest {
+  source: QuestSource;
+}
+
+interface QuestGroup {
+  key: string;
+  source: QuestSource;
+  quests: QuestWithSource[];
+}
+
+function groupBySource(quests: QuestWithSource[]): QuestGroup[] {
+  const map = new Map<string, QuestGroup>();
+  for (const quest of quests) {
+    const key = quest.source.npcId;
+    const existing = map.get(key);
+    if (existing) {
+      existing.quests.push(quest);
+    } else {
+      map.set(key, { key, source: quest.source, quests: [quest] });
+    }
+  }
+  return Array.from(map.values());
+}
 
 export default function QuestBoard({
   walletAddress,
@@ -74,9 +108,16 @@ export default function QuestBoard({
       setOpen(true);
       loadQuests();
     };
+    const handleNPCClick = (payload: NPCClickPayload) => {
+      if (payload.npcId !== 'quest-board') return;
+      setOpen(true);
+      loadQuests();
+    };
     EventBus.on('quest-board-open', handleOpen);
+    EventBus.on('npc-clicked', handleNPCClick);
     return () => {
       EventBus.off('quest-board-open', handleOpen);
+      EventBus.off('npc-clicked', handleNPCClick);
     };
   }, [loadQuests]);
 
@@ -132,18 +173,51 @@ export default function QuestBoard({
     [walletAddress, tokenId, loadQuests]
   );
 
-  if (!open) return null;
+  const navigateToRoom = useCallback(
+    (room: string) => {
+      EventBus.emit('highlight-door', { room });
+      close();
+    },
+    [close]
+  );
 
-  const filtered = tab === 'all' ? quests : quests.filter((q) => q.quest_type === tab);
-  const active = filtered.filter((q) => !q.progress?.completed);
+  const questsWithSource = useMemo<QuestWithSource[]>(
+    () =>
+      quests.map((q) => ({
+        ...q,
+        source: getQuestSource(q.requirement_type),
+      })),
+    [quests]
+  );
+
+  const filtered = useMemo<QuestWithSource[]>(() => {
+    switch (tab) {
+      case 'room':
+        return questsWithSource.filter((q) => q.source.room !== null);
+      case 'daily':
+        return questsWithSource.filter((q) => q.quest_type === 'daily');
+      case 'weekly':
+        return questsWithSource.filter((q) => q.quest_type === 'weekly');
+      case 'all':
+      default:
+        return questsWithSource;
+    }
+  }, [questsWithSource, tab]);
+
+  const activeGroups = useMemo(
+    () => groupBySource(filtered.filter((q) => !q.progress?.completed)),
+    [filtered]
+  );
   const completed = filtered.filter((q) => q.progress?.completed);
   const totalCompleted = quests.filter((q) => q.progress?.completed).length;
+
+  if (!open) return null;
 
   return (
     <div className="absolute inset-0 z-40 flex items-center justify-center pointer-events-none">
       <div
         ref={panelRef}
-        className={`w-80 max-h-[85%] overflow-hidden flex flex-col pointer-events-auto
+        className={`w-96 max-h-[85%] overflow-hidden flex flex-col pointer-events-auto
           bg-black/95 border border-[#ffd700]/40 rounded-lg shadow-[0_0_25px_rgba(255,215,0,0.15)]
           transition-all duration-200 ${
             open ? 'opacity-100 scale-100' : 'opacity-0 scale-95'
@@ -165,6 +239,7 @@ export default function QuestBoard({
               <button
                 onClick={close}
                 className="text-gray-500 hover:text-white text-sm transition-colors"
+                aria-label="Close quest board"
               >
                 ✕
               </button>
@@ -190,25 +265,47 @@ export default function QuestBoard({
         </div>
 
         {/* Quest List */}
-        <div className="overflow-y-auto flex-1 p-3 space-y-2">
+        <div className="overflow-y-auto flex-1 p-3 space-y-3">
           {loading && (
             <p className="text-gray-500 text-[7px] text-center py-4">Loading quests...</p>
           )}
 
-          {!loading && active.length === 0 && completed.length === 0 && (
+          {!loading && activeGroups.length === 0 && completed.length === 0 && (
             <div className="text-center py-6 space-y-1">
               <p className="text-[#ffd700]/40 text-[12px]">🗺️</p>
-              <p className="text-gray-500 text-[8px]">No quests available.</p>
-              <p className="text-gray-600 text-[7px]">New quests appear each season!</p>
+              <p className="text-gray-500 text-[8px]">No quests in this category.</p>
+              <p className="text-gray-600 text-[7px]">Try a different tab!</p>
             </div>
           )}
 
-          {active.length > 0 && (
-            <div className="space-y-2">
-              <p className="text-gray-500 text-[6px] font-['Press_Start_2P'] tracking-wider">
-                ACTIVE
-              </p>
-              {active.map((quest) => {
+          {activeGroups.map((group) => (
+            <div key={group.key} className="space-y-1.5">
+              {/* Group header: NPC name + zone + Go button */}
+              <div className="flex items-center justify-between bg-[#0a0a15]/80 rounded px-2 py-1.5 border border-[#00f7ff]/20">
+                <div className="flex items-center gap-1.5 min-w-0">
+                  <span className="text-[9px]">🧙</span>
+                  <div className="min-w-0">
+                    <p className="text-[#00f7ff] text-[8px] font-['Press_Start_2P'] truncate">
+                      {group.source.npcName}
+                    </p>
+                    <p className="text-gray-500 text-[6px] truncate">{group.source.zone}</p>
+                  </div>
+                </div>
+                {group.source.room && (
+                  <button
+                    onClick={() => navigateToRoom(group.source.room as string)}
+                    className="px-2 py-1 text-[6px] font-['Press_Start_2P'] text-[#00f7ff]
+                      bg-[#00f7ff]/10 border border-[#00f7ff]/40 rounded
+                      hover:bg-[#00f7ff]/20 hover:shadow-[0_0_8px_#00f7ff] transition-all shrink-0 ml-2"
+                    title={`Highlight the door to ${group.source.room}`}
+                  >
+                    GO ▸
+                  </button>
+                )}
+              </div>
+
+              {/* Quests under this source */}
+              {group.quests.map((quest) => {
                 const badge =
                   QUEST_TYPE_BADGE[quest.quest_type] ?? QUEST_TYPE_BADGE.seasonal;
                 const current = quest.progress?.current_count ?? 0;
@@ -217,7 +314,7 @@ export default function QuestBoard({
                 return (
                   <div
                     key={quest.id}
-                    className="bg-[#0a0a15] rounded-lg border border-[#2a2a4e] p-3"
+                    className="bg-[#0a0a15] rounded-lg border border-[#2a2a4e] p-3 ml-3"
                   >
                     <div className="flex items-start justify-between mb-1">
                       <div>
@@ -265,7 +362,7 @@ export default function QuestBoard({
                 );
               })}
             </div>
-          )}
+          ))}
 
           {completed.length > 0 && (
             <div className="space-y-2">
@@ -287,6 +384,9 @@ export default function QuestBoard({
                       <div>
                         <span className="text-[8px] mr-1">✨</span>
                         <span className="text-white text-[8px]">{quest.title}</span>
+                        <span className="text-gray-600 text-[6px] ml-1.5">
+                          · {quest.source.npcName}
+                        </span>
                       </div>
                       {canClaim ? (
                         <button

--- a/components/sanctuary/overlays/QuestDialog.tsx
+++ b/components/sanctuary/overlays/QuestDialog.tsx
@@ -74,7 +74,7 @@ export default function QuestDialog({
 
   const handleNPCClick = useCallback(
     (payload: NPCClickPayload) => {
-      if (payload.npcId === 'spawn-fox') {
+      if (payload.npcId === 'spawn-fox' || payload.npcId === 'quest-board') {
         return;
       }
       setNpc(payload);

--- a/game/config/npcDefinitions.ts
+++ b/game/config/npcDefinitions.ts
@@ -16,7 +16,7 @@ export interface NPCDefinition {
   spriteColor: number;
   spriteFile?: string;
   roomPlacement?: RoomPlacement;
-  kind?: 'quest' | 'intro';
+  kind?: 'quest' | 'intro' | 'board';
 }
 
 export const NPC_DEFINITIONS: NPCDefinition[] = [
@@ -30,6 +30,16 @@ export const NPC_DEFINITIONS: NPCDefinition[] = [
     spriteColor: 0xffd700,
     spriteFile: 'Spawn_Fox_Sprite.png',
     kind: 'intro',
+  },
+  {
+    id: 'quest-board',
+    name: 'Quest Board',
+    x: SPAWN.x - 48,
+    y: SPAWN.y - 8,
+    zone: 'Town Square',
+    dialogue: 'Browse quests from every corner of the Sanctuary.',
+    spriteColor: 0x00f7ff,
+    kind: 'board',
   },
   {
     id: 'npc-hot-springs',

--- a/game/config/questSourceMap.ts
+++ b/game/config/questSourceMap.ts
@@ -1,0 +1,76 @@
+import type { RoomKey } from './worldLayout';
+
+export interface QuestSource {
+  npcId: string;
+  npcName: string;
+  zone: string;
+  room: RoomKey | null;
+}
+
+const SPAWN_FOX: QuestSource = {
+  npcId: 'spawn-fox',
+  npcName: 'Spawn Fox',
+  zone: 'Town Square',
+  room: null,
+};
+
+const QUEST_SOURCE_BY_REQUIREMENT: Record<string, QuestSource> = {
+  observatory: {
+    npcId: 'npc-observatory',
+    npcName: 'Astris',
+    zone: 'Observatory',
+    room: 'Observatory',
+  },
+  springs: {
+    npcId: 'npc-hot-springs',
+    npcName: 'Ember',
+    zone: 'Hot Springs',
+    room: 'Hot Springs',
+  },
+  training: {
+    npcId: 'npc-training-grounds',
+    npcName: 'Valor',
+    zone: 'Training Grounds',
+    room: 'Training Grounds',
+  },
+  dream: {
+    npcId: 'npc-dream-hollow',
+    npcName: 'Somnia',
+    zone: 'Dream Hollow',
+    room: 'Dream Hollow',
+  },
+  garden: {
+    npcId: 'npc-star-garden',
+    npcName: 'Flora',
+    zone: 'Star Garden',
+    room: 'Star Garden',
+  },
+  kitchen: {
+    npcId: 'npc-nebula-kitchen',
+    npcName: 'Chef Cosmo',
+    zone: 'Nebula Kitchen',
+    room: 'Nebula Kitchen',
+  },
+  library: {
+    npcId: 'npc-cosmic-library',
+    npcName: 'Lorekeeper',
+    zone: 'Cosmic Library',
+    room: 'Cosmic Library',
+  },
+  forge: {
+    npcId: 'npc-aura-forge',
+    npcName: 'Pyrix',
+    zone: 'Aura Forge',
+    room: 'Aura Forge',
+  },
+  interact: SPAWN_FOX,
+  feed: SPAWN_FOX,
+  chat: SPAWN_FOX,
+  explore: SPAWN_FOX,
+  bond_threshold: SPAWN_FOX,
+  daily_streak: SPAWN_FOX,
+};
+
+export function getQuestSource(requirementType: string): QuestSource {
+  return QUEST_SOURCE_BY_REQUIREMENT[requirementType] ?? SPAWN_FOX;
+}

--- a/game/scenes/WorldScene.ts
+++ b/game/scenes/WorldScene.ts
@@ -36,6 +36,10 @@ export class WorldScene extends Phaser.Scene {
   private editorCornerA: { x: number; y: number } | null = null;
   private currentDoor: Door | null = null;
   private doorPrompt: Phaser.GameObjects.Text | null = null;
+  private doorHighlightGfx: Phaser.GameObjects.Graphics | null = null;
+  private doorHighlightTarget: Door | null = null;
+  private doorHighlightUntil = 0;
+  private doorHighlightArrow: Phaser.GameObjects.Text | null = null;
   private interactKey!: Phaser.Input.Keyboard.Key;
   private otherPlayers!: OtherPlayersManager;
   private npcManager!: NPCManager;
@@ -197,6 +201,9 @@ export class WorldScene extends Phaser.Scene {
       if ((CONSTELLATIONS as readonly string[]).includes(lower)) this.companion.setConstellation(lower);
     });
     EventBus.on('editor-mode', (enabled: boolean) => this.setEditorMode(enabled));
+    EventBus.on('highlight-door', (data: { room: string }) => {
+      this.highlightDoor(data?.room);
+    });
     EventBus.on('room-exit', (data: { returnTo?: { x: number; y: number } }) => {
       if (this.scene.isSleeping()) {
         this.scene.stop('RoomScene');
@@ -229,6 +236,64 @@ export class WorldScene extends Phaser.Scene {
       .setOrigin(0.5, 1)
       .setDepth(30)
       .setVisible(false);
+    this.doorHighlightGfx = this.add.graphics().setDepth(29);
+    this.doorHighlightArrow = this.add
+      .text(0, 0, '▼', {
+        fontFamily: '"Press Start 2P", monospace',
+        fontSize: '10px',
+        color: '#00f7ff',
+        stroke: '#000000',
+        strokeThickness: 3,
+      })
+      .setOrigin(0.5, 1)
+      .setDepth(31)
+      .setVisible(false);
+  }
+
+  private highlightDoor(roomName: string | undefined) {
+    if (!roomName) return;
+    const door = DOORS.find((d) => d.room === roomName);
+    if (!door) return;
+    this.doorHighlightTarget = door;
+    this.doorHighlightUntil = this.time.now + 5000;
+    if (this.doorHighlightArrow) {
+      this.doorHighlightArrow.setVisible(true);
+    }
+  }
+
+  private updateDoorHighlight(time: number) {
+    if (!this.doorHighlightGfx) return;
+    if (!this.doorHighlightTarget || time > this.doorHighlightUntil) {
+      this.doorHighlightGfx.clear();
+      this.doorHighlightArrow?.setVisible(false);
+      this.doorHighlightTarget = null;
+      return;
+    }
+    const door = this.doorHighlightTarget;
+    const pulse = 0.4 + 0.6 * (0.5 + 0.5 * Math.sin(time * 0.006));
+    this.doorHighlightGfx.clear();
+    this.doorHighlightGfx.lineStyle(2, 0x00f7ff, pulse);
+    const pad = 4;
+    this.doorHighlightGfx.strokeRoundedRect(
+      door.x - pad,
+      door.y - pad,
+      door.w + pad * 2,
+      door.h + pad * 2,
+      4,
+    );
+    this.doorHighlightGfx.lineStyle(1, 0xffd700, pulse * 0.8);
+    this.doorHighlightGfx.strokeRoundedRect(
+      door.x - pad - 3,
+      door.y - pad - 3,
+      door.w + pad * 2 + 6,
+      door.h + pad * 2 + 6,
+      6,
+    );
+    if (this.doorHighlightArrow) {
+      const bob = Math.sin(time * 0.008) * 2;
+      this.doorHighlightArrow.setPosition(door.x + door.w / 2, door.y - 6 + bob);
+      this.doorHighlightArrow.setAlpha(pulse);
+    }
   }
 
   private updateDoorDetection() {
@@ -321,6 +386,7 @@ export class WorldScene extends Phaser.Scene {
     this.otherPlayers.update(this.cameras.main);
     this.npcManager.update(this.time.now);
     this.updateDoorDetection();
+    this.updateDoorHighlight(this.time.now);
 
     const cam = this.cameras.main;
     cameraState.viewX = cam.worldView.x;
@@ -349,6 +415,7 @@ export class WorldScene extends Phaser.Scene {
     EventBus.off('companion-mood');
     EventBus.off('companion-constellation');
     EventBus.off('editor-mode');
+    EventBus.off('highlight-door');
     EventBus.off('room-exit');
     EventBus.off('remote-player-add');
     EventBus.off('remote-player-remove');


### PR DESCRIPTION
## Summary

Enhances the Sanctuary V2 Quest Board overlay (`components/sanctuary/overlays/QuestBoard.tsx`) to act as a central, aggregated view of every available quest — grouped by the NPC/room that provides it, with a tab filter and a one-click navigation cue pointing the player at the right door.

### What changed

- **New Quest Board NPC in Town Square.** Added a `quest-board` entry in `game/config/npcDefinitions.ts` placed near the spawn. Clicking it opens the enhanced overlay. `QuestDialog` now skips it (same pattern as `spawn-fox`) so the click routes only to the board.
- **Tabs: All / Room / Daily / Weekly.** Replaces the previous `seasonal` tab with a `Room` filter that surfaces only quests tied to a specific physical room. Daily/Weekly filter by `quest_type`.
- **Grouped-by-source quest list.** Each active quest is grouped under its source NPC (name, zone label, icon). Mapping lives in the new `game/config/questSourceMap.ts` module, keyed on `requirement_type` → `{ npcId, npcName, zone, room }`. Location-based requirements (`observatory`, `springs`) map to their room NPCs (Astris, Ember, etc.); companion actions (`feed`, `chat`, `interact`, `bond_threshold`, `daily_streak`) map to Spawn Fox in Town Square.
- **Go button.** Each group whose source has a room shows a cyan `GO ▸` button that closes the board and emits a new `highlight-door` event.
- **Overworld door highlight.** `WorldScene` now listens for `highlight-door`, finds the matching `Door` in `DOORS`, and draws a pulsing cyan+gold ring with a bobbing `▼` arrow over the target door for ~5 seconds so the player can orient toward it.
- Each quest card also shows its NPC name in the Completed list, keeping source attribution consistent across states.

### Files
- `components/sanctuary/overlays/QuestBoard.tsx` — grouped rendering, new tabs, Go button, `npc-clicked` listener.
- `components/sanctuary/overlays/QuestDialog.tsx` — ignore `quest-board` clicks.
- `game/config/npcDefinitions.ts` — new `quest-board` NPC + `'board'` kind.
- `game/config/questSourceMap.ts` — new module.
- `game/scenes/WorldScene.ts` — `highlight-door` listener, pulsing graphics + arrow, update/shutdown hooks.

## Test plan
- [x] `npm run type-check` → 0 errors.
- [x] `npm run lint` → no new warnings/errors in changed files (201 pre-existing project-wide issues untouched).
- [x] `npm run build` → compiles cleanly.
- [x] `npm run test` → 275/279 passing; 4 pre-existing `api-e2e.test.ts` failures unrelated to this change.
- [ ] Manual QA in dev: open `/sanctuary`, click the new Quest Board NPC in Town Square, verify tabs filter correctly, hit Go on a room-scoped quest and confirm the target door pulses for ~5s.

## Mirror Validation (PROD)
- **Skipped**: PROD mirror at `/opt/star_world_order/PROD` does not yet contain the Sanctuary V2 feature (`components/sanctuary/` and `game/config/`, `game/scenes/` are absent). All modified files belong to that feature set, so there is no overlay baseline to diff against. Baseline `tsc` on PROD = 0 errors.