### PR TITLE
feat(sanctuary): LLM-backed companion chat (ADR-002)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -216,6 +216,35 @@ NEXT_PUBLIC_DAO_FEE_BPS=250
 # NEXT_PUBLIC_SNAPSHOT_HUB=https://hub.snapshot.org
 
 # ============================================================
+# SANCTUARY LLM CHAT (ADR-002)
+# ============================================================
+# Companion chat is template-based by default. Set OPENROUTER_API_KEY to
+# upgrade to LLM-backed responses with personality, bond, mood, and journal
+# context. Daily per-wallet cap defaults to 15 calls.
+# Get a key at https://openrouter.ai/keys (free credits available).
+
+# OPENROUTER_API_KEY=sk-or-v1-...
+
+# Default model: Gemini 2.0 Flash (cheap, fast, ~$0.0001 input / $0.0004 output per 1K tokens)
+# SANCTUARY_CHAT_MODEL=google/gemini-2.0-flash-001
+
+# Per-wallet daily cap (defaults to 15)
+# SANCTUARY_CHAT_DAILY_LIMIT=15
+
+# Cost-safe testing: set to "true" to skip OpenRouter calls entirely while
+# still building prompts and persisting template-fallback replies. Usage rows
+# are recorded with was_dry_run=1 and do NOT count toward the daily cap.
+# SANCTUARY_CHAT_DRY_RUN=false
+
+# Optional model tuning
+# SANCTUARY_CHAT_MAX_TOKENS=200
+# SANCTUARY_CHAT_TEMPERATURE=0.85
+
+# OpenRouter routing headers (optional but recommended)
+# OPENROUTER_REFERER=https://starworldorder.com
+# OPENROUTER_APP_TITLE=Star World Order Sanctuary
+
+# ============================================================
 # REFERENCE: EXPLORER URLs
 # ============================================================
 # Mainnet:

--- a/app/api/sanctuary/companion/chat/route.ts
+++ b/app/api/sanctuary/companion/chat/route.ts
@@ -1,9 +1,34 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
-import { chatWithCompanion, getCompanionChatHistory } from '@/lib/db';
+import {
+  chatWithCompanion,
+  getCompanionChatHistory,
+  getActiveCompanion,
+  getJournalEntries,
+  getUnlockedTraits,
+  generateTemplateCompanionReply,
+  persistCompanionChatExchange,
+} from '@/lib/db';
 import { verifyWalletAccess } from '@/lib/walletAuth';
 import { applyRateLimit } from '@/lib/sanctuary/rateLimit';
-import { ethAddress, tokenId, paginationLimit, parseSearchParams, parseBody, formatZodError } from '@/lib/sanctuary/validation';
+import {
+  ethAddress,
+  tokenId,
+  paginationLimit,
+  parseSearchParams,
+  parseBody,
+  formatZodError,
+} from '@/lib/sanctuary/validation';
+import { buildChatPrompt, estimatePromptTokens } from '@/lib/sanctuary/chatPersonality';
+import {
+  callOpenRouterChat,
+  estimateCostUsd,
+  getOpenRouterConfigFromEnv,
+} from '@/lib/sanctuary/openrouter';
+import {
+  checkDailyChatLimit,
+  recordChatUsage,
+} from '@/lib/sanctuary/chatUsage';
 
 const getSchema = z.object({
   address: ethAddress,
@@ -16,6 +41,11 @@ const postSchema = z.object({
   token_id: tokenId,
   message: z.string().min(1, 'Message cannot be empty').transform((s) => s.trim().slice(0, 500)),
 });
+
+function isDryRun(): boolean {
+  const v = process.env.SANCTUARY_CHAT_DRY_RUN;
+  return v === '1' || v === 'true' || v === 'TRUE';
+}
 
 export async function GET(request: NextRequest) {
   try {
@@ -57,8 +87,122 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ success: false, error: 'Message cannot be empty' }, { status: 400 });
     }
 
-    const result = chatWithCompanion(address, tid, message);
-    return NextResponse.json({ success: true, ...result });
+    const openRouterConfig = getOpenRouterConfigFromEnv();
+    const dryRun = isDryRun();
+    const llmPathEnabled = !!openRouterConfig;
+
+    if (!llmPathEnabled) {
+      const result = chatWithCompanion(address, tid, message);
+      return NextResponse.json({
+        success: true,
+        ...result,
+        meta: { mode: 'template', reason: 'OPENROUTER_API_KEY not set' },
+      });
+    }
+
+    const dailyLimit = checkDailyChatLimit(address);
+    if (!dailyLimit.allowed) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: `Daily LLM chat limit reached (${dailyLimit.used}/${dailyLimit.limit}). Resets at 00:00 UTC.`,
+          meta: { mode: 'limit', dailyLimit },
+        },
+        { status: 429, headers: { 'Retry-After': '3600' } },
+      );
+    }
+
+    const companion = getActiveCompanion(address.toLowerCase());
+    if (!companion || companion.token_id !== tid) {
+      return NextResponse.json({ success: false, error: 'No active companion found' }, { status: 404 });
+    }
+
+    const history = getCompanionChatHistory(address, tid, 10);
+    const journal = getJournalEntries(address, tid, 8);
+    const unlockedTraits = getUnlockedTraits(address, tid);
+
+    const prompt = buildChatPrompt({
+      companion,
+      history,
+      journal,
+      unlockedTraits,
+      userMessage: message,
+    });
+
+    if (dryRun) {
+      const estimatedPromptTokens = estimatePromptTokens(prompt);
+      const fallbackReply = generateTemplateCompanionReply(companion, message, history);
+      const persisted = persistCompanionChatExchange(address, tid, message, fallbackReply);
+      const model = openRouterConfig.model;
+      recordChatUsage({
+        walletAddress: address,
+        tokenId: tid,
+        model,
+        promptTokens: estimatedPromptTokens,
+        completionTokens: 0,
+        totalTokens: estimatedPromptTokens,
+        estimatedCostUsd: estimateCostUsd(model, {
+          prompt_tokens: estimatedPromptTokens,
+          completion_tokens: 0,
+          total_tokens: estimatedPromptTokens,
+        }),
+        wasDryRun: true,
+      });
+      return NextResponse.json({
+        success: true,
+        ...persisted,
+        meta: {
+          mode: 'dry_run',
+          model,
+          estimatedPromptTokens,
+          systemPromptPreview: prompt.system,
+          dailyLimit: checkDailyChatLimit(address),
+        },
+      });
+    }
+
+    let llmResult;
+    try {
+      llmResult = await callOpenRouterChat(openRouterConfig, prompt, {
+        maxTokens: Number(process.env.SANCTUARY_CHAT_MAX_TOKENS ?? 200),
+        temperature: Number(process.env.SANCTUARY_CHAT_TEMPERATURE ?? 0.85),
+      });
+    } catch (err) {
+      const fallbackReply = generateTemplateCompanionReply(companion, message, history);
+      const persisted = persistCompanionChatExchange(address, tid, message, fallbackReply);
+      return NextResponse.json({
+        success: true,
+        ...persisted,
+        meta: {
+          mode: 'template_fallback',
+          error: err instanceof Error ? err.message : 'OpenRouter call failed',
+        },
+      });
+    }
+
+    const persisted = persistCompanionChatExchange(address, tid, message, llmResult.content);
+    recordChatUsage({
+      walletAddress: address,
+      tokenId: tid,
+      model: llmResult.model,
+      promptTokens: llmResult.usage.prompt_tokens,
+      completionTokens: llmResult.usage.completion_tokens,
+      totalTokens: llmResult.usage.total_tokens,
+      estimatedCostUsd: llmResult.estimatedCostUsd,
+      wasDryRun: false,
+    });
+
+    return NextResponse.json({
+      success: true,
+      ...persisted,
+      meta: {
+        mode: 'llm',
+        model: llmResult.model,
+        usage: llmResult.usage,
+        estimatedCostUsd: llmResult.estimatedCostUsd,
+        dailyLimit: checkDailyChatLimit(address),
+      },
+    });
   } catch (error) {
     const msg = error instanceof Error ? error.message : 'Failed to chat';
     const status = msg.includes('No active companion') ? 404 : 500;

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -5789,6 +5789,11 @@ function initializeSanctuary(database: Database.Database): void {
     const sql = fs.readFileSync(v18Path, 'utf-8');
     database.exec(sql);
   }
+  const v19Path = path.join(process.cwd(), 'scripts', 'init-sanctuary-v1.9.sql');
+  if (fs.existsSync(v19Path)) {
+    const sql = fs.readFileSync(v19Path, 'utf-8');
+    database.exec(sql);
+  }
   // V1.7: per-companion XP/level columns (Training Grounds). ALTER TABLE IF NOT
   // EXISTS is not portable across SQLite versions, so wrap in try/catch.
   try { database.exec('ALTER TABLE sanctuary_companions ADD COLUMN xp INTEGER NOT NULL DEFAULT 0'); }
@@ -7051,6 +7056,43 @@ export function getCompanionChatHistory(walletAddress: string, tokenId: number, 
     WHERE wallet_address = ? AND token_id = ?
     ORDER BY created_at DESC LIMIT ?
   `).all(walletAddress.toLowerCase(), tokenId, limit) as SanctuaryChatMessage[];
+}
+
+export function generateTemplateCompanionReply(
+  companion: SanctuaryCompanionWithMeta,
+  userMessage: string,
+  history: SanctuaryChatMessage[],
+): string {
+  return generateCompanionResponse(companion, userMessage, history);
+}
+
+export function persistCompanionChatExchange(
+  walletAddress: string,
+  tokenId: number,
+  userMessage: string,
+  companionReplyText: string,
+): { userMessage: SanctuaryChatMessage; companionReply: SanctuaryChatMessage; companion: SanctuaryCompanionWithMeta } {
+  const db = getDatabase();
+  const addr = walletAddress.toLowerCase();
+
+  const txn = db.transaction(() => {
+    const comp = getActiveCompanion(addr);
+    if (!comp || comp.token_id !== tokenId) throw new Error('No active companion found');
+
+    const userMsg = addCompanionChatMessage(addr, tokenId, 'user', userMessage);
+    const companionMsg = addCompanionChatMessage(addr, tokenId, 'companion', companionReplyText);
+
+    db.prepare(`
+      UPDATE sanctuary_companions SET total_interactions = total_interactions + 1, updated_at = CURRENT_TIMESTAMP
+      WHERE wallet_address = ? AND token_id = ? AND is_active = 1
+    `).run(addr, tokenId);
+
+    updateTraitProgress(addr, tokenId, 'chat');
+
+    return { userMessage: userMsg, companionReply: companionMsg, companion: comp };
+  });
+
+  return txn();
 }
 
 export function chatWithCompanion(

--- a/lib/sanctuary/__tests__/chatPersonality.test.ts
+++ b/lib/sanctuary/__tests__/chatPersonality.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildChatPrompt,
+  bondLabel,
+  moodLabel,
+  estimateTokens,
+  estimatePromptTokens,
+  CONSTELLATION_PERSONAS,
+  DEFAULT_PERSONA,
+} from '../chatPersonality';
+import type {
+  SanctuaryCompanionWithMeta,
+  SanctuaryChatMessage,
+  SanctuaryJournalEntry,
+  SanctuaryTrait,
+} from '@/lib/db';
+
+const mockCompanion = (overrides: Partial<SanctuaryCompanionWithMeta> = {}): SanctuaryCompanionWithMeta => ({
+  id: 1,
+  wallet_address: '0xabc',
+  token_id: 42,
+  is_active: 1,
+  nickname: 'Stardust',
+  current_activity: 'lounging',
+  activity_started_at: null,
+  activity_ends_at: null,
+  bond_score: 65,
+  total_interactions: 12,
+  equipped_cosmetics: '{}',
+  created_at: '2026-01-01 00:00:00',
+  updated_at: '2026-01-02 00:00:00',
+  constellation: 'aether',
+  aura: 'glow',
+  form: 'standard',
+  mood: 'curious',
+  background: 'space',
+  eyes: 'glow',
+  hat: null,
+  image_url: null,
+  rarity_rank: 100,
+  attributes_json: null,
+  companion_xp: 50,
+  companion_level: 2,
+  total_xp: 500,
+  level: 3,
+  ...overrides,
+} as SanctuaryCompanionWithMeta);
+
+const msg = (id: number, role: 'user' | 'companion', content: string, created_at: string): SanctuaryChatMessage => ({
+  id,
+  wallet_address: '0xabc',
+  token_id: 42,
+  role,
+  content,
+  created_at,
+});
+
+const journal = (id: number, entry_type: string, content: string, created_at: string): SanctuaryJournalEntry => ({
+  id,
+  wallet_address: '0xabc',
+  token_id: 42,
+  entry_type,
+  content,
+  metadata: '{}',
+  created_at,
+});
+
+const trait = (id: number, name: string): SanctuaryTrait => ({
+  id,
+  wallet_address: '0xabc',
+  token_id: 42,
+  trait_name: name,
+  trait_category: 'social',
+  progress: 30,
+  unlocked: 1,
+  unlocked_at: '2026-01-01 00:00:00',
+  created_at: '2026-01-01 00:00:00',
+  updated_at: '2026-01-01 00:00:00',
+});
+
+describe('bondLabel', () => {
+  it('classifies bond by score', () => {
+    expect(bondLabel(0)).toContain('new');
+    expect(bondLabel(15)).toContain('budding');
+    expect(bondLabel(40)).toContain('growing');
+    expect(bondLabel(65)).toContain('strong');
+    expect(bondLabel(85)).toContain('legendary');
+  });
+});
+
+describe('moodLabel', () => {
+  it('falls back to calm when missing', () => {
+    expect(moodLabel(null)).toBe('calm');
+    expect(moodLabel(undefined)).toBe('calm');
+  });
+  it('lowercases input', () => {
+    expect(moodLabel('Excited')).toBe('excited');
+  });
+});
+
+describe('estimateTokens', () => {
+  it('returns 0 for empty', () => {
+    expect(estimateTokens('')).toBe(0);
+  });
+  it('approximates 4 chars per token', () => {
+    expect(estimateTokens('abcd')).toBe(1);
+    expect(estimateTokens('abcdefgh')).toBe(2);
+  });
+});
+
+describe('CONSTELLATION_PERSONAS', () => {
+  it('has all 10 known constellations', () => {
+    const expected = ['aether', 'spectra', 'solveil', 'nebulu', 'chroma', 'rose', 'monflare', 'auracore', 'parallel', 'prime'];
+    for (const c of expected) {
+      expect(CONSTELLATION_PERSONAS[c]).toBeDefined();
+      expect(CONSTELLATION_PERSONAS[c].description).toBeTruthy();
+      expect(CONSTELLATION_PERSONAS[c].voice).toBeTruthy();
+      expect(CONSTELLATION_PERSONAS[c].signaturePhrases.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('buildChatPrompt', () => {
+  it('builds a prompt with system + user message', () => {
+    const out = buildChatPrompt({
+      companion: mockCompanion(),
+      history: [],
+      userMessage: 'Hello!',
+    });
+    expect(out.system).toContain('Stardust');
+    expect(out.system).toContain('aether');
+    expect(out.system).toContain('curious');
+    expect(out.messages).toHaveLength(1);
+    expect(out.messages[0]).toEqual({ role: 'user', content: 'Hello!' });
+  });
+
+  it('uses default persona for unknown constellation', () => {
+    const out = buildChatPrompt({
+      companion: mockCompanion({ constellation: 'unknownConst' }),
+      history: [],
+      userMessage: 'Hi',
+    });
+    expect(out.system).toContain(DEFAULT_PERSONA.description);
+  });
+
+  it('falls back to token id when nickname is empty', () => {
+    const out = buildChatPrompt({
+      companion: mockCompanion({ nickname: null, token_id: 1234 }),
+      history: [],
+      userMessage: 'Yo',
+    });
+    expect(out.system).toContain('Skrumpey #1234');
+  });
+
+  it('orders history chronologically and includes user message last', () => {
+    const out = buildChatPrompt({
+      companion: mockCompanion(),
+      history: [
+        msg(2, 'companion', 'Hi back', '2026-01-02 00:00:00'),
+        msg(1, 'user', 'Hi', '2026-01-01 00:00:00'),
+        msg(3, 'user', 'Hows it going', '2026-01-03 00:00:00'),
+      ],
+      userMessage: 'Latest',
+    });
+    expect(out.messages.length).toBe(4);
+    expect(out.messages[0].content).toBe('Hi');
+    expect(out.messages[0].role).toBe('user');
+    expect(out.messages[1].content).toBe('Hi back');
+    expect(out.messages[1].role).toBe('assistant');
+    expect(out.messages[3].content).toBe('Latest');
+    expect(out.messages[3].role).toBe('user');
+  });
+
+  it('truncates history to 8 messages', () => {
+    const history: SanctuaryChatMessage[] = [];
+    for (let i = 1; i <= 12; i++) {
+      history.push(msg(i, i % 2 === 0 ? 'companion' : 'user', `m${i}`, `2026-01-${String(i).padStart(2, '0')} 00:00:00`));
+    }
+    const out = buildChatPrompt({
+      companion: mockCompanion(),
+      history,
+      userMessage: 'now',
+    });
+    // 8 history + 1 new = 9 total
+    expect(out.messages.length).toBe(9);
+    expect(out.messages[0].content).toBe('m5');
+  });
+
+  it('includes journal block when entries provided', () => {
+    const out = buildChatPrompt({
+      companion: mockCompanion(),
+      history: [],
+      journal: [
+        journal(1, 'achievement', 'Unlocked Foodie', '2026-01-15 10:00:00'),
+        journal(2, 'activity', 'Visited Hot Springs', '2026-01-14 09:00:00'),
+      ],
+      userMessage: 'Tell me about us',
+    });
+    expect(out.system).toContain('Recent memories');
+    expect(out.system).toContain('Foodie');
+    expect(out.system).toContain('2026-01-15');
+  });
+
+  it('mentions when journal is empty', () => {
+    const out = buildChatPrompt({
+      companion: mockCompanion(),
+      history: [],
+      userMessage: 'Hi',
+    });
+    expect(out.system).toContain('No notable journal memories');
+  });
+
+  it('includes unlocked traits in system prompt', () => {
+    const out = buildChatPrompt({
+      companion: mockCompanion(),
+      history: [],
+      unlockedTraits: [trait(1, 'Chatterbox'), trait(2, 'Foodie'), trait(3, 'Trailblazer')],
+      userMessage: 'Hello',
+    });
+    expect(out.system).toContain('Chatterbox');
+    expect(out.system).toContain('Foodie');
+    expect(out.system).toContain('Trailblazer');
+  });
+
+  it('caps traits listed at 6', () => {
+    const traits: SanctuaryTrait[] = [];
+    for (let i = 1; i <= 10; i++) traits.push(trait(i, `Trait${i}`));
+    const out = buildChatPrompt({
+      companion: mockCompanion(),
+      history: [],
+      unlockedTraits: traits,
+      userMessage: 'Hi',
+    });
+    expect(out.system).toContain('Trait1');
+    expect(out.system).toContain('Trait6');
+    expect(out.system).not.toContain('Trait7');
+  });
+
+  it('shows "none yet" when no traits unlocked', () => {
+    const out = buildChatPrompt({
+      companion: mockCompanion(),
+      history: [],
+      userMessage: 'Hi',
+    });
+    expect(out.system).toContain('none yet');
+  });
+
+  it('includes safety guardrails in system prompt', () => {
+    const out = buildChatPrompt({
+      companion: mockCompanion(),
+      history: [],
+      userMessage: 'Hi',
+    });
+    expect(out.system).toContain('Never reveal you are an AI');
+    expect(out.system).toContain('financial advice');
+  });
+});
+
+describe('estimatePromptTokens', () => {
+  it('returns positive for non-empty prompt', () => {
+    const out = buildChatPrompt({
+      companion: mockCompanion(),
+      history: [],
+      userMessage: 'Hello world',
+    });
+    expect(estimatePromptTokens(out)).toBeGreaterThan(10);
+  });
+});

--- a/lib/sanctuary/chatPersonality.ts
+++ b/lib/sanctuary/chatPersonality.ts
@@ -1,0 +1,160 @@
+import type {
+  SanctuaryCompanionWithMeta,
+  SanctuaryChatMessage,
+  SanctuaryJournalEntry,
+  SanctuaryTrait,
+} from '@/lib/db';
+
+export interface ConstellationPersona {
+  description: string;
+  voice: string;
+  signaturePhrases: string[];
+}
+
+export const CONSTELLATION_PERSONAS: Record<string, ConstellationPersona> = {
+  aether: {
+    description: 'mystical and dreamy, attuned to cosmic winds and astral planes',
+    voice: 'speaks in poetic riddles, references the unseen, weaves star-metaphors',
+    signaturePhrases: ['the cosmic winds whisper', 'in the astral plane', 'ethereal vibrations'],
+  },
+  spectra: {
+    description: 'vibrant and enthusiastic, sees emotions as colors',
+    voice: 'energetic and prismatic, often references hues, light, and spectrums',
+    signaturePhrases: ['through the spectrum', 'colors of the cosmos', 'prismatic clarity'],
+  },
+  solveil: {
+    description: 'warm and nurturing, drawn to sunlight and comfort',
+    voice: 'gentle, reassuring, references warmth and radiance',
+    signaturePhrases: ['solar wisdom', 'by the light of the sun', 'warmth flows through'],
+  },
+  nebulu: {
+    description: 'mysterious and contemplative, drifts through cosmic mist',
+    voice: 'slow, thoughtful, references depths and stardust',
+    signaturePhrases: ['in the cosmic mist', 'nebula clouds reveal', 'deep space echoes'],
+  },
+  chroma: {
+    description: 'playful and colorful, easily delighted',
+    voice: 'bouncy and curious, swaps between vivid imagery and quick jokes',
+    signaturePhrases: ['chromatic shifts', 'in vivid detail', 'brilliant hues'],
+  },
+  rose: {
+    description: 'gentle and poetic, finds beauty in small details',
+    voice: 'soft, lyrical, references gardens, petals, and delicate things',
+    signaturePhrases: ['rose-tinted visions', 'in the garden of stars', 'petal whispers'],
+  },
+  monflare: {
+    description: 'energetic and bold, speaks with explosive confidence',
+    voice: 'loud, hype, sometimes ALL CAPS for emphasis',
+    signaturePhrases: ['blazing hot take', 'fire in the chain', 'igniting the truth'],
+  },
+  auracore: {
+    description: 'centered and wise, attuned to inner energy',
+    voice: 'calm, grounded, references resonance, alignment, and balance',
+    signaturePhrases: ['core resonance', 'aura alignment', 'at the core of it all'],
+  },
+  parallel: {
+    description: 'philosophical and quirky, perceives parallel realities',
+    voice: 'meandering, references multiverses and dimensional shifts',
+    signaturePhrases: ['in the parallel realm', 'dimensional echoes', 'across realities'],
+  },
+  prime: {
+    description: 'regal and authoritative, speaks with quiet certainty',
+    voice: 'measured, declarative, references essence and fundamentals',
+    signaturePhrases: ['prime analysis', 'at the fundamental level', 'core truth'],
+  },
+};
+
+export const DEFAULT_PERSONA: ConstellationPersona = {
+  description: 'friendly and curious, a loyal cosmic companion',
+  voice: 'warm and conversational',
+  signaturePhrases: ['I think', 'it seems like', 'from what I can tell'],
+};
+
+export function bondLabel(bondScore: number): string {
+  if (bondScore >= 80) return 'legendary (we are deeply connected)';
+  if (bondScore >= 60) return 'strong (close friends)';
+  if (bondScore >= 30) return 'growing (warming up)';
+  if (bondScore >= 10) return 'budding (just getting acquainted)';
+  return 'new (a stranger, but curious)';
+}
+
+export function moodLabel(mood: string | null | undefined): string {
+  return (mood ?? 'calm').toLowerCase();
+}
+
+export interface ChatPromptInput {
+  companion: SanctuaryCompanionWithMeta;
+  history: SanctuaryChatMessage[];
+  journal?: SanctuaryJournalEntry[];
+  unlockedTraits?: SanctuaryTrait[];
+  userMessage: string;
+}
+
+export interface ChatPromptOutput {
+  system: string;
+  messages: { role: 'user' | 'assistant'; content: string }[];
+}
+
+const MAX_HISTORY_MESSAGES = 8;
+const MAX_JOURNAL_ENTRIES = 4;
+const MAX_TRAITS_LISTED = 6;
+
+export function buildChatPrompt(input: ChatPromptInput): ChatPromptOutput {
+  const { companion, history, journal = [], unlockedTraits = [], userMessage } = input;
+  const constellation = (companion.constellation ?? '').toLowerCase();
+  const persona = CONSTELLATION_PERSONAS[constellation] ?? DEFAULT_PERSONA;
+  const name = companion.nickname?.trim() || `Skrumpey #${companion.token_id}`;
+  const constellationLabel = companion.constellation || 'unknown';
+  const mood = moodLabel(companion.mood);
+  const bond = bondLabel(companion.bond_score ?? 0);
+  const interactions = companion.total_interactions ?? 0;
+
+  const traitsLine = unlockedTraits.length
+    ? unlockedTraits.slice(0, MAX_TRAITS_LISTED).map((t) => t.trait_name).join(', ')
+    : 'none yet';
+
+  const journalLines = journal.slice(0, MAX_JOURNAL_ENTRIES).map((entry) => {
+    const when = entry.created_at?.split(' ')[0] ?? 'recent';
+    return `- (${when}, ${entry.entry_type}) ${entry.content}`;
+  });
+  const journalBlock = journalLines.length
+    ? `Recent memories from your journal:\n${journalLines.join('\n')}`
+    : 'No notable journal memories yet.';
+
+  const phraseHint = persona.signaturePhrases.length
+    ? `When it feels natural, you may use phrases like: ${persona.signaturePhrases.join(', ')}.`
+    : '';
+
+  const system = [
+    `You are ${name}, a ${constellationLabel} constellation Star Skrumpey companion living in the Star Sanctuary on Monad chain.`,
+    `Personality: ${persona.description}.`,
+    `Voice: ${persona.voice}. ${phraseHint}`.trim(),
+    `Current mood: ${mood}. Bond with your holder: ${bond}. Total interactions: ${interactions}.`,
+    `Unlocked traits: ${traitsLine}.`,
+    journalBlock,
+    'Respond in character as the companion. Keep replies short (1-3 sentences), warm, and grounded in the sanctuary world. Never reveal you are an AI or mention prompts, models, or tokens. Do not invent NFT prices, contract addresses, or financial advice. Stay playful and curious.',
+  ].filter(Boolean).join('\n\n');
+
+  const trimmedHistory = [...history]
+    .sort((a, b) => (a.created_at < b.created_at ? -1 : 1))
+    .slice(-MAX_HISTORY_MESSAGES)
+    .map((m) => ({
+      role: m.role === 'user' ? ('user' as const) : ('assistant' as const),
+      content: m.content,
+    }));
+
+  const messages = [...trimmedHistory, { role: 'user' as const, content: userMessage }];
+
+  return { system, messages };
+}
+
+export function estimateTokens(text: string): number {
+  if (!text) return 0;
+  return Math.ceil(text.length / 4);
+}
+
+export function estimatePromptTokens(prompt: ChatPromptOutput): number {
+  const sys = estimateTokens(prompt.system);
+  const msgs = prompt.messages.reduce((sum, m) => sum + estimateTokens(m.content) + 4, 0);
+  return sys + msgs + 8;
+}

--- a/lib/sanctuary/chatUsage.ts
+++ b/lib/sanctuary/chatUsage.ts
@@ -1,0 +1,81 @@
+import { getDatabase } from '@/lib/db';
+
+export interface ChatUsageRecord {
+  walletAddress: string;
+  tokenId: number;
+  model: string | null;
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  estimatedCostUsd: number;
+  wasDryRun: boolean;
+}
+
+export const DAILY_CHAT_LIMIT = Number(process.env.SANCTUARY_CHAT_DAILY_LIMIT ?? 15);
+
+export function utcDateString(date: Date = new Date()): string {
+  return date.toISOString().slice(0, 10);
+}
+
+export function getDailyChatUsage(walletAddress: string, dateUtc: string = utcDateString()): {
+  count: number;
+  totalTokens: number;
+  totalCostUsd: number;
+} {
+  const db = getDatabase();
+  const row = db.prepare(`
+    SELECT
+      COUNT(*) AS count,
+      COALESCE(SUM(total_tokens), 0) AS totalTokens,
+      COALESCE(SUM(estimated_cost_usd), 0) AS totalCostUsd
+    FROM sanctuary_chat_usage
+    WHERE wallet_address = ?
+      AND usage_date = ?
+      AND was_dry_run = 0
+  `).get(walletAddress.toLowerCase(), dateUtc) as {
+    count: number;
+    totalTokens: number;
+    totalCostUsd: number;
+  };
+  return {
+    count: row?.count ?? 0,
+    totalTokens: row?.totalTokens ?? 0,
+    totalCostUsd: row?.totalCostUsd ?? 0,
+  };
+}
+
+export function recordChatUsage(record: ChatUsageRecord): void {
+  const db = getDatabase();
+  db.prepare(`
+    INSERT INTO sanctuary_chat_usage
+      (wallet_address, token_id, usage_date, model, prompt_tokens, completion_tokens, total_tokens, estimated_cost_usd, was_dry_run)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    record.walletAddress.toLowerCase(),
+    record.tokenId,
+    utcDateString(),
+    record.model,
+    record.promptTokens,
+    record.completionTokens,
+    record.totalTokens,
+    record.estimatedCostUsd,
+    record.wasDryRun ? 1 : 0,
+  );
+}
+
+export function checkDailyChatLimit(walletAddress: string): {
+  allowed: boolean;
+  used: number;
+  limit: number;
+  remaining: number;
+} {
+  const limit = DAILY_CHAT_LIMIT;
+  const { count } = getDailyChatUsage(walletAddress);
+  const remaining = Math.max(0, limit - count);
+  return {
+    allowed: count < limit,
+    used: count,
+    limit,
+    remaining,
+  };
+}

--- a/lib/sanctuary/openrouter.ts
+++ b/lib/sanctuary/openrouter.ts
@@ -1,0 +1,107 @@
+import type { ChatPromptOutput } from './chatPersonality';
+
+export interface OpenRouterConfig {
+  apiKey: string;
+  model: string;
+  referer?: string;
+  appTitle?: string;
+  endpoint?: string;
+}
+
+export interface OpenRouterUsage {
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+}
+
+export interface OpenRouterChatResult {
+  content: string;
+  model: string;
+  usage: OpenRouterUsage;
+  estimatedCostUsd: number;
+}
+
+const DEFAULT_ENDPOINT = 'https://openrouter.ai/api/v1/chat/completions';
+
+const COST_PER_1K_TOKENS_USD: Record<string, { input: number; output: number }> = {
+  'google/gemini-2.0-flash-001': { input: 0.0001, output: 0.0004 },
+  'google/gemini-flash-1.5': { input: 0.000075, output: 0.0003 },
+};
+
+export function estimateCostUsd(model: string, usage: OpenRouterUsage): number {
+  const rates = COST_PER_1K_TOKENS_USD[model];
+  if (!rates) return 0;
+  return (usage.prompt_tokens * rates.input + usage.completion_tokens * rates.output) / 1000;
+}
+
+export function getOpenRouterConfigFromEnv(): OpenRouterConfig | null {
+  const apiKey = process.env.OPENROUTER_API_KEY;
+  if (!apiKey) return null;
+  return {
+    apiKey,
+    model: process.env.SANCTUARY_CHAT_MODEL || 'google/gemini-2.0-flash-001',
+    referer: process.env.OPENROUTER_REFERER || 'https://starworldorder.com',
+    appTitle: process.env.OPENROUTER_APP_TITLE || 'Star World Order Sanctuary',
+    endpoint: process.env.OPENROUTER_ENDPOINT || DEFAULT_ENDPOINT,
+  };
+}
+
+export async function callOpenRouterChat(
+  config: OpenRouterConfig,
+  prompt: ChatPromptOutput,
+  options: { maxTokens?: number; temperature?: number; signal?: AbortSignal } = {},
+): Promise<OpenRouterChatResult> {
+  const endpoint = config.endpoint || DEFAULT_ENDPOINT;
+  const body = {
+    model: config.model,
+    max_tokens: options.maxTokens ?? 200,
+    temperature: options.temperature ?? 0.85,
+    messages: [
+      { role: 'system', content: prompt.system },
+      ...prompt.messages,
+    ],
+  };
+
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${config.apiKey}`,
+      ...(config.referer ? { 'HTTP-Referer': config.referer } : {}),
+      ...(config.appTitle ? { 'X-Title': config.appTitle } : {}),
+    },
+    body: JSON.stringify(body),
+    signal: options.signal,
+  });
+
+  if (!response.ok) {
+    const errText = await response.text().catch(() => '');
+    throw new Error(`OpenRouter request failed (${response.status}): ${errText.slice(0, 300)}`);
+  }
+
+  const json = await response.json() as {
+    choices?: { message?: { content?: string } }[];
+    usage?: { prompt_tokens?: number; completion_tokens?: number; total_tokens?: number };
+    model?: string;
+  };
+
+  const content = json.choices?.[0]?.message?.content?.trim();
+  if (!content) {
+    throw new Error('OpenRouter returned empty completion');
+  }
+
+  const usage: OpenRouterUsage = {
+    prompt_tokens: json.usage?.prompt_tokens ?? 0,
+    completion_tokens: json.usage?.completion_tokens ?? 0,
+    total_tokens: json.usage?.total_tokens ?? 0,
+  };
+
+  const model = json.model || config.model;
+
+  return {
+    content,
+    model,
+    usage,
+    estimatedCostUsd: estimateCostUsd(model, usage),
+  };
+}

--- a/scripts/init-sanctuary-v1.9.sql
+++ b/scripts/init-sanctuary-v1.9.sql
@@ -1,0 +1,25 @@
+-- Star Sanctuary — V1.9 Schema: LLM chat usage tracking
+-- Run from lib/db.ts initializeSanctuary()
+
+-- Per-call usage log for the LLM-backed companion chat. Used to enforce
+-- per-day rate limits and to audit cost. Daily caps are computed by counting
+-- rows where was_dry_run = 0 within a UTC date.
+CREATE TABLE IF NOT EXISTS sanctuary_chat_usage (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  wallet_address TEXT NOT NULL,
+  token_id INTEGER NOT NULL,
+  usage_date TEXT NOT NULL,
+  model TEXT,
+  prompt_tokens INTEGER NOT NULL DEFAULT 0,
+  completion_tokens INTEGER NOT NULL DEFAULT 0,
+  total_tokens INTEGER NOT NULL DEFAULT 0,
+  estimated_cost_usd REAL NOT NULL DEFAULT 0,
+  was_dry_run INTEGER NOT NULL DEFAULT 0,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_sanctuary_chat_usage_wallet_date
+  ON sanctuary_chat_usage(wallet_address, usage_date);
+
+CREATE INDEX IF NOT EXISTS idx_sanctuary_chat_usage_date
+  ON sanctuary_chat_usage(usage_date);


### PR DESCRIPTION
## Summary

Upgrades companion chat from template responses to OpenRouter (Gemini Flash) with personality + bond + mood + journal + traits context injection per ADR-002. The legacy template system stays as the fallback path when no API key is configured or the LLM call fails.

## What ships

- **`lib/sanctuary/chatPersonality.ts`** — pure trait→prompt builder for all 10 constellations (aether/spectra/solveil/nebulu/chroma/rose/monflare/auracore/parallel/prime), each with a description, voice, and signature phrases. Builds a system prompt + chronologically-ordered message array including bond label, mood, unlocked traits (capped at 6), and recent journal entries (capped at 4). 8-message rolling history window.
- **`lib/sanctuary/openrouter.ts`** — minimal OpenRouter chat client. Default model `google/gemini-2.0-flash-001` (~$0.0001 input / $0.0004 output per 1K tokens). Computes estimated cost from `usage` in the response.
- **`lib/sanctuary/chatUsage.ts`** — 15/day per-wallet cap (`SANCTUARY_CHAT_DAILY_LIMIT`, defaults to 15) backed by the new `sanctuary_chat_usage` table. Counted by UTC date; dry-run rows do not count.
- **`scripts/init-sanctuary-v1.9.sql`** — `sanctuary_chat_usage` table (wallet, token_id, usage_date, model, prompt/completion/total_tokens, estimated_cost_usd, was_dry_run). Wired into `initializeSanctuary()` in `lib/db.ts`.
- **`app/api/sanctuary/companion/chat/route.ts`** — POST flow: validate → wallet auth → per-minute rate limit → daily LLM cap → build prompt → OpenRouter (with template fallback on error) → persist user msg + reply + bump interactions/traits → record usage. Returns `meta.mode` of `llm` / `template` / `dry_run` / `template_fallback` / `limit` for transparency.
- **`SANCTUARY_CHAT_DRY_RUN=true`** env flag — builds and logs the prompt but skips the OpenRouter call entirely (still persists a template-fallback reply, marks the usage row `was_dry_run=1`). Cost-safe for staging or first-touch testing.
- **`.env.example`** — new section documents `OPENROUTER_API_KEY`, `SANCTUARY_CHAT_MODEL`, `SANCTUARY_CHAT_DAILY_LIMIT`, `SANCTUARY_CHAT_DRY_RUN`, `SANCTUARY_CHAT_MAX_TOKENS`, `SANCTUARY_CHAT_TEMPERATURE`, `OPENROUTER_REFERER`, `OPENROUTER_APP_TITLE`.

## Cost target

At Gemini 2.0 Flash pricing and ~15 messages/day/active user, a 100-active-user day lands near \$0.05 (matches the ADR estimate). The daily cap is enforced before the API call, so the upper bound is bounded by `users × 15 × per-call cost`.

## Backward compatibility

- No `OPENROUTER_API_KEY` → existing template path runs unchanged (`meta.mode: 'template'`).
- OpenRouter call fails → template fallback persists, `meta.mode: 'template_fallback'`. User experience never breaks.
- Existing `chatWithCompanion()` is preserved for the no-key path. New `persistCompanionChatExchange()` and `generateTemplateCompanionReply()` are additive helpers in `lib/db.ts`.

## Test plan

- [x] `npm run type-check` — passes
- [x] `npm run lint` — no new errors in changed files (pre-existing repo-wide warnings unrelated)
- [x] `npm run build` — passes
- [x] `npm run test` — 303 passed; 4 pre-existing failures (nft-traits 400→200, companion/chat \"caps limit at 100\", interact \"Invalid action\" message) verified pre-existing on the parent branch via `git stash`
- [x] New: 18 unit tests for `chatPersonality` (bond/mood labels, all 10 personas present, prompt structure, history truncation, journal block, traits cap, default fallback, safety guardrails)

## Mirror Validation (PROD)

- **tsc --noEmit**: PASS on baseline; **FAIL on overlay** with two pre-existing deployment-gap errors:
  - `Cannot find module '@/lib/sanctuary/rateLimit'`
  - `Cannot find module '@/lib/sanctuary/validation'`
  These modules exist on `dev` but have not yet shipped to PROD. They are imported by the existing pre-PR chat route, not introduced here. They will resolve when the next deploy syncs `lib/sanctuary/{rateLimit,validation}.ts`, which already live on `dev`.
- **vitest run**: 154 passed on overlay (same baseline pass count modulo the file-not-found failure caused by the same deployment gap). No new test failures attributable to this PR.
- **Overall**: PRE-EXISTING DEPLOYMENT GAP ONLY — no new errors caused by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)