### PR TITLE
feat: timed quests for sanctuary companions from room NPCs

### DIFF
--- a/app/api/sanctuary/companion/send-to-activity/route.ts
+++ b/app/api/sanctuary/companion/send-to-activity/route.ts
@@ -5,10 +5,18 @@ import { verifyWalletAccess } from '@/lib/walletAuth';
 import { applyRateLimit } from '@/lib/sanctuary/rateLimit';
 import { ethAddress, tokenId, parseBody, formatZodError } from '@/lib/sanctuary/validation';
 
+const TIMED_QUEST_DURATIONS = [5, 15, 60, 240, 480] as const;
+
 const bodySchema = z.object({
   address: ethAddress,
   token_id: tokenId,
   location_id: z.coerce.number().int().min(1, 'location_id is required'),
+  duration_minutes: z
+    .coerce.number().int()
+    .refine((n) => (TIMED_QUEST_DURATIONS as readonly number[]).includes(n), {
+      message: 'duration_minutes must be one of 5, 15, 60, 240, 480',
+    })
+    .optional(),
 });
 
 export async function POST(request: NextRequest) {
@@ -23,7 +31,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const { address, token_id: tid, location_id } = parsed.data;
+    const { address, token_id: tid, location_id, duration_minutes } = parsed.data;
 
     const auth = await verifyWalletAccess(request, address);
     if (!auth.valid) {
@@ -33,12 +41,13 @@ export async function POST(request: NextRequest) {
     const rateLimited = applyRateLimit(address, 'companion/send-to-activity');
     if (rateLimited) return rateLimited;
 
-    const result = sendToActivity(address, tid, location_id);
+    const result = sendToActivity(address, tid, location_id, { durationMinutes: duration_minutes });
     return NextResponse.json({ success: true, ...result });
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Failed to send to activity';
     const status = message.includes('No active companion') ? 404
       : message.includes('already on an activity') ? 409
+      : message.includes('Invalid quest duration') ? 400
       : message.includes('not found') ? 404
       : 500;
     return NextResponse.json({ success: false, error: message }, { status });

--- a/components/sanctuary/overlays/CompanionHUD.tsx
+++ b/components/sanctuary/overlays/CompanionHUD.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import EventBus from '@/components/sanctuary/EventBus';
+import { getWalletAuthHeader } from '@/lib/clientWalletAuth';
 
 interface CompanionData {
   nickname: string | null;
@@ -10,6 +11,8 @@ interface CompanionData {
   bond_score: number;
   total_xp: number;
   level: number;
+  current_activity: string;
+  activity_ends_at: string | null;
 }
 
 interface CompanionHUDProps {
@@ -36,42 +39,87 @@ function xpProgress(totalXp: number, level: number): { current: number; needed: 
   return { current: totalXp - thisLevel, needed: nextLevel - thisLevel };
 }
 
+function formatCountdown(endsAtIso: string): { label: string; done: boolean } {
+  const endsAt = new Date(endsAtIso + 'Z').getTime();
+  const remaining = Math.max(0, endsAt - Date.now());
+  if (remaining <= 0) return { label: 'READY', done: true };
+  const totalSeconds = Math.ceil(remaining / 1000);
+  const h = Math.floor(totalSeconds / 3600);
+  const m = Math.floor((totalSeconds % 3600) / 60);
+  const s = totalSeconds % 60;
+  if (h > 0) return { label: `${h}h ${m.toString().padStart(2, '0')}m`, done: false };
+  if (m > 0) return { label: `${m}m ${s.toString().padStart(2, '0')}s`, done: false };
+  return { label: `${s}s`, done: false };
+}
+
+function isOnQuest(activity: string | null | undefined, endsAt: string | null | undefined): boolean {
+  if (!activity || !activity.startsWith('exploring:')) return false;
+  if (!endsAt) return false;
+  return true;
+}
+
 export default function CompanionHUD({ walletAddress }: CompanionHUDProps) {
   const [companion, setCompanion] = useState<CompanionData | null>(null);
   const [locationName, setLocationName] = useState<string | null>(null);
   const [locationVisible, setLocationVisible] = useState(false);
+  const [tick, setTick] = useState(0);
+  const [claiming, setClaiming] = useState(false);
+  const [claimFeedback, setClaimFeedback] = useState<string | null>(null);
+  const prevAwayRef = useRef<boolean>(false);
+
+  const fetchCompanion = useCallback(async () => {
+    if (!walletAddress) return;
+    try {
+      const res = await fetch(`/api/sanctuary/companion?address=${walletAddress}`);
+      if (!res.ok) return;
+      const data = await res.json();
+      if (data.companion) {
+        setCompanion({
+          nickname: data.companion.nickname,
+          token_id: data.companion.token_id,
+          mood: data.companion.mood,
+          bond_score: data.companion.bond_score,
+          total_xp: data.companion.total_xp ?? 0,
+          level: data.companion.level ?? 1,
+          current_activity: data.companion.current_activity ?? 'lounging',
+          activity_ends_at: data.companion.activity_ends_at ?? null,
+        });
+      }
+    } catch {
+      // HUD is non-critical
+    }
+  }, [walletAddress]);
 
   useEffect(() => {
     if (!walletAddress) return;
-    let cancelled = false;
-
-    async function fetchCompanion() {
-      try {
-        const res = await fetch(
-          `/api/sanctuary/companion?address=${walletAddress}`
-        );
-        if (!res.ok) return;
-        const data = await res.json();
-        if (!cancelled && data.companion) {
-          setCompanion({
-            nickname: data.companion.nickname,
-            token_id: data.companion.token_id,
-            mood: data.companion.mood,
-            bond_score: data.companion.bond_score,
-            total_xp: data.companion.total_xp ?? 0,
-            level: data.companion.level ?? 1,
-          });
-        }
-      } catch {
-        // HUD is non-critical
-      }
-    }
-
     fetchCompanion();
+  }, [walletAddress, fetchCompanion]);
+
+  useEffect(() => {
+    const onQuestStarted = () => fetchCompanion();
+    const onQuestClaimed = () => fetchCompanion();
+    EventBus.on('companion-quest-started', onQuestStarted);
+    EventBus.on('companion-quest-claimed', onQuestClaimed);
     return () => {
-      cancelled = true;
+      EventBus.off('companion-quest-started', onQuestStarted);
+      EventBus.off('companion-quest-claimed', onQuestClaimed);
     };
-  }, [walletAddress]);
+  }, [fetchCompanion]);
+
+  const onQuest = isOnQuest(companion?.current_activity, companion?.activity_ends_at);
+
+  useEffect(() => {
+    if (!onQuest) return;
+    const id = setInterval(() => setTick((t) => t + 1), 1000);
+    return () => clearInterval(id);
+  }, [onQuest]);
+
+  useEffect(() => {
+    if (prevAwayRef.current !== onQuest) {
+      EventBus.emit('companion-away', { away: onQuest });
+      prevAwayRef.current = onQuest;
+    }
+  }, [onQuest]);
 
   const onEnter = useCallback((payload: { name: string }) => {
     setLocationName(payload.name);
@@ -99,6 +147,43 @@ export default function CompanionHUD({ walletAddress }: CompanionHUDProps) {
     EventBus.emit('traits-overlay-toggle');
   }, []);
 
+  const handleClaim = useCallback(async () => {
+    if (!walletAddress || !companion || claiming) return;
+    setClaiming(true);
+    setClaimFeedback(null);
+    try {
+      const walletAuthHeader = await getWalletAuthHeader(walletAddress);
+      if (!walletAuthHeader) {
+        setClaiming(false);
+        return;
+      }
+      const res = await fetch('/api/sanctuary/companion/complete-activity', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-wallet-auth': walletAuthHeader,
+        },
+        body: JSON.stringify({ address: walletAddress, token_id: companion.token_id }),
+      });
+      const data = await res.json();
+      if (data.success) {
+        const bonus = data.starBonus ? ' ✨STAR' : '';
+        setClaimFeedback(`REWARDS CLAIMED${bonus}`);
+        EventBus.emit('companion-quest-claimed', { tokenId: companion.token_id });
+        await fetchCompanion();
+        setTimeout(() => setClaimFeedback(null), 2500);
+      } else {
+        setClaimFeedback(data.error ?? 'Claim failed');
+        setTimeout(() => setClaimFeedback(null), 2500);
+      }
+    } catch {
+      setClaimFeedback('Claim failed');
+      setTimeout(() => setClaimFeedback(null), 2500);
+    } finally {
+      setClaiming(false);
+    }
+  }, [walletAddress, companion, claiming, fetchCompanion]);
+
   if (!companion) return null;
 
   const displayName =
@@ -107,6 +192,15 @@ export default function CompanionHUD({ walletAddress }: CompanionHUDProps) {
   const bondPct = Math.min((companion.bond_score / 100) * 100, 100);
   const xp = xpProgress(companion.total_xp, companion.level);
   const xpPct = xp.needed > 0 ? Math.min((xp.current / xp.needed) * 100, 100) : 100;
+
+  const questName = onQuest
+    ? companion.current_activity.slice('exploring:'.length)
+    : null;
+  const countdown = onQuest && companion.activity_ends_at
+    ? formatCountdown(companion.activity_ends_at)
+    : null;
+  // touch tick so linter treats it as used for countdown re-render
+  void tick;
 
   return (
     <>
@@ -137,6 +231,41 @@ export default function CompanionHUD({ walletAddress }: CompanionHUDProps) {
           </div>
         </div>
       </div>
+
+      {/* Quest away-state panel */}
+      {onQuest && questName && countdown && (
+        <div className="absolute top-14 left-2 z-20 bg-black/90 border border-[#9966ff]/50 rounded px-3 py-2 pointer-events-auto select-none max-w-[200px] shadow-[0_0_12px_rgba(153,102,255,0.25)]">
+          <div className="flex items-center gap-1.5 mb-1">
+            <span className="text-xs">{countdown.done ? '✨' : '💤'}</span>
+            <span className="text-[7px] text-[#9966ff] font-['Press_Start_2P'] uppercase tracking-wider">
+              On Quest
+            </span>
+          </div>
+          <p className="text-[8px] text-white font-['Press_Start_2P'] leading-tight mb-1 truncate">
+            {questName}
+          </p>
+          <p className={`text-[10px] font-['Press_Start_2P'] mb-1.5 ${countdown.done ? 'text-[#44ff88]' : 'text-[#ffd700]'}`}>
+            {countdown.done ? '✨ READY' : `⏱ ${countdown.label}`}
+          </p>
+          {countdown.done ? (
+            <button
+              onClick={handleClaim}
+              disabled={claiming}
+              className="w-full py-1.5 bg-[#44ff88]/20 border border-[#44ff88]/60 rounded text-[#44ff88] text-[7px] font-['Press_Start_2P'] uppercase tracking-wider hover:bg-[#44ff88]/30 disabled:opacity-40 transition-colors"
+              aria-label="Claim quest rewards"
+            >
+              {claiming ? '...' : 'Claim'}
+            </button>
+          ) : (
+            <div className="text-[6px] text-gray-500 text-center leading-tight">
+              Skrumpey is busy
+            </div>
+          )}
+          {claimFeedback && (
+            <p className="text-[6px] text-[#ffd700] mt-1 text-center">{claimFeedback}</p>
+          )}
+        </div>
+      )}
 
       {/* Journal book icon */}
       <button

--- a/components/sanctuary/overlays/CompanionMenu.tsx
+++ b/components/sanctuary/overlays/CompanionMenu.tsx
@@ -49,11 +49,28 @@ export default function CompanionMenu({
   const [floatingTexts, setFloatingTexts] = useState<FloatingText[]>([]);
   const [reaction, setReaction] = useState<ReactionEffect | null>(null);
   const [visible, setVisible] = useState(false);
+  const [busyOnQuest, setBusyOnQuest] = useState(false);
+  const [busyNotice, setBusyNotice] = useState<MenuPosition | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
   const openMenu = useCallback((payload: { screenX: number; screenY: number }) => {
+    if (busyOnQuest) {
+      setBusyNotice({ x: payload.screenX, y: payload.screenY });
+      setTimeout(() => setBusyNotice(null), 1600);
+      return;
+    }
     setMenuPos({ x: payload.screenX, y: payload.screenY });
     setVisible(true);
+  }, [busyOnQuest]);
+
+  useEffect(() => {
+    const onAway = (data: { away: boolean }) => {
+      setBusyOnQuest(!!data?.away);
+    };
+    EventBus.on('companion-away', onAway);
+    return () => {
+      EventBus.off('companion-away', onAway);
+    };
   }, []);
 
   const closeMenu = useCallback(() => {
@@ -150,6 +167,21 @@ export default function CompanionMenu({
       closeMenu();
     }
   }, [walletAddress, tokenId, interacting, menuPos, triggerReaction, addFloatingText, closeMenu, onInteracted]);
+
+  if (busyNotice && !menuPos) {
+    return (
+      <div className="absolute inset-0 z-30 pointer-events-none">
+        <div
+          className="absolute pointer-events-none -translate-x-1/2 -translate-y-1/2 bg-black/90 border border-[#9966ff]/60 rounded px-2 py-1 animate-pulse"
+          style={{ left: busyNotice.x, top: busyNotice.y - 36 }}
+        >
+          <span className="text-[7px] text-[#9966ff] font-['Press_Start_2P'] uppercase tracking-wider">
+            💤 On Quest
+          </span>
+        </div>
+      </div>
+    );
+  }
 
   if (!menuPos) return null;
 

--- a/components/sanctuary/overlays/QuestDialog.tsx
+++ b/components/sanctuary/overlays/QuestDialog.tsx
@@ -31,11 +31,29 @@ interface NPCClickPayload {
   screenY: number;
 }
 
+interface MapLocation {
+  id: number;
+  name: string;
+}
+
+interface CompanionActivityState {
+  current_activity: string;
+  activity_ends_at: string | null;
+}
+
 const QUEST_TYPE_BADGE: Record<string, { label: string; color: string }> = {
   daily: { label: 'DAILY', color: '#44ff88' },
   weekly: { label: 'WEEKLY', color: '#66bbff' },
   seasonal: { label: 'SEASONAL', color: '#ffd700' },
 };
+
+const TIMED_QUEST_OPTIONS: { minutes: 5 | 15 | 60 | 240 | 480; label: string }[] = [
+  { minutes: 5, label: '5m' },
+  { minutes: 15, label: '15m' },
+  { minutes: 60, label: '1h' },
+  { minutes: 240, label: '4h' },
+  { minutes: 480, label: '8h' },
+];
 
 export default function QuestDialog({
   walletAddress,
@@ -49,6 +67,10 @@ export default function QuestDialog({
   const [loading, setLoading] = useState(false);
   const [claiming, setClaiming] = useState<number | null>(null);
   const [visible, setVisible] = useState(false);
+  const [locations, setLocations] = useState<MapLocation[]>([]);
+  const [companionState, setCompanionState] = useState<CompanionActivityState | null>(null);
+  const [startingDuration, setStartingDuration] = useState<number | null>(null);
+  const [questFeedback, setQuestFeedback] = useState<string | null>(null);
   const panelRef = useRef<HTMLDivElement>(null);
 
   const close = useCallback(() => {
@@ -72,6 +94,38 @@ export default function QuestDialog({
     }
   }, [walletAddress, tokenId]);
 
+  const loadMapLocations = useCallback(async () => {
+    try {
+      const res = await fetch('/api/sanctuary/map');
+      if (!res.ok) return;
+      const data = await res.json();
+      if (data.success && Array.isArray(data.locations)) {
+        setLocations(
+          data.locations.map((l: { id: number; name: string }) => ({ id: l.id, name: l.name })),
+        );
+      }
+    } catch {
+      // Non-critical
+    }
+  }, []);
+
+  const loadCompanionState = useCallback(async () => {
+    if (!walletAddress) return;
+    try {
+      const res = await fetch(`/api/sanctuary/companion?address=${walletAddress}`);
+      if (!res.ok) return;
+      const data = await res.json();
+      if (data.companion) {
+        setCompanionState({
+          current_activity: data.companion.current_activity ?? 'lounging',
+          activity_ends_at: data.companion.activity_ends_at ?? null,
+        });
+      }
+    } catch {
+      // Non-critical
+    }
+  }, [walletAddress]);
+
   const handleNPCClick = useCallback(
     (payload: NPCClickPayload) => {
       if (payload.npcId === 'spawn-fox' || payload.npcId === 'quest-board') {
@@ -79,9 +133,12 @@ export default function QuestDialog({
       }
       setNpc(payload);
       setVisible(true);
+      setQuestFeedback(null);
       loadQuests();
+      loadMapLocations();
+      loadCompanionState();
     },
-    [loadQuests]
+    [loadQuests, loadMapLocations, loadCompanionState]
   );
 
   useEffect(() => {
@@ -106,6 +163,56 @@ export default function QuestDialog({
       document.removeEventListener('mousedown', handleClickOutside);
     };
   }, [visible, close]);
+
+  const startTimedQuest = useCallback(
+    async (minutes: number) => {
+      if (!walletAddress || tokenId === null || !npc || startingDuration !== null) return;
+      const location = locations.find((l) => l.name === npc.zone);
+      if (!location) {
+        setQuestFeedback('Location unavailable.');
+        return;
+      }
+      setStartingDuration(minutes);
+      setQuestFeedback(null);
+      try {
+        const walletAuthHeader = await getWalletAuthHeader(walletAddress);
+        if (!walletAuthHeader) {
+          setStartingDuration(null);
+          return;
+        }
+        const res = await fetch('/api/sanctuary/companion/send-to-activity', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-wallet-auth': walletAuthHeader,
+          },
+          body: JSON.stringify({
+            address: walletAddress,
+            token_id: tokenId,
+            location_id: location.id,
+            duration_minutes: minutes,
+          }),
+        });
+        const data = await res.json();
+        if (data.success) {
+          setQuestFeedback(`Quest started! Returning in ${minutes < 60 ? `${minutes}m` : `${minutes / 60}h`}.`);
+          EventBus.emit('companion-quest-started', {
+            tokenId,
+            locationName: location.name,
+            durationMinutes: minutes,
+          });
+          await loadCompanionState();
+        } else {
+          setQuestFeedback(data.error ?? 'Failed to start quest.');
+        }
+      } catch {
+        setQuestFeedback('Failed to start quest.');
+      } finally {
+        setStartingDuration(null);
+      }
+    },
+    [walletAddress, tokenId, npc, locations, startingDuration, loadCompanionState],
+  );
 
   const claimReward = useCallback(
     async (questId: number) => {
@@ -149,6 +256,14 @@ export default function QuestDialog({
   const activeQuests = zoneQuests.filter((q) => !q.progress?.completed);
   const completedQuests = zoneQuests.filter((q) => q.progress?.completed);
 
+  const companionBusy = !!(
+    companionState
+    && companionState.current_activity.startsWith('exploring:')
+    && companionState.activity_ends_at
+    && new Date(companionState.activity_ends_at + 'Z').getTime() > Date.now()
+  );
+  const zoneHasLocation = locations.some((l) => l.name === npc.zone);
+
   return (
     <div className="absolute inset-0 z-40 pointer-events-none">
       <div
@@ -180,6 +295,52 @@ export default function QuestDialog({
           </div>
           <p className="text-gray-400 text-[7px] mt-2 italic">&ldquo;{npc.dialogue}&rdquo;</p>
         </div>
+
+        {/* Send on Timed Quest */}
+        {zoneHasLocation && tokenId !== null && (
+          <div className="p-3 border-b border-[#2a2a4e]">
+            <div className="flex items-center gap-1.5 mb-2">
+              <span className="text-[8px]">🗺️</span>
+              <span className="text-[#9966ff] font-['Press_Start_2P'] text-[7px] uppercase tracking-wider">
+                Send on Quest
+              </span>
+            </div>
+            {companionBusy ? (
+              <p className="text-gray-500 text-[7px] italic leading-tight">
+                Your Skrumpey is already on a quest. Check the HUD to claim when ready.
+              </p>
+            ) : (
+              <>
+                <p className="text-gray-400 text-[7px] mb-2 leading-tight">
+                  Pick a duration. Longer quests grant greater rewards.
+                </p>
+                <div className="grid grid-cols-5 gap-1">
+                  {TIMED_QUEST_OPTIONS.map((opt) => {
+                    const isStarting = startingDuration === opt.minutes;
+                    return (
+                      <button
+                        key={opt.minutes}
+                        onClick={() => startTimedQuest(opt.minutes)}
+                        disabled={startingDuration !== null}
+                        className={`py-1.5 rounded border text-[7px] font-['Press_Start_2P'] transition-colors ${
+                          isStarting
+                            ? 'bg-[#9966ff]/30 border-[#9966ff] text-[#9966ff]'
+                            : 'bg-[#0a0a15] border-[#2a2a4e] text-white hover:bg-[#9966ff]/20 hover:border-[#9966ff]/60 hover:text-[#9966ff]'
+                        } disabled:opacity-40 disabled:cursor-not-allowed`}
+                        aria-label={`Start ${opt.label} quest`}
+                      >
+                        {isStarting ? '...' : opt.label}
+                      </button>
+                    );
+                  })}
+                </div>
+              </>
+            )}
+            {questFeedback && (
+              <p className="text-[#ffd700] text-[7px] mt-2">{questFeedback}</p>
+            )}
+          </div>
+        )}
 
         {/* Quest List */}
         <div className="p-3 space-y-2">

--- a/game/scenes/WorldScene.ts
+++ b/game/scenes/WorldScene.ts
@@ -200,6 +200,9 @@ export class WorldScene extends Phaser.Scene {
       const lower = constellation.toLowerCase() as Constellation;
       if ((CONSTELLATIONS as readonly string[]).includes(lower)) this.companion.setConstellation(lower);
     });
+    EventBus.on('companion-away', (data: { away: boolean }) => {
+      this.companion.setAway(!!data?.away);
+    });
     EventBus.on('editor-mode', (enabled: boolean) => this.setEditorMode(enabled));
     EventBus.on('highlight-door', (data: { room: string }) => {
       this.highlightDoor(data?.room);
@@ -414,6 +417,7 @@ export class WorldScene extends Phaser.Scene {
     this.npcManager?.destroy();
     EventBus.off('companion-mood');
     EventBus.off('companion-constellation');
+    EventBus.off('companion-away');
     EventBus.off('editor-mode');
     EventBus.off('highlight-door');
     EventBus.off('room-exit');

--- a/game/sprites/CompanionSprite.ts
+++ b/game/sprites/CompanionSprite.ts
@@ -16,6 +16,8 @@ export class CompanionSprite extends Phaser.GameObjects.Sprite {
   private animSystem: AnimationSystem | null = null;
   private lastTime = 0;
   private prevTextureKey = '';
+  private away = false;
+  private zzzText: Phaser.GameObjects.Text | null = null;
 
   constructor(scene: Phaser.Scene, x: number, y: number, textureKey?: string) {
     super(scene, x, y, textureKey || 'companion-placeholder');
@@ -23,6 +25,43 @@ export class CompanionSprite extends Phaser.GameObjects.Sprite {
     this.setDepth(9);
     this.setScale(1.5);
     this.baseY = y;
+  }
+
+  isAway(): boolean {
+    return this.away;
+  }
+
+  setAway(away: boolean) {
+    if (this.away === away) return;
+    this.away = away;
+
+    if (away) {
+      this.setAlpha(0.45);
+      this.setTint(0x8899cc);
+      if (this.animSystem) {
+        this.animSystem.setMood('sleepy');
+        this.refreshTexture();
+      }
+      if (!this.zzzText && this.scene) {
+        this.zzzText = this.scene.add
+          .text(this.x, this.y - 12, 'Zzz', {
+            fontFamily: '"Press Start 2P", monospace',
+            fontSize: '6px',
+            color: '#9966ff',
+            stroke: '#000000',
+            strokeThickness: 2,
+          })
+          .setOrigin(0.5, 1)
+          .setDepth(10);
+      }
+    } else {
+      this.setAlpha(1);
+      this.clearTint();
+      if (this.zzzText) {
+        this.zzzText.destroy();
+        this.zzzText = null;
+      }
+    }
   }
 
   static loadConstellationAssets(scene: Phaser.Scene): void {
@@ -166,6 +205,19 @@ export class CompanionSprite extends Phaser.GameObjects.Sprite {
     } else if (playerDirection === 'right') {
       this.setFlipX(false);
     }
+
+    if (this.zzzText) {
+      const bob = Math.sin(now * 0.004) * 1.5;
+      this.zzzText.setPosition(this.x, this.y - 14 + bob);
+    }
+  }
+
+  destroy(fromScene?: boolean): void {
+    if (this.zzzText) {
+      this.zzzText.destroy();
+      this.zzzText = null;
+    }
+    super.destroy(fromScene);
   }
 
   setNFTTexture(url: string) {

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -6137,6 +6137,13 @@ const ACTIVITY_DURATIONS: Record<string, number> = {
   'Observatory': 150,
 };
 
+export const TIMED_QUEST_DURATIONS_MINUTES = [5, 15, 60, 240, 480] as const;
+export type TimedQuestDurationMinutes = typeof TIMED_QUEST_DURATIONS_MINUTES[number];
+
+function isValidTimedDuration(minutes: number): minutes is TimedQuestDurationMinutes {
+  return (TIMED_QUEST_DURATIONS_MINUTES as readonly number[]).includes(minutes);
+}
+
 const ACTIVITY_BOND_REWARDS: Record<string, number> = {
   'Dream Hollow': 0.8,
   'Nebula Kitchen': 1.2,
@@ -6160,7 +6167,8 @@ const ACTIVITY_XP_REWARDS: Record<string, number> = {
 };
 
 export function sendToActivity(
-  walletAddress: string, tokenId: number, locationId: number
+  walletAddress: string, tokenId: number, locationId: number,
+  options?: { durationMinutes?: number }
 ): { companion: SanctuaryCompanion; journal: SanctuaryJournalEntry } {
   const db = getDatabase();
   const addr = walletAddress.toLowerCase();
@@ -6185,7 +6193,11 @@ export function sendToActivity(
 
     if (!location) throw new Error('Location not found');
 
-    const durationMinutes = ACTIVITY_DURATIONS[location.name] ?? 60;
+    const requestedDuration = options?.durationMinutes;
+    if (requestedDuration !== undefined && !isValidTimedDuration(requestedDuration)) {
+      throw new Error('Invalid quest duration');
+    }
+    const durationMinutes = requestedDuration ?? ACTIVITY_DURATIONS[location.name] ?? 60;
     const now = new Date();
     const endsAt = new Date(now.getTime() + durationMinutes * 60 * 1000);
 


### PR DESCRIPTION
## Summary
- Send the active companion on a timed quest from any room NPC dialog. Duration options: **5m / 15m / 1h / 4h / 8h**, reusing the existing `activity_ends_at` column.
- `CompanionHUD` gains a purple away-state panel showing quest name, live countdown, and a **CLAIM** button that triggers the existing `/api/sanctuary/companion/complete-activity` route — XP + bond + Star bonus awarded by the current reward pipeline.
- `CompanionSprite` dims, gets a cool tint, and displays a bobbing `Zzz` label while on quest.
- Interaction menu is blocked while the companion is on quest; clicking the sprite surfaces a `💤 On Quest` tooltip instead.

## Changes
- `lib/db.ts` — `sendToActivity` now accepts `{ durationMinutes }` and validates against `TIMED_QUEST_DURATIONS_MINUTES = [5, 15, 60, 240, 480]`; falls back to the default zone duration when omitted.
- `app/api/sanctuary/companion/send-to-activity/route.ts` — zod schema now accepts optional `duration_minutes`; 400 on invalid value.
- `components/sanctuary/overlays/CompanionHUD.tsx` — full away-state UI with 1s countdown tick, auto-refresh on `companion-quest-started` / `companion-quest-claimed`, emits `companion-away`.
- `components/sanctuary/overlays/CompanionMenu.tsx` — listens for `companion-away`; busy clicks show a short floating notice instead of opening the radial menu.
- `components/sanctuary/overlays/QuestDialog.tsx` — adds a **Send on Quest** panel inside the NPC dialog with a 5-button duration grid, loads `/api/sanctuary/map` to map NPC zone → `location_id`, gates on existing companion activity.
- `game/sprites/CompanionSprite.ts` — new `setAway(bool)` applies alpha/tint, sleepy mood, and a bobbing `Zzz` label; `destroy()` cleans up.
- `game/scenes/WorldScene.ts` — wires `companion-away` event to the sprite.

## Validation
- `npm run type-check` — PASS (0 errors)
- `npm run lint` — PASS (no new errors in changed files; pre-existing repo baseline unchanged)
- `npm run build` — PASS
- `npm run test` — 275/279 pass (4 pre-existing failures on `dev` in `lib/sanctuary/__tests__/api-e2e.test.ts`, unrelated; all `send-to-activity` and `complete-activity` tests pass)

## Mirror Validation (PROD)
- **tsc --noEmit**: Pre-existing errors appeared for new game/ files because the PROD mirror lacks `phaser` in `node_modules`; this is an environmental baseline issue (PROD is 56 commits behind dev and has not yet pulled the sanctuary V2 files). No type errors in workspace tsc.
- **vitest run**: Pre-existing `ERR_MODULE_NOT_FOUND` in the PROD mirror for `api-e2e.test.ts` (missing module in PROD deps); 136/136 runnable tests pass.
- Overall: baseline-diff clean for files that exist in PROD (`route.ts`, `lib/db.ts`). New files are not comparable since they don't exist in the PROD baseline.

## Test plan
- [ ] Connect wallet with an active companion, walk to any themed room (e.g. Hot Springs), click the NPC inside.
- [ ] Dialog shows **Send on Quest** with 5 duration buttons. Click 5m.
- [ ] Companion sprite dims, shows `Zzz`, follows the player as usual.
- [ ] Away-state panel appears top-left with live countdown.
- [ ] Clicking the companion shows `💤 On Quest` instead of the radial menu.
- [ ] After the timer ends the panel switches to **READY** + green CLAIM.
- [ ] Clicking CLAIM grants XP + bond (+ Star bonus if Star holder) and returns companion to normal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)