### PR TITLE
feat(sanctuary-v2): minigame framework + Star Catch arcade

### DIFF
--- a/app/api/sanctuary/minigame/leaderboard/route.ts
+++ b/app/api/sanctuary/minigame/leaderboard/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import {
+  getMinigameLeaderboard,
+  getMinigamePersonalBest,
+  SANCTUARY_MINIGAMES,
+  getMinigameDef,
+} from '@/lib/db';
+import { ethAddress, tokenId, parseSearchParams, formatZodError } from '@/lib/sanctuary/validation';
+
+const GAME_IDS = Object.keys(SANCTUARY_MINIGAMES) as [string, ...string[]];
+
+const querySchema = z.object({
+  game_id: z.enum(GAME_IDS),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+  address: ethAddress.optional(),
+  token_id: tokenId.optional(),
+});
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const parsed = parseSearchParams(querySchema, searchParams);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { success: false, error: formatZodError(parsed.error) },
+        { status: 400 },
+      );
+    }
+
+    const { game_id, limit, address, token_id: tid } = parsed.data;
+    const def = getMinigameDef(game_id);
+    if (!def) {
+      return NextResponse.json(
+        { success: false, error: 'Unknown minigame' },
+        { status: 404 },
+      );
+    }
+
+    const leaderboard = getMinigameLeaderboard(game_id, limit);
+
+    let personalBest = null;
+    if (address && tid !== undefined) {
+      personalBest = getMinigamePersonalBest(address, tid, game_id);
+    }
+
+    return NextResponse.json({
+      success: true,
+      game: def,
+      leaderboard,
+      personal_best: personalBest,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to fetch leaderboard';
+    return NextResponse.json({ success: false, error: message }, { status: 500 });
+  }
+}

--- a/app/api/sanctuary/minigame/score/route.ts
+++ b/app/api/sanctuary/minigame/score/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { submitMinigameScore, SANCTUARY_MINIGAMES } from '@/lib/db';
+import { verifyWalletAccess } from '@/lib/walletAuth';
+import { applyRateLimit } from '@/lib/sanctuary/rateLimit';
+import { ethAddress, tokenId, parseBody, formatZodError } from '@/lib/sanctuary/validation';
+import { verifyTokenOwnership } from '@/lib/skrumpeyOwnership';
+
+const GAME_IDS = Object.keys(SANCTUARY_MINIGAMES) as [string, ...string[]];
+
+const bodySchema = z.object({
+  address: ethAddress,
+  token_id: tokenId,
+  game_id: z.enum(GAME_IDS),
+  score: z.number().int().min(0).max(99999),
+});
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const parsed = parseBody(bodySchema, body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { success: false, error: formatZodError(parsed.error) },
+        { status: 400 },
+      );
+    }
+
+    const { address, token_id: tid, game_id, score } = parsed.data;
+
+    const auth = await verifyWalletAccess(request, address);
+    if (!auth.valid) {
+      return NextResponse.json({ success: false, error: auth.error }, { status: 401 });
+    }
+
+    const rateLimited = applyRateLimit(address, 'minigame/score');
+    if (rateLimited) return rateLimited;
+
+    const owns = await verifyTokenOwnership(address, tid);
+    if (!owns) {
+      return NextResponse.json(
+        { success: false, error: 'You do not own this Skrumpey.' },
+        { status: 403 },
+      );
+    }
+
+    const result = submitMinigameScore(address, tid, game_id, score);
+    return NextResponse.json({ success: true, ...result });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to record score';
+    const status = message.includes('Invalid minigame') ? 400
+      : message.includes('Invalid score') ? 400
+      : 500;
+    return NextResponse.json({ success: false, error: message }, { status });
+  }
+}

--- a/app/sanctuary/SanctuaryV2.tsx
+++ b/app/sanctuary/SanctuaryV2.tsx
@@ -41,6 +41,11 @@ const QuestDialog = dynamic(
   { ssr: false }
 );
 
+const MinigameDialog = dynamic(
+  () => import('@/components/sanctuary/overlays/MinigameDialog'),
+  { ssr: false }
+);
+
 const QuestBoard = dynamic(
   () => import('@/components/sanctuary/overlays/QuestBoard'),
   { ssr: false }
@@ -150,6 +155,7 @@ export default function SanctuaryV2() {
           />
         )}
         <QuestDialog walletAddress={address} tokenId={activeTokenId} />
+        <MinigameDialog walletAddress={address} tokenId={activeTokenId} />
         <QuestBoard walletAddress={address} tokenId={activeTokenId} />
         <QuestTracker walletAddress={address} tokenId={activeTokenId} />
         <JournalOverlay walletAddress={address} tokenId={activeTokenId} />

--- a/components/sanctuary/overlays/MinigameDialog.tsx
+++ b/components/sanctuary/overlays/MinigameDialog.tsx
@@ -1,0 +1,318 @@
+'use client';
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import EventBus from '@/components/sanctuary/EventBus';
+import { getWalletAuthHeader } from '@/lib/clientWalletAuth';
+
+interface NPCClickPayload {
+  npcId: string;
+  npcName: string;
+  zone: string;
+  dialogue: string;
+  screenX: number;
+  screenY: number;
+}
+
+interface MinigameCompletePayload {
+  gameId: string;
+  tokenId: number | null;
+  score: number;
+  durationSeconds: number;
+}
+
+interface LeaderboardRow {
+  rank: number;
+  wallet_address: string;
+  token_id: number;
+  score: number;
+  played_at: string;
+}
+
+interface GameMeta {
+  game_id: string;
+  label: string;
+  description: string;
+  durationSeconds: number;
+  firstPlayBonusStar: number;
+}
+
+interface PersonalBest {
+  personal_best: number;
+  total_plays: number;
+  total_star_earned: number;
+}
+
+// NPC IDs that launch minigames + their game_id mapping
+const MINIGAME_NPCS: Record<string, { gameId: string; sceneKey: string; defaultRoom: string }> = {
+  'npc-observatory-arcade': {
+    gameId: 'star-catch',
+    sceneKey: 'StarCatchScene',
+    defaultRoom: 'Observatory',
+  },
+};
+
+export default function MinigameDialog({
+  walletAddress,
+  tokenId,
+}: {
+  walletAddress: string | undefined;
+  tokenId: number | null;
+}) {
+  const [npc, setNpc] = useState<NPCClickPayload | null>(null);
+  const [visible, setVisible] = useState(false);
+  const [game, setGame] = useState<GameMeta | null>(null);
+  const [leaderboard, setLeaderboard] = useState<LeaderboardRow[]>([]);
+  const [personalBest, setPersonalBest] = useState<PersonalBest | null>(null);
+  const [submissionError, setSubmissionError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  const close = useCallback(() => {
+    setVisible(false);
+    setTimeout(() => {
+      setNpc(null);
+      setSubmissionError(null);
+    }, 200);
+  }, []);
+
+  const loadLeaderboard = useCallback(async (gameId: string) => {
+    try {
+      const params = new URLSearchParams({ game_id: gameId, limit: '20' });
+      if (walletAddress) params.set('address', walletAddress);
+      if (tokenId !== null) params.set('token_id', String(tokenId));
+      const res = await fetch(`/api/sanctuary/minigame/leaderboard?${params.toString()}`);
+      if (!res.ok) return;
+      const data = await res.json();
+      if (data.success) {
+        setGame(data.game);
+        setLeaderboard(data.leaderboard ?? []);
+        setPersonalBest(data.personal_best ?? null);
+      }
+    } catch {
+      // Non-critical
+    }
+  }, [walletAddress, tokenId]);
+
+  const handleNPCClick = useCallback((payload: NPCClickPayload) => {
+    const meta = MINIGAME_NPCS[payload.npcId];
+    if (!meta) return;
+    setNpc(payload);
+    setVisible(true);
+    setSubmissionError(null);
+    loadLeaderboard(meta.gameId);
+  }, [loadLeaderboard]);
+
+  useEffect(() => {
+    EventBus.on('npc-clicked', handleNPCClick);
+    return () => {
+      EventBus.off('npc-clicked', handleNPCClick);
+    };
+  }, [handleNPCClick]);
+
+  // Listen for minigame completion → POST score → broadcast result back to scene
+  useEffect(() => {
+    const handleComplete = async (payload: MinigameCompletePayload) => {
+      if (!walletAddress || payload.tokenId === null) {
+        EventBus.emit('minigame-result-update', {
+          gameId: payload.gameId,
+          starAwarded: 0,
+          personalBest: payload.score,
+          isFirstPlay: false,
+          isNewPersonalBest: false,
+          totalPlays: 0,
+        });
+        setSubmissionError('Connect a wallet and select a Skrumpey to save scores.');
+        return;
+      }
+      setSubmitting(true);
+      setSubmissionError(null);
+      try {
+        const authHeader = await getWalletAuthHeader(walletAddress);
+        if (!authHeader) {
+          setSubmitting(false);
+          return;
+        }
+        const res = await fetch('/api/sanctuary/minigame/score', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-wallet-auth': authHeader,
+          },
+          body: JSON.stringify({
+            address: walletAddress,
+            token_id: payload.tokenId,
+            game_id: payload.gameId,
+            score: payload.score,
+          }),
+        });
+        const data = await res.json();
+        if (!data.success) {
+          setSubmissionError(data.error ?? 'Failed to save score.');
+          EventBus.emit('minigame-result-update', {
+            gameId: payload.gameId,
+            starAwarded: 0,
+            personalBest: payload.score,
+            isFirstPlay: false,
+            isNewPersonalBest: false,
+            totalPlays: 0,
+          });
+          return;
+        }
+        EventBus.emit('minigame-result-update', {
+          gameId: payload.gameId,
+          starAwarded: data.star_awarded,
+          personalBest: data.personal_best,
+          isFirstPlay: data.is_first_play,
+          isNewPersonalBest: data.is_new_personal_best,
+          totalPlays: data.total_plays,
+        });
+        loadLeaderboard(payload.gameId);
+      } catch {
+        setSubmissionError('Failed to save score.');
+      } finally {
+        setSubmitting(false);
+      }
+    };
+
+    const handleExit = () => {
+      // Scene reports exit via WorldScene/RoomScene wake handler.
+      // No-op here; we keep the dialog state intact for next time.
+    };
+
+    EventBus.on('minigame-complete', handleComplete);
+    EventBus.on('minigame-exit', handleExit);
+    return () => {
+      EventBus.off('minigame-complete', handleComplete);
+      EventBus.off('minigame-exit', handleExit);
+    };
+  }, [walletAddress, loadLeaderboard]);
+
+  useEffect(() => {
+    if (!visible) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        close();
+      }
+    };
+    const timer = setTimeout(() => {
+      document.addEventListener('mousedown', handleClickOutside);
+    }, 50);
+    return () => {
+      clearTimeout(timer);
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [visible, close]);
+
+  const launchGame = useCallback(() => {
+    if (!npc) return;
+    const meta = MINIGAME_NPCS[npc.npcId];
+    if (!meta) return;
+    EventBus.emit('minigame-launch', {
+      gameId: meta.gameId,
+      sceneKey: meta.sceneKey,
+      tokenId,
+      returnRoom: meta.defaultRoom,
+      durationSeconds: game?.durationSeconds,
+      title: game?.label ?? meta.gameId.toUpperCase(),
+    });
+    close();
+  }, [npc, tokenId, game, close]);
+
+  if (!npc) return null;
+
+  return (
+    <div className="absolute inset-0 z-40 pointer-events-none">
+      <div
+        ref={panelRef}
+        className={`absolute right-4 top-4 w-80 max-h-[85%] overflow-y-auto pointer-events-auto
+          bg-black/95 border border-[#00f7ff]/40 rounded-lg shadow-[0_0_20px_rgba(0,247,255,0.2)]
+          transition-all duration-200 ${
+            visible ? 'opacity-100 translate-x-0' : 'opacity-0 translate-x-4'
+          }`}
+      >
+        <div className="sticky top-0 bg-black/95 border-b border-[#00f7ff]/20 p-3 z-10">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <span className="text-lg">🎮</span>
+              <div>
+                <h3 className="text-[#00f7ff] font-['Press_Start_2P'] text-[8px]">
+                  {npc.npcName}
+                </h3>
+                <span className="text-gray-500 text-[6px]">{npc.zone}</span>
+              </div>
+            </div>
+            <button
+              onClick={close}
+              className="text-gray-500 hover:text-white text-sm transition-colors"
+            >
+              ✕
+            </button>
+          </div>
+          <p className="text-gray-400 text-[7px] mt-2 italic">&ldquo;{npc.dialogue}&rdquo;</p>
+        </div>
+
+        {game && (
+          <div className="p-3 border-b border-[#2a2a4e] space-y-1.5">
+            <div className="flex items-center gap-1.5">
+              <span className="text-[8px]">🌟</span>
+              <span className="text-[#ffd700] font-['Press_Start_2P'] text-[8px] uppercase tracking-wider">
+                {game.label}
+              </span>
+            </div>
+            <p className="text-gray-400 text-[7px] leading-tight">{game.description}</p>
+            <p className="text-gray-500 text-[6px]">
+              Round: {game.durationSeconds}s · First-play bonus: +{game.firstPlayBonusStar} STAR
+            </p>
+            {personalBest && personalBest.total_plays > 0 && (
+              <p className="text-[#9966ff] text-[7px]">
+                Your best: {personalBest.personal_best} (×{personalBest.total_plays} plays · {personalBest.total_star_earned} STAR earned)
+              </p>
+            )}
+            <button
+              onClick={launchGame}
+              disabled={tokenId === null}
+              className="mt-2 w-full px-3 py-2 rounded border border-[#00f7ff] bg-[#00f7ff]/20 hover:bg-[#00f7ff]/30 text-[#00f7ff] text-[8px] font-['Press_Start_2P'] disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+            >
+              {tokenId === null ? 'SELECT A SKRUMPEY' : 'PLAY NOW'}
+            </button>
+            {submitting && (
+              <p className="text-[#ffd700] text-[7px]">Saving last score...</p>
+            )}
+            {submissionError && (
+              <p className="text-red-400 text-[7px]">{submissionError}</p>
+            )}
+          </div>
+        )}
+
+        <div className="p-3">
+          <div className="flex items-center gap-1.5 mb-2">
+            <span className="text-[8px]">🏆</span>
+            <span className="text-[#ff66aa] font-['Press_Start_2P'] text-[7px] uppercase tracking-wider">
+              Leaderboard · Top 20
+            </span>
+          </div>
+          {leaderboard.length === 0 ? (
+            <p className="text-gray-500 text-[7px] italic">No scores yet — be the first!</p>
+          ) : (
+            <ol className="space-y-0.5">
+              {leaderboard.map((row) => (
+                <li
+                  key={`${row.wallet_address}-${row.token_id}`}
+                  className="flex items-center justify-between text-[7px] text-white font-mono"
+                >
+                  <span className="text-gray-400">
+                    #{row.rank.toString().padStart(2, '0')}
+                  </span>
+                  <span className="text-[#9966ff]">
+                    {row.wallet_address.slice(0, 6)}...{row.wallet_address.slice(-4)}
+                  </span>
+                  <span className="text-[#ffd700]">{row.score}</span>
+                </li>
+              ))}
+            </ol>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/sanctuary/overlays/QuestDialog.tsx
+++ b/components/sanctuary/overlays/QuestDialog.tsx
@@ -165,7 +165,11 @@ export default function QuestDialog({
 
   const handleNPCClick = useCallback(
     (payload: NPCClickPayload) => {
-      if (payload.npcId === 'spawn-fox' || payload.npcId === 'quest-board') {
+      if (
+        payload.npcId === 'spawn-fox'
+        || payload.npcId === 'quest-board'
+        || payload.npcId.startsWith('npc-observatory-arcade')
+      ) {
         return;
       }
       setNpc(payload);

--- a/game/config/GameConfig.ts
+++ b/game/config/GameConfig.ts
@@ -2,6 +2,7 @@ import Phaser from 'phaser';
 import { BootScene } from '../scenes/BootScene';
 import { WorldScene } from '../scenes/WorldScene';
 import { RoomScene } from '../scenes/RoomScene';
+import { StarCatchScene } from '../scenes/StarCatchScene';
 
 export const GAME_CONFIG: Phaser.Types.Core.GameConfig = {
   type: Phaser.AUTO,
@@ -20,7 +21,7 @@ export const GAME_CONFIG: Phaser.Types.Core.GameConfig = {
       debug: false,
     },
   },
-  scene: [BootScene, WorldScene, RoomScene],
+  scene: [BootScene, WorldScene, RoomScene, StarCatchScene],
   pixelArt: true,
   antialias: false,
   roundPixels: true,

--- a/game/config/npcDefinitions.ts
+++ b/game/config/npcDefinitions.ts
@@ -16,7 +16,8 @@ export interface NPCDefinition {
   spriteColor: number;
   spriteFile?: string;
   roomPlacement?: RoomPlacement;
-  kind?: 'quest' | 'intro' | 'board';
+  kind?: 'quest' | 'intro' | 'board' | 'minigame';
+  minigameId?: string;
 }
 
 export const NPC_DEFINITIONS: NPCDefinition[] = [
@@ -117,6 +118,18 @@ export const NPC_DEFINITIONS: NPCDefinition[] = [
     spriteColor: 0xffffaa,
     spriteFile: 'Observatory_Owl_Sprite.png',
     roomPlacement: { room: 'Observatory', x: 720, y: 440 },
+  },
+  {
+    id: 'npc-observatory-arcade',
+    name: 'Star Catch Arcade',
+    x: Math.round(0.5 * WORLD_WIDTH) + 30,
+    y: Math.round(0.1 * WORLD_HEIGHT) + 50,
+    zone: 'Observatory',
+    dialogue: 'A retro cabinet flickers. Ready to chase falling stars?',
+    spriteColor: 0x00f7ff,
+    roomPlacement: { room: 'Observatory', x: 480, y: 480 },
+    kind: 'minigame',
+    minigameId: 'star-catch',
   },
   {
     id: 'npc-aura-forge',

--- a/game/scenes/MinigameScene.ts
+++ b/game/scenes/MinigameScene.ts
@@ -1,0 +1,468 @@
+import Phaser from 'phaser';
+import EventBus from '@/components/sanctuary/EventBus';
+import type { RoomKey } from '../config/worldLayout';
+
+export interface MinigameLaunchData {
+  gameId: string;
+  tokenId: number | null;
+  returnRoom: RoomKey;
+  returnTo: { x: number; y: number };
+  durationSeconds?: number;
+  title?: string;
+}
+
+export interface MinigameCompletePayload {
+  gameId: string;
+  tokenId: number | null;
+  score: number;
+  durationSeconds: number;
+}
+
+export interface MinigameResultUpdate {
+  gameId: string;
+  starAwarded: number;
+  personalBest: number;
+  isFirstPlay: boolean;
+  isNewPersonalBest: boolean;
+  totalPlays: number;
+}
+
+type Phase = 'intro' | 'playing' | 'paused' | 'result';
+
+const SCREEN_W = 1200;
+const SCREEN_H = 900;
+
+export abstract class MinigameScene extends Phaser.Scene {
+  protected gameId: string = '';
+  protected gameTitle: string = 'MINIGAME';
+  protected tokenId: number | null = null;
+  protected returnRoom: RoomKey | null = null;
+  protected returnTo: { x: number; y: number } = { x: 600, y: 800 };
+  protected durationSeconds: number = 60;
+  protected score: number = 0;
+  protected phase: Phase = 'intro';
+  protected timeRemaining: number = 0;
+  protected lastTickAt: number = 0;
+  protected exiting = false;
+
+  // HUD elements (managed by base)
+  private scoreText: Phaser.GameObjects.Text | null = null;
+  private timerText: Phaser.GameObjects.Text | null = null;
+  private titleText: Phaser.GameObjects.Text | null = null;
+  private overlayContainer: Phaser.GameObjects.Container | null = null;
+
+  // Result-screen state populated via 'minigame-result-update'
+  private serverStarAwarded: number | null = null;
+  private serverPersonalBest: number | null = null;
+  private serverIsNewPB: boolean = false;
+  private serverIsFirstPlay: boolean = false;
+  private resultStatusText: Phaser.GameObjects.Text | null = null;
+  private resultDetailText: Phaser.GameObjects.Text | null = null;
+
+  constructor(key: string) {
+    super({ key });
+  }
+
+  create(data: MinigameLaunchData) {
+    this.gameId = data.gameId;
+    this.tokenId = data.tokenId;
+    this.returnRoom = data.returnRoom;
+    this.returnTo = data.returnTo;
+    this.durationSeconds = Math.max(15, Math.min(data.durationSeconds ?? 60, 120));
+    this.gameTitle = data.title ?? this.gameId.toUpperCase();
+    this.score = 0;
+    this.phase = 'intro';
+    this.timeRemaining = this.durationSeconds;
+    this.exiting = false;
+    this.serverStarAwarded = null;
+    this.serverPersonalBest = null;
+    this.serverIsNewPB = false;
+    this.serverIsFirstPlay = false;
+
+    this.cameras.main.setBackgroundColor('#0a0015');
+    this.cameras.main.fadeIn(250, 0, 0, 0);
+
+    this.drawBackdrop();
+    this.setupHUD();
+    this.setup();
+    this.showIntro();
+
+    this.input.keyboard!.on('keydown-ESC', () => this.handleEscape());
+    this.input.keyboard!.on('keydown-P', () => this.togglePause());
+
+    EventBus.on('minigame-result-update', this.handleResultUpdate, this);
+  }
+
+  /** Subclass hook — preload assets and create game objects (idle state). */
+  protected abstract setup(): void;
+
+  /** Subclass hook — start the active gameplay logic. Called when phase → playing. */
+  protected abstract startPlay(): void;
+
+  /** Subclass hook — pause/resume logic for active gameplay. */
+  protected abstract setPlayPaused(paused: boolean): void;
+
+  /** Subclass hook — clean up gameplay objects/timers when entering result phase. */
+  protected abstract teardownPlay(): void;
+
+  /** Subclass hook — per-frame update during the playing phase only. */
+  protected abstract updatePlaying(_time: number, _delta: number): void;
+
+  /** Subclasses call this whenever they want to add to the score. */
+  protected addScore(delta: number) {
+    if (this.phase !== 'playing') return;
+    this.score = Math.max(0, Math.floor(this.score + delta));
+    this.refreshHUD();
+  }
+
+  // ----- Phase management ---------------------------------------------------
+
+  private showIntro() {
+    this.phase = 'intro';
+    this.refreshHUD();
+    this.showOverlay({
+      title: this.gameTitle,
+      lines: [
+        `${this.durationSeconds}s round.`,
+        'Score points to earn STAR XP.',
+        'First play of the round grants a bonus.',
+      ],
+      buttons: [
+        { label: 'BEGIN [SPACE]', onClick: () => this.beginPlay() },
+        { label: 'EXIT [ESC]', onClick: () => this.requestExit() },
+      ],
+    });
+    const space = this.input.keyboard!.addKey(Phaser.Input.Keyboard.KeyCodes.SPACE);
+    space.once('down', () => {
+      if (this.phase === 'intro') this.beginPlay();
+    });
+  }
+
+  private beginPlay() {
+    this.hideOverlay();
+    this.phase = 'playing';
+    this.timeRemaining = this.durationSeconds;
+    this.lastTickAt = this.time.now;
+    this.refreshHUD();
+    this.startPlay();
+  }
+
+  private togglePause() {
+    if (this.phase === 'playing') {
+      this.phase = 'paused';
+      this.setPlayPaused(true);
+      this.showOverlay({
+        title: 'PAUSED',
+        lines: [`Score: ${this.score}`, `Time left: ${Math.ceil(this.timeRemaining)}s`],
+        buttons: [
+          { label: 'RESUME [P]', onClick: () => this.togglePause() },
+          { label: 'EXIT [ESC]', onClick: () => this.requestExit() },
+        ],
+      });
+    } else if (this.phase === 'paused') {
+      this.hideOverlay();
+      this.phase = 'playing';
+      this.lastTickAt = this.time.now;
+      this.setPlayPaused(false);
+    }
+  }
+
+  private finishPlay() {
+    if (this.phase === 'result') return;
+    this.phase = 'result';
+    this.teardownPlay();
+    this.refreshHUD();
+    this.showResultScreen();
+
+    const payload: MinigameCompletePayload = {
+      gameId: this.gameId,
+      tokenId: this.tokenId,
+      score: this.score,
+      durationSeconds: this.durationSeconds,
+    };
+    EventBus.emit('minigame-complete', payload);
+  }
+
+  private handleResultUpdate(update: MinigameResultUpdate) {
+    if (update.gameId !== this.gameId) return;
+    this.serverStarAwarded = update.starAwarded;
+    this.serverPersonalBest = update.personalBest;
+    this.serverIsNewPB = update.isNewPersonalBest;
+    this.serverIsFirstPlay = update.isFirstPlay;
+    this.refreshResultText();
+  }
+
+  private handleEscape() {
+    if (this.phase === 'playing') {
+      this.togglePause();
+      return;
+    }
+    if (this.phase === 'paused' || this.phase === 'intro' || this.phase === 'result') {
+      this.requestExit();
+    }
+  }
+
+  private requestExit() {
+    if (this.exiting) return;
+    this.exiting = true;
+    if (this.phase === 'playing') {
+      // Skip scoring submission — player bailed mid-round.
+      this.teardownPlay();
+    }
+    this.cameras.main.fadeOut(250, 0, 0, 0);
+    this.time.delayedCall(260, () => {
+      EventBus.emit('minigame-exit', {
+        gameId: this.gameId,
+        returnRoom: this.returnRoom,
+        returnTo: this.returnTo,
+      });
+    });
+  }
+
+  // ----- Frame loop ---------------------------------------------------------
+
+  update(time: number, delta: number) {
+    if (this.phase !== 'playing') return;
+    const dtSec = delta / 1000;
+    this.timeRemaining -= dtSec;
+    if (this.timeRemaining <= 0) {
+      this.timeRemaining = 0;
+      this.refreshHUD();
+      this.finishPlay();
+      return;
+    }
+    this.refreshHUD();
+    this.updatePlaying(time, delta);
+  }
+
+  // ----- Pixel-art HUD/overlay primitives -----------------------------------
+
+  private drawBackdrop() {
+    const g = this.add.graphics().setDepth(-5).setScrollFactor(0);
+    g.fillGradientStyle(0x1a0033, 0x1a0033, 0x0a0015, 0x0a0015, 1);
+    g.fillRect(0, 0, SCREEN_W, SCREEN_H);
+    // Synthwave grid lines for retro feel
+    g.lineStyle(1, 0x00f7ff, 0.15);
+    for (let x = 0; x < SCREEN_W; x += 40) {
+      g.lineBetween(x, 0, x, SCREEN_H);
+    }
+    for (let y = 0; y < SCREEN_H; y += 40) {
+      g.lineBetween(0, y, SCREEN_W, y);
+    }
+  }
+
+  private setupHUD() {
+    this.titleText = this.add
+      .text(SCREEN_W / 2, 24, this.gameTitle, {
+        fontFamily: '"Press Start 2P", monospace',
+        fontSize: '16px',
+        color: '#ffd700',
+        stroke: '#000000',
+        strokeThickness: 4,
+        backgroundColor: 'rgba(10,0,21,0.75)',
+        padding: { x: 14, y: 6 },
+      })
+      .setOrigin(0.5, 0)
+      .setScrollFactor(0)
+      .setDepth(100);
+
+    this.scoreText = this.add
+      .text(20, 60, '', {
+        fontFamily: '"Press Start 2P", monospace',
+        fontSize: '12px',
+        color: '#00f7ff',
+        stroke: '#000000',
+        strokeThickness: 3,
+      })
+      .setScrollFactor(0)
+      .setDepth(100);
+
+    this.timerText = this.add
+      .text(SCREEN_W - 20, 60, '', {
+        fontFamily: '"Press Start 2P", monospace',
+        fontSize: '12px',
+        color: '#ff66aa',
+        stroke: '#000000',
+        strokeThickness: 3,
+      })
+      .setOrigin(1, 0)
+      .setScrollFactor(0)
+      .setDepth(100);
+
+    this.refreshHUD();
+  }
+
+  private refreshHUD() {
+    if (this.scoreText) this.scoreText.setText(`SCORE  ${this.score}`);
+    if (this.timerText) this.timerText.setText(`TIME  ${Math.ceil(this.timeRemaining)}s`);
+  }
+
+  private clearOverlay() {
+    if (this.overlayContainer) {
+      this.overlayContainer.destroy();
+      this.overlayContainer = null;
+    }
+    this.resultStatusText = null;
+    this.resultDetailText = null;
+  }
+
+  private hideOverlay() {
+    this.clearOverlay();
+  }
+
+  private showOverlay(opts: {
+    title: string;
+    lines: string[];
+    buttons: { label: string; onClick: () => void }[];
+    extra?: (container: Phaser.GameObjects.Container) => void;
+  }) {
+    this.clearOverlay();
+    const w = 560;
+    const h = 380;
+    const x = SCREEN_W / 2;
+    const y = SCREEN_H / 2;
+    const container = this.add.container(x, y).setScrollFactor(0).setDepth(200);
+
+    // Pixel-art panel: outer cyan stroke + inner dark fill + accent border
+    const panelG = this.add.graphics();
+    panelG.fillStyle(0x0a0015, 0.95);
+    panelG.fillRect(-w / 2, -h / 2, w, h);
+    panelG.lineStyle(3, 0x00f7ff, 1);
+    panelG.strokeRect(-w / 2, -h / 2, w, h);
+    panelG.lineStyle(1, 0xff00ff, 0.8);
+    panelG.strokeRect(-w / 2 + 4, -h / 2 + 4, w - 8, h - 8);
+    container.add(panelG);
+
+    const titleObj = this.add
+      .text(0, -h / 2 + 28, opts.title, {
+        fontFamily: '"Press Start 2P", monospace',
+        fontSize: '18px',
+        color: '#ffd700',
+        stroke: '#000000',
+        strokeThickness: 4,
+      })
+      .setOrigin(0.5, 0);
+    container.add(titleObj);
+
+    opts.lines.forEach((line, i) => {
+      const lineObj = this.add
+        .text(0, -h / 2 + 80 + i * 26, line, {
+          fontFamily: '"Press Start 2P", monospace',
+          fontSize: '10px',
+          color: '#00f7ff',
+          stroke: '#000000',
+          strokeThickness: 2,
+          align: 'center',
+        })
+        .setOrigin(0.5, 0);
+      container.add(lineObj);
+    });
+
+    opts.extra?.(container);
+
+    const btnY = h / 2 - 60;
+    const btnSpacing = 220;
+    const btnStartX = -((opts.buttons.length - 1) * btnSpacing) / 2;
+    opts.buttons.forEach((btn, i) => {
+      const bx = btnStartX + i * btnSpacing;
+      const btnG = this.add.graphics();
+      btnG.fillStyle(0x9966ff, 0.25);
+      btnG.fillRect(-90, -16, 180, 32);
+      btnG.lineStyle(2, 0x9966ff, 1);
+      btnG.strokeRect(-90, -16, 180, 32);
+      const label = this.add
+        .text(0, 0, btn.label, {
+          fontFamily: '"Press Start 2P", monospace',
+          fontSize: '10px',
+          color: '#ffffff',
+          stroke: '#000000',
+          strokeThickness: 2,
+        })
+        .setOrigin(0.5);
+      const btnContainer = this.add.container(bx, btnY, [btnG, label]);
+      btnContainer.setSize(180, 32);
+      btnContainer.setInteractive({ useHandCursor: true });
+      btnContainer.on('pointerover', () => label.setColor('#ffd700'));
+      btnContainer.on('pointerout', () => label.setColor('#ffffff'));
+      btnContainer.on('pointerdown', () => btn.onClick());
+      container.add(btnContainer);
+    });
+
+    this.overlayContainer = container;
+  }
+
+  private showResultScreen() {
+    this.showOverlay({
+      title: 'ROUND COMPLETE',
+      lines: [
+        `Score: ${this.score}`,
+        '',
+        'STAR  +calculating...',
+        'Personal Best: ...',
+      ],
+      buttons: [
+        { label: 'PLAY AGAIN [SPACE]', onClick: () => this.replay() },
+        { label: 'EXIT TO ROOM [ESC]', onClick: () => this.requestExit() },
+      ],
+      extra: (container) => {
+        // Replace the placeholder lines with named refs we can update later.
+        const status = this.add
+          .text(0, -20, 'STAR  +calculating...', {
+            fontFamily: '"Press Start 2P", monospace',
+            fontSize: '12px',
+            color: '#ffd700',
+            stroke: '#000000',
+            strokeThickness: 3,
+          })
+          .setOrigin(0.5);
+        const detail = this.add
+          .text(0, 14, 'Personal Best: ...', {
+            fontFamily: '"Press Start 2P", monospace',
+            fontSize: '9px',
+            color: '#9966ff',
+            stroke: '#000000',
+            strokeThickness: 2,
+          })
+          .setOrigin(0.5);
+        container.add([status, detail]);
+        this.resultStatusText = status;
+        this.resultDetailText = detail;
+        this.refreshResultText();
+      },
+    });
+
+    const space = this.input.keyboard!.addKey(Phaser.Input.Keyboard.KeyCodes.SPACE);
+    space.once('down', () => {
+      if (this.phase === 'result') this.replay();
+    });
+  }
+
+  private refreshResultText() {
+    if (!this.resultStatusText || !this.resultDetailText) return;
+    if (this.serverStarAwarded === null) {
+      this.resultStatusText.setText('STAR  +calculating...');
+      this.resultDetailText.setText('Saving score...');
+      return;
+    }
+    const bonusTag = this.serverIsFirstPlay ? ' (first-play bonus!)' : '';
+    this.resultStatusText.setText(`STAR  +${this.serverStarAwarded}${bonusTag}`);
+    const pb = this.serverPersonalBest ?? this.score;
+    const pbTag = this.serverIsNewPB ? '  ★ NEW BEST' : '';
+    this.resultDetailText.setText(`Personal Best: ${pb}${pbTag}`);
+  }
+
+  private replay() {
+    this.score = 0;
+    this.serverStarAwarded = null;
+    this.serverPersonalBest = null;
+    this.serverIsNewPB = false;
+    this.serverIsFirstPlay = false;
+    this.refreshResultText();
+    this.beginPlay();
+  }
+
+  shutdown() {
+    EventBus.off('minigame-result-update', this.handleResultUpdate, this);
+    this.clearOverlay();
+  }
+}

--- a/game/scenes/RoomScene.ts
+++ b/game/scenes/RoomScene.ts
@@ -80,6 +80,51 @@ export class RoomScene extends Phaser.Scene {
     this.input.keyboard!.on('keydown-T', () => {
       EventBus.emit('traits-overlay-toggle');
     });
+
+    EventBus.on('minigame-launch', this.handleMinigameLaunch, this);
+    EventBus.on('minigame-exit', this.handleMinigameExit, this);
+  }
+
+  private handleMinigameLaunch(payload: {
+    gameId: string;
+    sceneKey: string;
+    tokenId: number | null;
+    durationSeconds?: number;
+    title?: string;
+  }) {
+    if (this.exiting) return;
+    if (!this.scene.manager.keys[payload.sceneKey]) return;
+    this.cameras.main.fadeOut(250, 0, 0, 0);
+    this.time.delayedCall(260, () => {
+      const returnTo = { x: this.player.x, y: this.player.y };
+      this.scene.sleep();
+      this.scene.launch(payload.sceneKey, {
+        gameId: payload.gameId,
+        tokenId: payload.tokenId,
+        returnRoom: this.room,
+        returnTo,
+        durationSeconds: payload.durationSeconds,
+        title: payload.title,
+      });
+    });
+  }
+
+  private handleMinigameExit(payload: { returnRoom?: string; returnTo?: { x: number; y: number } }) {
+    if (!payload?.returnRoom || payload.returnRoom !== this.room) return;
+    if (!this.scene.isSleeping()) return;
+    // Stop any minigame scene that's still active.
+    const keys = ['StarCatchScene'];
+    for (const k of keys) {
+      if (this.scene.manager.getScene(k)?.scene.isActive()) {
+        this.scene.stop(k);
+      }
+    }
+    this.scene.wake();
+    this.cameras.main.fadeIn(250, 0, 0, 0);
+    if (payload.returnTo && this.player) {
+      this.player.setPosition(payload.returnTo.x, payload.returnTo.y);
+      this.companion.setPosition(payload.returnTo.x + 20, payload.returnTo.y + 10);
+    }
   }
 
   private buildNavGrid() {
@@ -218,5 +263,7 @@ export class RoomScene extends Phaser.Scene {
   shutdown() {
     this.npcManager?.destroy();
     this.npcManager = null;
+    EventBus.off('minigame-launch', this.handleMinigameLaunch, this);
+    EventBus.off('minigame-exit', this.handleMinigameExit, this);
   }
 }

--- a/game/scenes/StarCatchScene.ts
+++ b/game/scenes/StarCatchScene.ts
@@ -1,0 +1,138 @@
+import Phaser from 'phaser';
+import { MinigameScene } from './MinigameScene';
+
+interface FallingStar {
+  sprite: Phaser.GameObjects.Container;
+  vy: number;
+  alive: boolean;
+  pointValue: number;
+  isBomb: boolean;
+}
+
+const PLAY_LEFT = 80;
+const PLAY_RIGHT = 1120;
+const PLAY_BOTTOM = 820;
+const SPAWN_INTERVAL_MS = 700;
+
+export class StarCatchScene extends MinigameScene {
+  private stars: FallingStar[] = [];
+  private spawnTimer: Phaser.Time.TimerEvent | null = null;
+  private playGfx: Phaser.GameObjects.Graphics | null = null;
+  private isPaused = false;
+
+  constructor() {
+    super('StarCatchScene');
+  }
+
+  protected setup(): void {
+    this.playGfx = this.add.graphics().setDepth(0);
+    // Draw playfield border
+    this.playGfx.lineStyle(2, 0x00f7ff, 0.4);
+    this.playGfx.strokeRect(PLAY_LEFT - 4, 90, PLAY_RIGHT - PLAY_LEFT + 8, PLAY_BOTTOM - 90 + 8);
+  }
+
+  protected startPlay(): void {
+    this.isPaused = false;
+    this.spawnTimer = this.time.addEvent({
+      delay: SPAWN_INTERVAL_MS,
+      loop: true,
+      callback: () => this.spawnFallingObject(),
+    });
+  }
+
+  protected setPlayPaused(paused: boolean): void {
+    this.isPaused = paused;
+    if (this.spawnTimer) this.spawnTimer.paused = paused;
+  }
+
+  protected teardownPlay(): void {
+    this.isPaused = false;
+    if (this.spawnTimer) {
+      this.spawnTimer.destroy();
+      this.spawnTimer = null;
+    }
+    for (const s of this.stars) {
+      s.sprite.destroy();
+    }
+    this.stars = [];
+  }
+
+  protected updatePlaying(_time: number, delta: number): void {
+    if (this.isPaused) return;
+    const dt = delta / 1000;
+    for (const s of this.stars) {
+      if (!s.alive) continue;
+      s.sprite.y += s.vy * dt;
+      if (s.sprite.y > PLAY_BOTTOM) {
+        s.alive = false;
+        s.sprite.destroy();
+        // Missing a regular star: small penalty (no negative), bomb missed: bonus
+        if (s.isBomb) {
+          this.addScore(2);
+        }
+      }
+    }
+    this.stars = this.stars.filter((s) => s.alive);
+  }
+
+  private spawnFallingObject() {
+    if (this.isPaused) return;
+    const x = Phaser.Math.Between(PLAY_LEFT + 20, PLAY_RIGHT - 20);
+    const isBomb = Math.random() < 0.18;
+    const speed = Phaser.Math.Between(180, 280);
+
+    const container = this.add.container(x, 100).setDepth(5);
+    const g = this.add.graphics();
+
+    if (isBomb) {
+      // Pixel-art bomb: dark circle + spark
+      g.fillStyle(0x440011, 1);
+      g.fillRect(-10, -10, 20, 20);
+      g.fillStyle(0xff3344, 1);
+      g.fillRect(-6, -6, 12, 12);
+      g.fillStyle(0xffd700, 1);
+      g.fillRect(-2, -12, 4, 4);
+    } else {
+      // Pixel-art star: cyan/gold
+      g.fillStyle(0xffd700, 1);
+      g.fillRect(-8, -2, 16, 4);
+      g.fillRect(-2, -8, 4, 16);
+      g.fillStyle(0x00f7ff, 1);
+      g.fillRect(-4, -4, 8, 8);
+    }
+    container.add(g);
+    container.setSize(24, 24);
+    container.setInteractive({ useHandCursor: true });
+
+    const star: FallingStar = {
+      sprite: container,
+      vy: speed,
+      alive: true,
+      pointValue: isBomb ? -8 : Phaser.Math.Between(3, 6),
+      isBomb,
+    };
+
+    container.on('pointerdown', (event: Phaser.Input.Pointer) => {
+      event.event?.stopPropagation?.();
+      if (!star.alive || this.isPaused) return;
+      star.alive = false;
+      this.addScore(star.pointValue);
+      this.flashAt(container.x, container.y, isBomb ? 0xff3344 : 0x00f7ff);
+      container.destroy();
+    });
+
+    this.stars.push(star);
+  }
+
+  private flashAt(x: number, y: number, color: number) {
+    const flash = this.add.graphics().setDepth(10);
+    flash.fillStyle(color, 0.9);
+    flash.fillCircle(x, y, 14);
+    this.tweens.add({
+      targets: flash,
+      alpha: 0,
+      duration: 250,
+      onComplete: () => flash.destroy(),
+    });
+  }
+}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -5784,6 +5784,11 @@ function initializeSanctuary(database: Database.Database): void {
     const sql = fs.readFileSync(v17Path, 'utf-8');
     database.exec(sql);
   }
+  const v18Path = path.join(process.cwd(), 'scripts', 'init-sanctuary-v1.8.sql');
+  if (fs.existsSync(v18Path)) {
+    const sql = fs.readFileSync(v18Path, 'utf-8');
+    database.exec(sql);
+  }
   // V1.7: per-companion XP/level columns (Training Grounds). ALTER TABLE IF NOT
   // EXISTS is not portable across SQLite versions, so wrap in try/catch.
   try { database.exec('ALTER TABLE sanctuary_companions ADD COLUMN xp INTEGER NOT NULL DEFAULT 0'); }
@@ -6523,6 +6528,174 @@ export function completeActivity(
   });
 
   return txn();
+}
+
+// ============================================================================
+// Minigame system (V1.8) — shared scoring + STAR rewards across mini-games
+// ============================================================================
+
+export interface MinigameDef {
+  game_id: string;
+  label: string;
+  description: string;
+  durationSeconds: number;
+  firstPlayBonusStar: number;
+  starPerScore: number; // STAR awarded = floor(score * starPerScore), capped
+  starCapPerPlay: number;
+}
+
+export const SANCTUARY_MINIGAMES: Record<string, MinigameDef> = {
+  'star-catch': {
+    game_id: 'star-catch',
+    label: 'Star Catch',
+    description: 'Catch falling stars before they hit the ground.',
+    durationSeconds: 60,
+    firstPlayBonusStar: 25,
+    starPerScore: 0.05,
+    starCapPerPlay: 10,
+  },
+};
+
+export function getMinigameDef(gameId: string): MinigameDef | null {
+  return SANCTUARY_MINIGAMES[gameId] ?? null;
+}
+
+export interface SanctuaryMinigameScore {
+  id: number;
+  wallet_address: string;
+  token_id: number;
+  game_id: string;
+  score: number;
+  star_awarded: number;
+  played_at: string;
+}
+
+export interface MinigameSubmissionResult {
+  score: number;
+  star_awarded: number;
+  is_first_play: boolean;
+  personal_best: number;
+  is_new_personal_best: boolean;
+  total_plays: number;
+  game_id: string;
+  token_id: number;
+}
+
+export function submitMinigameScore(
+  walletAddress: string,
+  tokenId: number,
+  gameId: string,
+  score: number,
+): MinigameSubmissionResult {
+  const def = getMinigameDef(gameId);
+  if (!def) throw new Error('Invalid minigame');
+  if (!Number.isFinite(score) || score < 0) throw new Error('Invalid score');
+
+  const db = getDatabase();
+  const addr = walletAddress.toLowerCase();
+  const cappedScore = Math.min(Math.floor(score), 9999);
+
+  const txn = db.transaction(() => {
+    const prior = db.prepare(
+      'SELECT COUNT(*) as count, COALESCE(MAX(score), 0) as best FROM sanctuary_minigame_scores WHERE wallet_address = ? AND token_id = ? AND game_id = ?',
+    ).get(addr, tokenId, gameId) as { count: number; best: number };
+
+    const isFirstPlay = prior.count === 0;
+    const scoreReward = Math.min(
+      Math.floor(cappedScore * def.starPerScore),
+      def.starCapPerPlay,
+    );
+    const firstPlayBonus = isFirstPlay ? def.firstPlayBonusStar : 0;
+    const starAwarded = scoreReward + firstPlayBonus;
+
+    db.prepare(
+      'INSERT INTO sanctuary_minigame_scores (wallet_address, token_id, game_id, score, star_awarded) VALUES (?, ?, ?, ?, ?)',
+    ).run(addr, tokenId, gameId, cappedScore, starAwarded);
+
+    if (starAwarded > 0) {
+      addUserXP(addr, starAwarded);
+    }
+
+    addJournalEntry(addr, tokenId, 'achievement',
+      `Played ${def.label} — Score ${cappedScore}, STAR +${starAwarded}${isFirstPlay ? ' (first play bonus!)' : ''}`,
+      JSON.stringify({
+        action: 'minigame_score',
+        game_id: gameId,
+        score: cappedScore,
+        star_awarded: starAwarded,
+        first_play: isFirstPlay,
+      }),
+    );
+
+    return {
+      score: cappedScore,
+      star_awarded: starAwarded,
+      is_first_play: isFirstPlay,
+      personal_best: Math.max(prior.best, cappedScore),
+      is_new_personal_best: cappedScore > prior.best,
+      total_plays: prior.count + 1,
+      game_id: gameId,
+      token_id: tokenId,
+    };
+  });
+
+  return txn();
+}
+
+export interface MinigameLeaderboardRow {
+  rank: number;
+  wallet_address: string;
+  token_id: number;
+  score: number;
+  played_at: string;
+}
+
+export function getMinigameLeaderboard(
+  gameId: string,
+  limit: number = 20,
+): MinigameLeaderboardRow[] {
+  const db = getDatabase();
+  const cap = Math.max(1, Math.min(Math.floor(limit), 100));
+  // Best score per (wallet, token) pair, ranked descending.
+  const rows = db.prepare(`
+    SELECT wallet_address, token_id, score, played_at
+    FROM (
+      SELECT wallet_address, token_id, score, played_at,
+             ROW_NUMBER() OVER (PARTITION BY wallet_address, token_id ORDER BY score DESC, played_at ASC) as rn
+      FROM sanctuary_minigame_scores
+      WHERE game_id = ?
+    )
+    WHERE rn = 1
+    ORDER BY score DESC, played_at ASC
+    LIMIT ?
+  `).all(gameId, cap) as Array<{
+    wallet_address: string;
+    token_id: number;
+    score: number;
+    played_at: string;
+  }>;
+
+  return rows.map((r, i) => ({ rank: i + 1, ...r }));
+}
+
+export function getMinigamePersonalBest(
+  walletAddress: string,
+  tokenId: number,
+  gameId: string,
+): { personal_best: number; total_plays: number; total_star_earned: number } {
+  const db = getDatabase();
+  const row = db.prepare(
+    'SELECT COUNT(*) as count, COALESCE(MAX(score), 0) as best, COALESCE(SUM(star_awarded), 0) as star FROM sanctuary_minigame_scores WHERE wallet_address = ? AND token_id = ? AND game_id = ?',
+  ).get(walletAddress.toLowerCase(), tokenId, gameId) as {
+    count: number;
+    best: number;
+    star: number;
+  };
+  return {
+    personal_best: row.best,
+    total_plays: row.count,
+    total_star_earned: row.star,
+  };
 }
 
 export function getCompanionsAtLocations(): { location_name: string; count: number; companions: { token_id: number; nickname: string | null }[] }[] {

--- a/lib/sanctuary/__tests__/api-e2e.test.ts
+++ b/lib/sanctuary/__tests__/api-e2e.test.ts
@@ -27,6 +27,21 @@ const db = vi.hoisted(() => ({
   completeActivityV15: vi.fn(),
   getJournalEntriesPaginated: vi.fn(),
   getJournalStats: vi.fn(),
+  submitMinigameScore: vi.fn(),
+  getMinigameLeaderboard: vi.fn(),
+  getMinigamePersonalBest: vi.fn(),
+  getMinigameDef: vi.fn(),
+  SANCTUARY_MINIGAMES: {
+    'star-catch': {
+      game_id: 'star-catch',
+      label: 'Star Catch',
+      description: 'Catch falling stars before they hit the ground.',
+      durationSeconds: 60,
+      firstPlayBonusStar: 25,
+      starPerScore: 0.05,
+      starCapPerPlay: 10,
+    },
+  },
 }));
 
 const walletAuth = vi.hoisted(() => ({
@@ -74,6 +89,8 @@ import { POST as interactPOST } from '@/app/api/sanctuary/companion/interact/rou
 import { POST as sendActivityPOST } from '@/app/api/sanctuary/companion/send-to-activity/route';
 import { POST as completeActivityPOST } from '@/app/api/sanctuary/companion/complete-activity/route';
 import { GET as journalGET } from '@/app/api/sanctuary/companion/journal/route';
+import { POST as minigameScorePOST } from '@/app/api/sanctuary/minigame/score/route';
+import { GET as minigameLeaderboardGET } from '@/app/api/sanctuary/minigame/leaderboard/route';
 
 // ─── Constants & helpers ────────────────────────────────────────────
 
@@ -930,6 +947,140 @@ describe('Flow: send to activity → complete activity', () => {
     expect(completeRes.status).toBe(200);
     const result = await completeRes.json();
     expect(result.xp_gained).toBe(75);
+  });
+});
+
+// =====================================================================
+// POST /api/sanctuary/minigame/score
+// =====================================================================
+
+describe('POST /api/sanctuary/minigame/score', () => {
+  it('records score and returns reward when wallet owns token', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: true });
+    ownership.verifyTokenOwnership.mockResolvedValue(true);
+    db.submitMinigameScore.mockReturnValue({
+      score: 50,
+      star_awarded: 27,
+      is_first_play: true,
+      personal_best: 50,
+      is_new_personal_best: true,
+      total_plays: 1,
+      game_id: 'star-catch',
+      token_id: TOKEN,
+    });
+    const res = await minigameScorePOST(
+      post('/api/sanctuary/minigame/score', {
+        address: ALICE, token_id: TOKEN, game_id: 'star-catch', score: 50,
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.star_awarded).toBe(27);
+    expect(body.is_first_play).toBe(true);
+  });
+
+  it('returns 400 when params missing', async () => {
+    const res = await minigameScorePOST(
+      post('/api/sanctuary/minigame/score', { address: ALICE, score: 5 }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when game_id is unknown', async () => {
+    const res = await minigameScorePOST(
+      post('/api/sanctuary/minigame/score', {
+        address: ALICE, token_id: TOKEN, game_id: 'bogus', score: 10,
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 401 when wallet auth fails', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: false, error: 'Bad signature' });
+    const res = await minigameScorePOST(
+      post('/api/sanctuary/minigame/score', {
+        address: ALICE, token_id: TOKEN, game_id: 'star-catch', score: 50,
+      }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when token not owned', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: true });
+    ownership.verifyTokenOwnership.mockResolvedValue(false);
+    const res = await minigameScorePOST(
+      post('/api/sanctuary/minigame/score', {
+        address: ALICE, token_id: TOKEN, game_id: 'star-catch', score: 50,
+      }),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects negative scores', async () => {
+    const res = await minigameScorePOST(
+      post('/api/sanctuary/minigame/score', {
+        address: ALICE, token_id: TOKEN, game_id: 'star-catch', score: -5,
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+// =====================================================================
+// GET /api/sanctuary/minigame/leaderboard
+// =====================================================================
+
+describe('GET /api/sanctuary/minigame/leaderboard', () => {
+  it('returns top scores for a game', async () => {
+    db.getMinigameDef.mockReturnValue({
+      game_id: 'star-catch', label: 'Star Catch', description: 'x',
+      durationSeconds: 60, firstPlayBonusStar: 25, starPerScore: 0.05, starCapPerPlay: 10,
+    });
+    db.getMinigameLeaderboard.mockReturnValue([
+      { rank: 1, wallet_address: ALICE, token_id: TOKEN, score: 100, played_at: '2026-01-01' },
+    ]);
+    const res = await minigameLeaderboardGET(
+      get('/api/sanctuary/minigame/leaderboard', { game_id: 'star-catch' }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.leaderboard).toHaveLength(1);
+    expect(body.leaderboard[0].score).toBe(100);
+    expect(body.personal_best).toBeNull();
+  });
+
+  it('includes personal best when address+token provided', async () => {
+    db.getMinigameDef.mockReturnValue({
+      game_id: 'star-catch', label: 'Star Catch', description: 'x',
+      durationSeconds: 60, firstPlayBonusStar: 25, starPerScore: 0.05, starCapPerPlay: 10,
+    });
+    db.getMinigameLeaderboard.mockReturnValue([]);
+    db.getMinigamePersonalBest.mockReturnValue({
+      personal_best: 75, total_plays: 4, total_star_earned: 33,
+    });
+    const res = await minigameLeaderboardGET(
+      get('/api/sanctuary/minigame/leaderboard', {
+        game_id: 'star-catch', address: ALICE, token_id: String(TOKEN),
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.personal_best.personal_best).toBe(75);
+    expect(body.personal_best.total_plays).toBe(4);
+  });
+
+  it('returns 400 when game_id missing', async () => {
+    const res = await minigameLeaderboardGET(get('/api/sanctuary/minigame/leaderboard'));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when game_id is unknown', async () => {
+    const res = await minigameLeaderboardGET(
+      get('/api/sanctuary/minigame/leaderboard', { game_id: 'bogus' }),
+    );
+    expect(res.status).toBe(400);
   });
 });
 

--- a/lib/sanctuary/rateLimit.ts
+++ b/lib/sanctuary/rateLimit.ts
@@ -16,6 +16,7 @@ const LIMITS: Record<string, RateLimitConfig> = {
   'companion/training': { maxRequests: 20, windowSeconds: 60 },
   'companion/chat': { maxRequests: 30, windowSeconds: 60 },
   'quests/claim': { maxRequests: 10, windowSeconds: 60 },
+  'minigame/score': { maxRequests: 30, windowSeconds: 60 },
 };
 
 let cleanupCounter = 0;

--- a/scripts/init-sanctuary-v1.8.sql
+++ b/scripts/init-sanctuary-v1.8.sql
@@ -1,0 +1,22 @@
+-- Star Sanctuary — V1.8 Schema: Minigame scores
+-- Run from lib/db.ts initializeSanctuary()
+
+-- Per-play score log. Multiple rows per (wallet, token, game_id) allow leaderboard
+-- queries by best/recent score and per-token personal-best tracking.
+CREATE TABLE IF NOT EXISTS sanctuary_minigame_scores (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  wallet_address TEXT NOT NULL,
+  token_id INTEGER NOT NULL,
+  game_id TEXT NOT NULL,
+  score INTEGER NOT NULL,
+  star_awarded INTEGER NOT NULL DEFAULT 0,
+  played_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (token_id) REFERENCES star_skrumpey_metadata(token_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_minigame_scores_game_score
+  ON sanctuary_minigame_scores(game_id, score DESC);
+CREATE INDEX IF NOT EXISTS idx_minigame_scores_wallet_game
+  ON sanctuary_minigame_scores(wallet_address, game_id);
+CREATE INDEX IF NOT EXISTS idx_minigame_scores_token_game
+  ON sanctuary_minigame_scores(wallet_address, token_id, game_id);


### PR DESCRIPTION
## Summary
- New abstract `MinigameScene` Phaser base class providing score tracking, 60-90s timer, pause/resume, pixel-art result screen with server-driven STAR/PB display, and exit-to-room flow.
- First concrete implementation: **Star Catch** — a 60s falling-stars game with bonus stars and bombs, launchable from a new arcade NPC in the Observatory room.
- New API surface for minigame scoring and leaderboards, gated by wallet auth + token ownership and rate-limited.

## Backend
- `POST /api/sanctuary/minigame/score` — wallet-auth + token-ownership protected, rate-limited 30/60s. Records the play, awards STAR (first-play bonus + score scaling capped per play), writes a journal entry.
- `GET /api/sanctuary/minigame/leaderboard?game_id=...` — top 20 best scores per (wallet, token), with optional personal-best lookup when `address` + `token_id` are provided.
- New `sanctuary_minigame_scores` table (V1.8 migration in `scripts/init-sanctuary-v1.8.sql`).
- DB helpers in `lib/db.ts`: `SANCTUARY_MINIGAMES` registry, `submitMinigameScore`, `getMinigameLeaderboard`, `getMinigamePersonalBest`.
- `lib/sanctuary/rateLimit.ts` gains a `minigame/score` entry (30/60s).

## Frontend (Phaser + React)
- `game/scenes/MinigameScene.ts` — abstract base. Phases: intro → playing → paused → result. Subclass hooks: `setup`, `startPlay`, `setPlayPaused`, `teardownPlay`, `updatePlaying`. Emits `minigame-complete` on round end and `minigame-exit` on user exit. Listens for `minigame-result-update` to populate STAR earned and personal-best on the result panel.
- `game/scenes/StarCatchScene.ts` — concrete subclass. Programmatically drawn pixel-art falling stars (3-6 pts) and bombs (-8 if clicked, +2 if dodged). Synthwave grid backdrop in the base class.
- `RoomScene.ts` — handles `minigame-launch` (sleeps room, launches scene with returnRoom + returnTo) and `minigame-exit` (stops minigame, wakes room, restores player position).
- New `components/sanctuary/overlays/MinigameDialog.tsx` — opens when an arcade NPC is clicked. Shows description, leaderboard preview, personal best, and a PLAY NOW button. Subscribes to `minigame-complete`, posts the score with cached wallet auth header, then broadcasts the server result to the scene so the result screen can update.
- `QuestDialog.tsx` filters out arcade NPC IDs so the quest panel doesn't fire for minigame NPCs.
- New NPC `npc-observatory-arcade` in `npcDefinitions.ts` with `kind: 'minigame'` + `minigameId: 'star-catch'`. Placed in Observatory room.

## STAR rewards
- First play of a (wallet, token, game) → +25 STAR bonus.
- Per-play score reward = `floor(score * 0.05)` capped at 10 STAR/play.
- Awarded STAR is also added to wallet XP (existing `addUserXP` call).

## Tests
- 10 new vitest cases in `lib/sanctuary/__tests__/api-e2e.test.ts` covering happy path, missing params, unknown game_id, auth failure, ownership failure, negative scores, leaderboard with/without personal best.
- Local validations pass: `npm run type-check`, `npm run lint` (no new errors in changed files), `npm run test` (285 pass, the 4 pre-existing failures are unrelated to this PR), `npm run build` (lists both new routes).

## Mirror Validation (PROD)
- **tsc --noEmit (baseline)**: PASS (0 errors)
- **tsc --noEmit (with overlay)**: introduces module-not-found errors because PROD/main does not yet have the Sanctuary V2 stack (Phaser, EventBus, worldLayout, validation helpers). These are pre-existing infrastructure gaps; every V2-touching dev PR is blocked at PROD until V2 lands on main. Baseline-diff exclusion will treat these as pre-existing.
- **vitest (PROD)**: cannot run — `lib/sanctuary/validation.ts` is dev-only.
- Mirror was restored byte-identical after validation.

Overall: **Local PASS** / Mirror tracking unblocked once V2 stack ships to main.

## Test plan
- [ ] `npm run dev`, navigate to `/sanctuary`, enter Observatory room.
- [ ] Click the **Star Catch Arcade** NPC → MinigameDialog opens.
- [ ] Click PLAY NOW with an active Skrumpey selected → game scene launches.
- [ ] Click stars/dodge bombs for 60s → result screen shows score.
- [ ] STAR earned + personal best populates after server response.
- [ ] Press ESC or click EXIT → returns to Observatory room at original position.
- [ ] Refresh dialog leaderboard reflects new score.
- [ ] Verify rate limit at 31 rapid POSTs returns 429.

🤖 Generated with [Claude Code](https://claude.com/claude-code)