### PR TITLE
feat(sanctuary): Training Grounds room with per-Skrumpey XP and level-up

### DIFF
--- a/app/api/sanctuary/companion/training/route.ts
+++ b/app/api/sanctuary/companion/training/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import {
+  startCompanionTraining,
+  listTrainingTypesForLevel,
+  calculateCompanionLevel,
+  getActiveCompanion,
+  COMPANION_TRAINING_TYPES,
+} from '@/lib/db';
+import { verifyWalletAccess } from '@/lib/walletAuth';
+import { applyRateLimit } from '@/lib/sanctuary/rateLimit';
+import { ethAddress, tokenId, parseBody, parseSearchParams, formatZodError } from '@/lib/sanctuary/validation';
+
+const TRAINING_TYPE_NAMES = Object.keys(COMPANION_TRAINING_TYPES) as [string, ...string[]];
+
+const bodySchema = z.object({
+  address: ethAddress,
+  token_id: tokenId,
+  training_type: z.enum(TRAINING_TYPE_NAMES),
+});
+
+const querySchema = z.object({
+  address: ethAddress,
+});
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const parsed = parseSearchParams(querySchema, searchParams);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { success: false, error: formatZodError(parsed.error) },
+        { status: 400 },
+      );
+    }
+    const { address } = parsed.data;
+    const companion = getActiveCompanion(address);
+    const companionLevel = companion
+      ? calculateCompanionLevel(companion.companion_xp ?? 0)
+      : 1;
+    const available = listTrainingTypesForLevel(companionLevel);
+    const all = Object.values(COMPANION_TRAINING_TYPES).sort(
+      (a, b) => a.minLevel - b.minLevel || a.xpReward - b.xpReward,
+    );
+    return NextResponse.json({
+      success: true,
+      companion_level: companionLevel,
+      companion_xp: companion?.companion_xp ?? 0,
+      available,
+      all,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to fetch training options';
+    return NextResponse.json({ success: false, error: message }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const parsed = parseBody(bodySchema, body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { success: false, error: formatZodError(parsed.error) },
+        { status: 400 },
+      );
+    }
+
+    const { address, token_id: tid, training_type } = parsed.data;
+
+    const auth = await verifyWalletAccess(request, address);
+    if (!auth.valid) {
+      return NextResponse.json({ success: false, error: auth.error }, { status: 401 });
+    }
+
+    const rateLimited = applyRateLimit(address, 'companion/training');
+    if (rateLimited) return rateLimited;
+
+    const result = startCompanionTraining(address, tid, training_type);
+    return NextResponse.json({ success: true, ...result });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to start training';
+    const status = message.includes('No active companion') ? 404
+      : message.includes('already on an activity') ? 409
+      : message.includes('Invalid training type') ? 400
+      : message.includes('requires companion level') ? 403
+      : 500;
+    return NextResponse.json({ success: false, error: message }, { status });
+  }
+}

--- a/app/sanctuary/SanctuaryV2.tsx
+++ b/app/sanctuary/SanctuaryV2.tsx
@@ -66,6 +66,11 @@ const WelcomeDialog = dynamic(
   { ssr: false }
 );
 
+const LevelUpCelebration = dynamic(
+  () => import('@/components/sanctuary/overlays/LevelUpCelebration'),
+  { ssr: false }
+);
+
 const DevMapEditor = dynamic(
   () => import('@/components/sanctuary/DevMapEditor'),
   { ssr: false }
@@ -150,6 +155,7 @@ export default function SanctuaryV2() {
         <JournalOverlay walletAddress={address} tokenId={activeTokenId} />
         <TraitsOverlay walletAddress={address} tokenId={activeTokenId} />
         <WelcomeDialog walletAddress={address} />
+        <LevelUpCelebration />
         <ChatBubble />
         <ChatInput />
         {editMode && <DevMapEditor />}

--- a/components/sanctuary/overlays/CompanionHUD.tsx
+++ b/components/sanctuary/overlays/CompanionHUD.tsx
@@ -11,6 +11,8 @@ interface CompanionData {
   bond_score: number;
   total_xp: number;
   level: number;
+  companion_xp: number;
+  companion_level: number;
   current_activity: string;
   activity_ends_at: string | null;
 }
@@ -37,6 +39,19 @@ function xpProgress(totalXp: number, level: number): { current: number; needed: 
   const thisLevel = xpForLevel(level);
   const nextLevel = xpForLevel(level + 1);
   return { current: totalXp - thisLevel, needed: nextLevel - thisLevel };
+}
+
+// Per-companion XP thresholds (must match COMPANION_LEVEL_THRESHOLDS in lib/db.ts)
+const COMPANION_LEVEL_THRESHOLDS = [0, 100, 300, 600, 1000, 1500];
+
+function companionXpProgress(xp: number, level: number): { current: number; needed: number } {
+  const idx = Math.min(level - 1, COMPANION_LEVEL_THRESHOLDS.length - 1);
+  const thisLevel = COMPANION_LEVEL_THRESHOLDS[idx] ?? 0;
+  const nextLevel = COMPANION_LEVEL_THRESHOLDS[idx + 1];
+  if (nextLevel === undefined) {
+    return { current: 1, needed: 1 };
+  }
+  return { current: Math.max(0, xp - thisLevel), needed: nextLevel - thisLevel };
 }
 
 function formatCountdown(endsAtIso: string): { label: string; done: boolean } {
@@ -81,6 +96,8 @@ export default function CompanionHUD({ walletAddress }: CompanionHUDProps) {
           bond_score: data.companion.bond_score,
           total_xp: data.companion.total_xp ?? 0,
           level: data.companion.level ?? 1,
+          companion_xp: data.companion.companion_xp ?? data.companion.xp ?? 0,
+          companion_level: data.companion.companion_level ?? data.companion.level ?? 1,
           current_activity: data.companion.current_activity ?? 'lounging',
           activity_ends_at: data.companion.activity_ends_at ?? null,
         });
@@ -170,6 +187,13 @@ export default function CompanionHUD({ walletAddress }: CompanionHUDProps) {
         const bonus = data.starBonus ? ' ✨STAR' : '';
         setClaimFeedback(`REWARDS CLAIMED${bonus}`);
         EventBus.emit('companion-quest-claimed', { tokenId: companion.token_id });
+        if (data.leveledUp && data.levelAfter) {
+          EventBus.emit('companion-level-up', {
+            tokenId: companion.token_id,
+            levelBefore: data.levelBefore,
+            levelAfter: data.levelAfter,
+          });
+        }
         await fetchCompanion();
         setTimeout(() => setClaimFeedback(null), 2500);
       } else {
@@ -192,6 +216,8 @@ export default function CompanionHUD({ walletAddress }: CompanionHUDProps) {
   const bondPct = Math.min((companion.bond_score / 100) * 100, 100);
   const xp = xpProgress(companion.total_xp, companion.level);
   const xpPct = xp.needed > 0 ? Math.min((xp.current / xp.needed) * 100, 100) : 100;
+  const compXp = companionXpProgress(companion.companion_xp, companion.companion_level);
+  const compXpPct = compXp.needed > 0 ? Math.min((compXp.current / compXp.needed) * 100, 100) : 100;
 
   const questName = onQuest
     ? companion.current_activity.slice('exploring:'.length)
@@ -228,6 +254,23 @@ export default function CompanionHUD({ walletAddress }: CompanionHUDProps) {
                 style={{ width: `${xpPct}%` }}
               />
             </div>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <span className="text-[6px] text-[#ffd700] w-6 text-right" title="Training level (per Skrumpey)">
+              T{companion.companion_level}
+            </span>
+            <div
+              className="w-28 h-1 bg-[#1a1a2e] rounded-full overflow-hidden border border-[#2a2a4e]"
+              title={`Training XP: ${companion.companion_xp}`}
+            >
+              <div
+                className="h-full rounded-full bg-[#ffd700] transition-all duration-500"
+                style={{ width: `${compXpPct}%` }}
+              />
+            </div>
+            <span className="text-[6px] text-gray-500 w-14 text-right tabular-nums">
+              {compXp.needed > 0 ? `${compXp.current}/${compXp.needed}` : 'MAX'}
+            </span>
           </div>
         </div>
       </div>

--- a/components/sanctuary/overlays/LevelUpCelebration.tsx
+++ b/components/sanctuary/overlays/LevelUpCelebration.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import EventBus from '@/components/sanctuary/EventBus';
+
+interface LevelUpPayload {
+  tokenId: number;
+  levelBefore: number;
+  levelAfter: number;
+}
+
+export default function LevelUpCelebration() {
+  const [payload, setPayload] = useState<LevelUpPayload | null>(null);
+  const [phase, setPhase] = useState<'enter' | 'hold' | 'exit'>('enter');
+
+  useEffect(() => {
+    const onLevelUp = (data: LevelUpPayload) => {
+      setPayload(data);
+      setPhase('enter');
+    };
+    EventBus.on('companion-level-up', onLevelUp);
+    return () => {
+      EventBus.off('companion-level-up', onLevelUp);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!payload) return;
+    const t1 = setTimeout(() => setPhase('hold'), 50);
+    const t2 = setTimeout(() => setPhase('exit'), 2200);
+    const t3 = setTimeout(() => setPayload(null), 2800);
+    return () => {
+      clearTimeout(t1);
+      clearTimeout(t2);
+      clearTimeout(t3);
+    };
+  }, [payload]);
+
+  if (!payload) return null;
+
+  const active = phase === 'enter' || phase === 'hold';
+  const scale = phase === 'enter' ? 'scale-50' : phase === 'exit' ? 'scale-125' : 'scale-100';
+  const opacity = active ? 'opacity-100' : 'opacity-0';
+
+  return (
+    <div className="pointer-events-none absolute inset-0 z-50 flex items-center justify-center">
+      <div
+        className={`transition-all duration-500 ease-out ${scale} ${opacity}`}
+        role="status"
+        aria-live="polite"
+      >
+        <div className="relative">
+          <div className="absolute inset-0 rounded-full blur-3xl bg-[#ffd700]/40 animate-pulse" />
+          <div className="relative bg-black/90 border-2 border-[#ffd700] rounded-lg px-6 py-5 shadow-[0_0_40px_rgba(255,215,0,0.6)] text-center">
+            <div className="text-3xl mb-1">✨🏆✨</div>
+            <div className="text-[#ffd700] font-['Press_Start_2P'] text-[10px] uppercase tracking-widest mb-1">
+              Level Up!
+            </div>
+            <div className="text-white font-['Press_Start_2P'] text-[14px]">
+              T{payload.levelBefore} → T{payload.levelAfter}
+            </div>
+            <div className="text-[#ffd700]/80 text-[7px] mt-2 font-['Press_Start_2P'] uppercase">
+              Skrumpey #{payload.tokenId}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/sanctuary/overlays/QuestDialog.tsx
+++ b/components/sanctuary/overlays/QuestDialog.tsx
@@ -41,6 +41,22 @@ interface CompanionActivityState {
   activity_ends_at: string | null;
 }
 
+interface TrainingOption {
+  type: string;
+  label: string;
+  durationMinutes: number;
+  xpReward: number;
+  bondReward: number;
+  minLevel: number;
+  description: string;
+}
+
+interface TrainingOptionsState {
+  companionLevel: number;
+  companionXp: number;
+  all: TrainingOption[];
+}
+
 const QUEST_TYPE_BADGE: Record<string, { label: string; color: string }> = {
   daily: { label: 'DAILY', color: '#44ff88' },
   weekly: { label: 'WEEKLY', color: '#66bbff' },
@@ -71,6 +87,9 @@ export default function QuestDialog({
   const [companionState, setCompanionState] = useState<CompanionActivityState | null>(null);
   const [startingDuration, setStartingDuration] = useState<number | null>(null);
   const [questFeedback, setQuestFeedback] = useState<string | null>(null);
+  const [trainingOptions, setTrainingOptions] = useState<TrainingOptionsState | null>(null);
+  const [startingTraining, setStartingTraining] = useState<string | null>(null);
+  const [trainingFeedback, setTrainingFeedback] = useState<string | null>(null);
   const panelRef = useRef<HTMLDivElement>(null);
 
   const close = useCallback(() => {
@@ -126,6 +145,24 @@ export default function QuestDialog({
     }
   }, [walletAddress]);
 
+  const loadTrainingOptions = useCallback(async () => {
+    if (!walletAddress) return;
+    try {
+      const res = await fetch(`/api/sanctuary/companion/training?address=${walletAddress}`);
+      if (!res.ok) return;
+      const data = await res.json();
+      if (data.success && Array.isArray(data.all)) {
+        setTrainingOptions({
+          companionLevel: data.companion_level ?? 1,
+          companionXp: data.companion_xp ?? 0,
+          all: data.all,
+        });
+      }
+    } catch {
+      // Non-critical
+    }
+  }, [walletAddress]);
+
   const handleNPCClick = useCallback(
     (payload: NPCClickPayload) => {
       if (payload.npcId === 'spawn-fox' || payload.npcId === 'quest-board') {
@@ -134,11 +171,15 @@ export default function QuestDialog({
       setNpc(payload);
       setVisible(true);
       setQuestFeedback(null);
+      setTrainingFeedback(null);
       loadQuests();
       loadMapLocations();
       loadCompanionState();
+      if (payload.npcId === 'npc-training-grounds') {
+        loadTrainingOptions();
+      }
     },
-    [loadQuests, loadMapLocations, loadCompanionState]
+    [loadQuests, loadMapLocations, loadCompanionState, loadTrainingOptions]
   );
 
   useEffect(() => {
@@ -212,6 +253,51 @@ export default function QuestDialog({
       }
     },
     [walletAddress, tokenId, npc, locations, startingDuration, loadCompanionState],
+  );
+
+  const startTraining = useCallback(
+    async (trainingType: string) => {
+      if (!walletAddress || tokenId === null || startingTraining !== null) return;
+      setStartingTraining(trainingType);
+      setTrainingFeedback(null);
+      try {
+        const walletAuthHeader = await getWalletAuthHeader(walletAddress);
+        if (!walletAuthHeader) {
+          setStartingTraining(null);
+          return;
+        }
+        const res = await fetch('/api/sanctuary/companion/training', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-wallet-auth': walletAuthHeader,
+          },
+          body: JSON.stringify({
+            address: walletAddress,
+            token_id: tokenId,
+            training_type: trainingType,
+          }),
+        });
+        const data = await res.json();
+        if (data.success) {
+          const mins = data.training?.durationMinutes ?? 0;
+          setTrainingFeedback(`Training started. Done in ${mins < 60 ? `${mins}m` : `${mins / 60}h`}.`);
+          EventBus.emit('companion-quest-started', {
+            tokenId,
+            locationName: 'Training Grounds',
+            durationMinutes: mins,
+          });
+          await loadCompanionState();
+        } else {
+          setTrainingFeedback(data.error ?? 'Failed to start training.');
+        }
+      } catch {
+        setTrainingFeedback('Failed to start training.');
+      } finally {
+        setStartingTraining(null);
+      }
+    },
+    [walletAddress, tokenId, startingTraining, loadCompanionState],
   );
 
   const claimReward = useCallback(
@@ -295,6 +381,76 @@ export default function QuestDialog({
           </div>
           <p className="text-gray-400 text-[7px] mt-2 italic">&ldquo;{npc.dialogue}&rdquo;</p>
         </div>
+
+        {/* Training Grounds — training menu */}
+        {npc.npcId === 'npc-training-grounds' && tokenId !== null && trainingOptions && (
+          <div className="p-3 border-b border-[#2a2a4e]">
+            <div className="flex items-center justify-between mb-2">
+              <div className="flex items-center gap-1.5">
+                <span className="text-[8px]">🏋️</span>
+                <span className="text-[#ffd700] font-['Press_Start_2P'] text-[7px] uppercase tracking-wider">
+                  Begin Training
+                </span>
+              </div>
+              <span className="text-[6px] text-[#ffd700]/80 font-['Press_Start_2P']">
+                T{trainingOptions.companionLevel} · {trainingOptions.companionXp} XP
+              </span>
+            </div>
+            {companionBusy ? (
+              <p className="text-gray-500 text-[7px] italic leading-tight">
+                Your Skrumpey is still mid-activity. Claim from the HUD first.
+              </p>
+            ) : (
+              <>
+                <p className="text-gray-400 text-[7px] mb-2 leading-tight">
+                  Training grants per-Skrumpey XP. Level up to unlock harder drills.
+                </p>
+                <div className="space-y-1.5">
+                  {trainingOptions.all.map((opt) => {
+                    const locked = opt.minLevel > trainingOptions.companionLevel;
+                    const isStarting = startingTraining === opt.type;
+                    return (
+                      <button
+                        key={opt.type}
+                        onClick={() => !locked && startTraining(opt.type)}
+                        disabled={locked || startingTraining !== null}
+                        className={`w-full text-left rounded border px-2 py-1.5 transition-colors ${
+                          locked
+                            ? 'bg-[#0a0a15] border-[#2a2a4e] opacity-40 cursor-not-allowed'
+                            : isStarting
+                              ? 'bg-[#ffd700]/20 border-[#ffd700] text-[#ffd700]'
+                              : 'bg-[#0a0a15] border-[#2a2a4e] hover:bg-[#ffd700]/10 hover:border-[#ffd700]/60'
+                        }`}
+                        aria-label={locked ? `${opt.label} (locked)` : `Start ${opt.label} training`}
+                      >
+                        <div className="flex items-center justify-between">
+                          <span className="text-white text-[8px] font-['Press_Start_2P']">
+                            {locked ? '🔒 ' : ''}{opt.label}
+                          </span>
+                          <span className="text-[#ffd700] text-[6px] font-['Press_Start_2P']">
+                            +{opt.xpReward} XP
+                          </span>
+                        </div>
+                        <div className="flex items-center justify-between mt-1">
+                          <span className="text-gray-500 text-[6px]">
+                            {opt.durationMinutes < 60 ? `${opt.durationMinutes}m` : `${opt.durationMinutes / 60}h`}
+                            {locked ? ` · Req L${opt.minLevel}` : ''}
+                          </span>
+                          {isStarting && (
+                            <span className="text-[#ffd700] text-[6px]">...</span>
+                          )}
+                        </div>
+                      </button>
+                    );
+                  })}
+                </div>
+              </>
+            )}
+            {trainingFeedback && (
+              <p className="text-[#ffd700] text-[7px] mt-2">{trainingFeedback}</p>
+            )}
+          </div>
+        )}
 
         {/* Send on Timed Quest */}
         {zoneHasLocation && tokenId !== null && (

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -5716,11 +5716,13 @@ export interface SanctuaryCompanion {
   bond_score: number;
   total_interactions: number;
   equipped_cosmetics: string;
+  xp: number;
+  level: number;
   created_at: string;
   updated_at: string;
 }
 
-export interface SanctuaryCompanionWithMeta extends SanctuaryCompanion {
+export interface SanctuaryCompanionWithMeta extends Omit<SanctuaryCompanion, 'level'> {
   constellation: string | null;
   aura: string | null;
   form: string | null;
@@ -5731,6 +5733,12 @@ export interface SanctuaryCompanionWithMeta extends SanctuaryCompanion {
   image_url: string | null;
   rarity_rank: number | null;
   attributes_json: string | null;
+  // Companion-level XP/level (per-token, set by Training Grounds)
+  companion_xp: number;
+  companion_level: number;
+  // Wallet-level XP/level (aggregate, set by user_xp table). The `level` field
+  // is the wallet-wide level for backward compatibility with existing UI that
+  // uses it for location unlock thresholds.
   total_xp: number;
   level: number;
 }
@@ -5771,6 +5779,17 @@ function initializeSanctuary(database: Database.Database): void {
     const sql = fs.readFileSync(v16Path, 'utf-8');
     database.exec(sql);
   }
+  const v17Path = path.join(process.cwd(), 'scripts', 'init-sanctuary-v1.7.sql');
+  if (fs.existsSync(v17Path)) {
+    const sql = fs.readFileSync(v17Path, 'utf-8');
+    database.exec(sql);
+  }
+  // V1.7: per-companion XP/level columns (Training Grounds). ALTER TABLE IF NOT
+  // EXISTS is not portable across SQLite versions, so wrap in try/catch.
+  try { database.exec('ALTER TABLE sanctuary_companions ADD COLUMN xp INTEGER NOT NULL DEFAULT 0'); }
+  catch { /* column already exists */ }
+  try { database.exec('ALTER TABLE sanctuary_companions ADD COLUMN level INTEGER NOT NULL DEFAULT 1'); }
+  catch { /* column already exists */ }
   const rateLimitPath = path.join(process.cwd(), 'scripts', 'init-sanctuary-rate-limits.sql');
   if (fs.existsSync(rateLimitPath)) {
     const sql = fs.readFileSync(rateLimitPath, 'utf-8');
@@ -5872,32 +5891,49 @@ export function getSanctuaryCompanion(walletAddress: string, tokenId: number): S
 export function getActiveCompanion(walletAddress: string): SanctuaryCompanionWithMeta | null {
   const db = getDatabase();
   const stmt = db.prepare(`
-    SELECT sc.*, ssm.constellation, ssm.aura, ssm.form, ssm.mood,
+    SELECT sc.id, sc.wallet_address, sc.token_id, sc.is_active, sc.nickname,
+           sc.current_activity, sc.activity_started_at, sc.activity_ends_at,
+           sc.bond_score, sc.total_interactions, sc.equipped_cosmetics,
+           sc.xp, sc.level, sc.created_at, sc.updated_at,
+           sc.xp as companion_xp, sc.level as companion_level,
+           ssm.constellation, ssm.aura, ssm.form, ssm.mood,
            ssm.background, ssm.eyes, ssm.hat, ssm.image_url,
            ssm.rarity_rank, ssm.attributes_json,
-           COALESCE(ux.total_xp, 0) as total_xp, COALESCE(ux.level, 1) as level
+           COALESCE(ux.total_xp, 0) as total_xp,
+           COALESCE(ux.level, 1) as wallet_level
     FROM sanctuary_companions sc
     LEFT JOIN star_skrumpey_metadata ssm ON sc.token_id = ssm.token_id
     LEFT JOIN user_xp ux ON sc.wallet_address = ux.wallet_address
     WHERE sc.wallet_address = ? AND sc.is_active = 1
   `);
-  return (stmt.get(walletAddress.toLowerCase()) as SanctuaryCompanionWithMeta) || null;
+  const row = stmt.get(walletAddress.toLowerCase()) as (SanctuaryCompanionWithMeta & { wallet_level: number }) | undefined;
+  if (!row) return null;
+  // Expose wallet-level level under `level` name for existing callers (SanctuaryContent
+  // uses companion.level for location unlocks, which is wallet-wide progression).
+  return { ...row, level: row.wallet_level } as SanctuaryCompanionWithMeta;
 }
 
 export function getAllCompanions(walletAddress: string): SanctuaryCompanionWithMeta[] {
   const db = getDatabase();
   const stmt = db.prepare(`
-    SELECT sc.*, ssm.constellation, ssm.aura, ssm.form, ssm.mood,
+    SELECT sc.id, sc.wallet_address, sc.token_id, sc.is_active, sc.nickname,
+           sc.current_activity, sc.activity_started_at, sc.activity_ends_at,
+           sc.bond_score, sc.total_interactions, sc.equipped_cosmetics,
+           sc.xp, sc.level, sc.created_at, sc.updated_at,
+           sc.xp as companion_xp, sc.level as companion_level,
+           ssm.constellation, ssm.aura, ssm.form, ssm.mood,
            ssm.background, ssm.eyes, ssm.hat, ssm.image_url,
            ssm.rarity_rank, ssm.attributes_json,
-           COALESCE(ux.total_xp, 0) as total_xp, COALESCE(ux.level, 1) as level
+           COALESCE(ux.total_xp, 0) as total_xp,
+           COALESCE(ux.level, 1) as wallet_level
     FROM sanctuary_companions sc
     LEFT JOIN star_skrumpey_metadata ssm ON sc.token_id = ssm.token_id
     LEFT JOIN user_xp ux ON sc.wallet_address = ux.wallet_address
     WHERE sc.wallet_address = ?
     ORDER BY sc.is_active DESC, sc.updated_at DESC
   `);
-  return stmt.all(walletAddress.toLowerCase()) as SanctuaryCompanionWithMeta[];
+  const rows = stmt.all(walletAddress.toLowerCase()) as (SanctuaryCompanionWithMeta & { wallet_level: number })[];
+  return rows.map((r) => ({ ...r, level: r.wallet_level }) as SanctuaryCompanionWithMeta);
 }
 
 export function selectCompanion(walletAddress: string, tokenId: number): SanctuaryCompanion {
@@ -6166,6 +6202,144 @@ const ACTIVITY_XP_REWARDS: Record<string, number> = {
   'Aura Forge': 40,
 };
 
+// --- Training Grounds (V1.7) ---
+// Per-companion XP thresholds (cumulative). Level 1 = 0-99 XP, Level 2 = 100-299 XP, etc.
+export const COMPANION_LEVEL_THRESHOLDS = [0, 100, 300, 600, 1000, 1500] as const;
+
+export function calculateCompanionLevel(xp: number): number {
+  let level = 1;
+  for (let i = 1; i < COMPANION_LEVEL_THRESHOLDS.length; i++) {
+    if (xp >= COMPANION_LEVEL_THRESHOLDS[i]) level = i + 1;
+    else break;
+  }
+  return level;
+}
+
+export interface CompanionTrainingTypeDef {
+  type: string;
+  label: string;
+  durationMinutes: number;
+  xpReward: number;
+  bondReward: number;
+  minLevel: number;
+  description: string;
+}
+
+// Training types keyed by name. Higher-level variants unlock at higher companion levels
+// and grant more XP (and longer duration).
+export const COMPANION_TRAINING_TYPES: Record<string, CompanionTrainingTypeDef> = {
+  Endurance: {
+    type: 'Endurance',
+    label: 'Endurance',
+    durationMinutes: 1,
+    xpReward: 40,
+    bondReward: 0.5,
+    minLevel: 1,
+    description: 'Short stamina drill. Quick XP for new companions.',
+  },
+  Agility: {
+    type: 'Agility',
+    label: 'Agility',
+    durationMinutes: 2,
+    xpReward: 85,
+    bondReward: 0.8,
+    minLevel: 2,
+    description: 'Reflex and speed work. Unlocks at level 2.',
+  },
+  Wisdom: {
+    type: 'Wisdom',
+    label: 'Wisdom',
+    durationMinutes: 5,
+    xpReward: 180,
+    bondReward: 1.2,
+    minLevel: 3,
+    description: 'Focused meditation drills. Unlocks at level 3.',
+  },
+  'Intense Endurance': {
+    type: 'Intense Endurance',
+    label: 'Intense Endurance',
+    durationMinutes: 10,
+    xpReward: 360,
+    bondReward: 2.0,
+    minLevel: 4,
+    description: 'Grueling stamina circuit. Unlocks at level 4.',
+  },
+  'Master Training': {
+    type: 'Master Training',
+    label: 'Master Training',
+    durationMinutes: 20,
+    xpReward: 700,
+    bondReward: 3.0,
+    minLevel: 5,
+    description: 'Peak conditioning across all disciplines. Unlocks at level 5.',
+  },
+};
+
+export function listTrainingTypesForLevel(companionLevel: number): CompanionTrainingTypeDef[] {
+  return Object.values(COMPANION_TRAINING_TYPES)
+    .filter((t) => t.minLevel <= companionLevel)
+    .sort((a, b) => a.minLevel - b.minLevel || a.xpReward - b.xpReward);
+}
+
+export function startCompanionTraining(
+  walletAddress: string,
+  tokenId: number,
+  trainingType: string,
+): { companion: SanctuaryCompanion; journal: SanctuaryJournalEntry; training: CompanionTrainingTypeDef } {
+  const def = COMPANION_TRAINING_TYPES[trainingType];
+  if (!def) throw new Error('Invalid training type');
+
+  const db = getDatabase();
+  const addr = walletAddress.toLowerCase();
+
+  const txn = db.transaction(() => {
+    const comp = db.prepare(
+      'SELECT * FROM sanctuary_companions WHERE wallet_address = ? AND token_id = ? AND is_active = 1'
+    ).get(addr, tokenId) as SanctuaryCompanion | undefined;
+
+    if (!comp) throw new Error('No active companion found');
+
+    if (comp.activity_ends_at) {
+      const endsAt = new Date(comp.activity_ends_at + 'Z').getTime();
+      if (endsAt > Date.now()) throw new Error('Companion is already on an activity');
+    }
+
+    const companionLevel = calculateCompanionLevel(comp.xp ?? 0);
+    if (companionLevel < def.minLevel) {
+      throw new Error(`Training requires companion level ${def.minLevel}`);
+    }
+
+    const now = new Date();
+    const endsAt = new Date(now.getTime() + def.durationMinutes * 60 * 1000);
+
+    db.prepare(`
+      UPDATE sanctuary_companions
+      SET current_activity = ?,
+          activity_started_at = ?,
+          activity_ends_at = ?,
+          total_interactions = total_interactions + 1,
+          updated_at = CURRENT_TIMESTAMP
+      WHERE id = ?
+    `).run(
+      `training:${def.type}`,
+      now.toISOString().replace('T', ' ').slice(0, 19),
+      endsAt.toISOString().replace('T', ' ').slice(0, 19),
+      comp.id,
+    );
+
+    const journal = addJournalEntry(addr, tokenId, 'activity',
+      `Began ${def.label} training at the Training Grounds. (${def.durationMinutes}m)`,
+      JSON.stringify({ action: 'start_training', training_type: def.type, duration_minutes: def.durationMinutes }));
+
+    const updated = db.prepare('SELECT * FROM sanctuary_companions WHERE id = ?')
+      .get(comp.id) as SanctuaryCompanion;
+
+    return { companion: updated, journal, training: def };
+  });
+
+  return txn();
+}
+
 export function sendToActivity(
   walletAddress: string, tokenId: number, locationId: number,
   options?: { durationMinutes?: number }
@@ -6229,10 +6403,22 @@ export function sendToActivity(
   return txn();
 }
 
+export interface CompleteActivityResult {
+  companion: SanctuaryCompanion;
+  journal: SanctuaryJournalEntry;
+  starBonus: boolean;
+  isTraining?: boolean;
+  trainingType?: string;
+  companionXpAwarded?: number;
+  levelBefore?: number;
+  levelAfter?: number;
+  leveledUp?: boolean;
+}
+
 export function completeActivity(
   walletAddress: string, tokenId: number,
   options?: { isStar?: boolean }
-): { companion: SanctuaryCompanion; journal: SanctuaryJournalEntry; starBonus: boolean } | null {
+): CompleteActivityResult | null {
   const db = getDatabase();
   const addr = walletAddress.toLowerCase();
 
@@ -6246,11 +6432,70 @@ export function completeActivity(
     const endsAt = new Date(comp.activity_ends_at + 'Z').getTime();
     if (endsAt > Date.now()) return null;
 
+    const starBonus = options?.isStar ?? false;
+    const isTraining = comp.current_activity.startsWith('training:');
+
+    if (isTraining) {
+      const trainingType = comp.current_activity.slice('training:'.length);
+      const def = COMPANION_TRAINING_TYPES[trainingType];
+      const xpBase = def?.xpReward ?? 20;
+      const bondBase = def?.bondReward ?? 0.5;
+      const bondReward = bondBase * (starBonus ? STAR_HOLDER_BOND_MULTIPLIER : 1);
+      const companionXpAwarded = Math.round(xpBase * (starBonus ? STAR_HOLDER_XP_MULTIPLIER : 1));
+
+      const xpBefore = comp.xp ?? 0;
+      const xpAfter = xpBefore + companionXpAwarded;
+      const levelBefore = calculateCompanionLevel(xpBefore);
+      const levelAfter = calculateCompanionLevel(xpAfter);
+
+      db.prepare(`
+        UPDATE sanctuary_companions
+        SET current_activity = 'lounging',
+            activity_started_at = NULL,
+            activity_ends_at = NULL,
+            bond_score = MIN(bond_score + ?, 100.0),
+            xp = ?,
+            level = ?,
+            updated_at = CURRENT_TIMESTAMP
+        WHERE id = ?
+      `).run(bondReward, xpAfter, levelAfter, comp.id);
+
+      addUserXP(addr, companionXpAwarded);
+
+      const bonusTag = starBonus ? ' (Star Bonus!)' : '';
+      const levelUpTag = levelAfter > levelBefore ? ` — LEVEL UP! ${levelBefore} → ${levelAfter}` : '';
+      const journal = addJournalEntry(addr, tokenId, 'activity',
+        `Finished ${trainingType} training. Bond +${bondReward.toFixed(1)}, XP +${companionXpAwarded}${bonusTag}${levelUpTag}`,
+        JSON.stringify({
+          action: 'complete_training',
+          training_type: trainingType,
+          bond_reward: bondReward,
+          companion_xp_awarded: companionXpAwarded,
+          level_before: levelBefore,
+          level_after: levelAfter,
+          starBonus,
+        }));
+
+      const updated = db.prepare('SELECT * FROM sanctuary_companions WHERE id = ?')
+        .get(comp.id) as SanctuaryCompanion;
+
+      return {
+        companion: updated,
+        journal,
+        starBonus,
+        isTraining: true,
+        trainingType,
+        companionXpAwarded,
+        levelBefore,
+        levelAfter,
+        leveledUp: levelAfter > levelBefore,
+      };
+    }
+
     const activityName = comp.current_activity.startsWith('exploring:')
       ? comp.current_activity.slice('exploring:'.length)
       : comp.current_activity;
 
-    const starBonus = options?.isStar ?? false;
     const bondReward = (ACTIVITY_BOND_REWARDS[activityName] ?? 1.0) * (starBonus ? STAR_HOLDER_BOND_MULTIPLIER : 1);
     const xpReward = Math.round((ACTIVITY_XP_REWARDS[activityName] ?? 5) * (starBonus ? STAR_HOLDER_XP_MULTIPLIER : 1));
 
@@ -6863,7 +7108,7 @@ export function interactWithCompanionV15(
 export function completeActivityV15(
   walletAddress: string, tokenId: number,
   options?: { isStar?: boolean }
-): { companion: SanctuaryCompanion; journal: SanctuaryJournalEntry; starBonus: boolean } | null {
+): CompleteActivityResult | null {
   const db = getDatabase();
   const addr = walletAddress.toLowerCase();
   const comp = db.prepare(
@@ -6873,6 +7118,7 @@ export function completeActivityV15(
   const activityName = comp?.current_activity?.startsWith('exploring:')
     ? comp.current_activity.slice('exploring:'.length)
     : null;
+  const wasTraining = comp?.current_activity?.startsWith('training:') ?? false;
 
   const result = completeActivity(walletAddress, tokenId, options);
   if (!result) return null;
@@ -6884,6 +7130,14 @@ export function completeActivityV15(
       incrementQuestProgress(addr, tokenId, trigger);
     }
     incrementQuestProgress(addr, tokenId, 'explore');
+  } else if (wasTraining) {
+    // Training finishing still counts as a Training Grounds exploration quest trigger
+    const trigger = ACTIVITY_TO_TRIGGER['Training Grounds'];
+    if (trigger) {
+      updateTraitProgress(addr, tokenId, trigger);
+      incrementQuestProgress(addr, tokenId, trigger);
+    }
+    incrementQuestProgress(addr, tokenId, 'train');
   }
 
   return result;

--- a/lib/sanctuary/rateLimit.ts
+++ b/lib/sanctuary/rateLimit.ts
@@ -13,6 +13,7 @@ const LIMITS: Record<string, RateLimitConfig> = {
   'companion/interact': { maxRequests: 20, windowSeconds: 60 },
   'companion/send-to-activity': { maxRequests: 10, windowSeconds: 60 },
   'companion/complete-activity': { maxRequests: 10, windowSeconds: 60 },
+  'companion/training': { maxRequests: 20, windowSeconds: 60 },
   'companion/chat': { maxRequests: 30, windowSeconds: 60 },
   'quests/claim': { maxRequests: 10, windowSeconds: 60 },
 };

--- a/scripts/init-sanctuary-v1.7.sql
+++ b/scripts/init-sanctuary-v1.7.sql
@@ -1,0 +1,15 @@
+-- Star Sanctuary — V1.7 Schema: Per-companion XP and level (Training Grounds)
+-- Run from lib/db.ts initializeSanctuary()
+--
+-- The columns `xp` and `level` on sanctuary_companions are added via ALTER TABLE
+-- in initializeSanctuary() (see lib/db.ts). ALTER TABLE with IF NOT EXISTS is
+-- not portable across SQLite versions, so the migration is handled in JS with
+-- a try/catch pattern matching the rest of the codebase.
+--
+-- Companion-level XP thresholds (see calculateCompanionLevel in lib/db.ts):
+--   Level 1: 0-99 XP
+--   Level 2: 100-299 XP
+--   Level 3: 300-599 XP
+--   Level 4: 600-999 XP
+--   Level 5: 1000-1499 XP
+--   Level 6+: 1500+ XP (cap reached)


### PR DESCRIPTION
## Summary
- Adds per-Skrumpey XP and level tracking via new `xp`/`level` columns on `sanctuary_companions`, with thresholds **0/100/300/600/1000/1500 XP** for levels 1–6.
- Training Wolf NPC (Valor) opens a training menu offering **Endurance / Agility / Wisdom** plus higher-tier drills that unlock at companion level 4 and 5 (Intense Endurance / Master Training). Each drill has its own duration, XP, and bond reward.
- HUD gains a new training XP bar (gold) showing per-Skrumpey level + progress alongside the existing bond and wallet XP bars.
- Claiming a completed training session awards per-Skrumpey XP, recomputes the level column, and emits a `companion-level-up` event that plays a celebration overlay.

## Implementation
- **Schema migration** (`scripts/init-sanctuary-v1.7.sql` + idempotent ALTER TABLE in `initializeSanctuary()`): adds `xp INTEGER DEFAULT 0` and `level INTEGER DEFAULT 1` to `sanctuary_companions`.
- **lib/db.ts**:
  - `COMPANION_LEVEL_THRESHOLDS`, `calculateCompanionLevel()`, `COMPANION_TRAINING_TYPES`, `listTrainingTypesForLevel()`.
  - `startCompanionTraining()` writes `current_activity = 'training:<type>'` with duration-based `activity_ends_at`.
  - `completeActivity()` extended: detects `training:*` prefix, writes `xp`/`level` directly on the companion, and returns `{ leveledUp, levelBefore, levelAfter, companionXpAwarded, isTraining, trainingType }`.
  - `SanctuaryCompanionWithMeta` now exposes `companion_xp` / `companion_level` alongside wallet-level `total_xp` / `level` (unchanged semantics for location unlocks).
- **API**: new `/api/sanctuary/companion/training` (GET lists locked/unlocked drills + current companion level/XP; POST starts a training session; wallet-auth + rate-limited).
- **QuestDialog**: when the Training Wolf NPC (`npc-training-grounds`) is clicked, a new training panel appears above the generic timed-quest panel. Locked drills are disabled with a requirement hint.
- **CompanionHUD**: new per-companion training bar (T{level}) plus existing Bond/XP bars. Claim handler emits `companion-level-up` on level crossing.
- **LevelUpCelebration** (new overlay): bloom-glow animation with level transition, registered in `SanctuaryV2.tsx`.

## Validation
- `npm run type-check`: **PASS** (0 errors)
- `npm run lint`: no new issues in changed files (pre-existing warnings only)
- `npm run build`: **PASS** — new route `/api/sanctuary/companion/training` included in route manifest
- `npm run test`: sanctuary + db tests **52/52 passing**; 4 `api-e2e.test.ts` failures are pre-existing (zod error-format drift + mock config) and identical on base branch `main` before these changes

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS (clean)
- **vitest run**: PASS (5 pre-existing failures in `api-e2e.test.ts` excluded — identical to baseline before overlay)
Overall: PASS

Only `lib/db.ts` and `scripts/init-sanctuary-v1.7.sql` were overlaid on the PROD mirror since the overlay components (`components/sanctuary/overlays/*`, `app/sanctuary/SanctuaryV2.tsx`, `lib/sanctuary/rateLimit.ts`) are part of the Sanctuary V2 system that is not yet deployed to PROD.

## Test plan
- [ ] Walk to Training Grounds room → click Valor → confirm training menu appears (not the timed-quest menu)
- [ ] Start an Endurance drill at level 1 → verify HUD countdown, then Claim → verify T-level XP bar fills
- [ ] Accumulate 100 XP → verify level-up celebration appears, HUD shows T2
- [ ] Confirm Agility drill becomes clickable only after reaching T2
- [ ] Verify Training Grounds location unlock on map still uses wallet level (not companion level)
- [ ] Restart server → verify `xp`/`level` columns persist and are restored in HUD

🤖 Generated with [Claude Code](https://claude.com/claude-code)