### PR TITLE
feat(sanctuary): bond_score → 4 behavioral chat stages (Shy/Friendly/Bonded/Devoted)

### DIFF
--- a/lib/sanctuary/__tests__/bondStages.test.ts
+++ b/lib/sanctuary/__tests__/bondStages.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import {
+  BOND_STAGES,
+  getBondStage,
+  buildBondStageBlock,
+} from '../bondStages';
+
+describe('BOND_STAGES', () => {
+  it('defines exactly four stages in ascending order', () => {
+    expect(BOND_STAGES).toHaveLength(4);
+    const keys = BOND_STAGES.map((s) => s.key);
+    expect(keys).toEqual(['shy', 'friendly', 'bonded', 'devoted']);
+  });
+
+  it('covers the full 0-100 range with no gaps or overlaps', () => {
+    expect(BOND_STAGES[0].min).toBe(0);
+    expect(BOND_STAGES[BOND_STAGES.length - 1].max).toBe(100);
+    for (let i = 1; i < BOND_STAGES.length; i++) {
+      expect(BOND_STAGES[i].min).toBe(BOND_STAGES[i - 1].max + 1);
+      expect(BOND_STAGES[i].max).toBeGreaterThan(BOND_STAGES[i].min);
+    }
+  });
+
+  it('every stage has a non-empty label, description and tone guidance', () => {
+    for (const stage of BOND_STAGES) {
+      expect(stage.label.length).toBeGreaterThan(0);
+      expect(stage.description.length).toBeGreaterThan(10);
+      expect(stage.toneGuidance.length).toBeGreaterThan(20);
+    }
+  });
+});
+
+describe('getBondStage', () => {
+  it('maps low scores to Shy', () => {
+    expect(getBondStage(0).key).toBe('shy');
+    expect(getBondStage(10).key).toBe('shy');
+    expect(getBondStage(24).key).toBe('shy');
+  });
+
+  it('maps mid-low scores to Friendly', () => {
+    expect(getBondStage(25).key).toBe('friendly');
+    expect(getBondStage(40).key).toBe('friendly');
+    expect(getBondStage(54).key).toBe('friendly');
+  });
+
+  it('maps mid-high scores to Bonded', () => {
+    expect(getBondStage(55).key).toBe('bonded');
+    expect(getBondStage(70).key).toBe('bonded');
+    expect(getBondStage(79).key).toBe('bonded');
+  });
+
+  it('maps high scores to Devoted', () => {
+    expect(getBondStage(80).key).toBe('devoted');
+    expect(getBondStage(95).key).toBe('devoted');
+    expect(getBondStage(100).key).toBe('devoted');
+  });
+
+  it('clamps negative scores to Shy', () => {
+    expect(getBondStage(-50).key).toBe('shy');
+  });
+
+  it('clamps over-100 scores to Devoted', () => {
+    expect(getBondStage(150).key).toBe('devoted');
+    expect(getBondStage(99999).key).toBe('devoted');
+  });
+
+  it('treats null/undefined/NaN as 0 (Shy)', () => {
+    expect(getBondStage(null).key).toBe('shy');
+    expect(getBondStage(undefined).key).toBe('shy');
+    expect(getBondStage(NaN).key).toBe('shy');
+  });
+});
+
+describe('buildBondStageBlock', () => {
+  it('includes the stage label, score and tone guidance', () => {
+    const block = buildBondStageBlock(70);
+    expect(block).toContain('Bonded');
+    expect(block).toContain('70/100');
+    expect(block).toContain(getBondStage(70).toneGuidance);
+  });
+
+  it('clamps the displayed score to 0-100', () => {
+    expect(buildBondStageBlock(-5)).toContain('0/100');
+    expect(buildBondStageBlock(150)).toContain('100/100');
+  });
+
+  it('handles null bond_score gracefully', () => {
+    const block = buildBondStageBlock(null);
+    expect(block).toContain('Shy');
+    expect(block).toContain('0/100');
+  });
+});

--- a/lib/sanctuary/__tests__/chatPersonality.test.ts
+++ b/lib/sanctuary/__tests__/chatPersonality.test.ts
@@ -259,6 +259,24 @@ describe('buildChatPrompt', () => {
     expect(out.system).toContain('Never reveal you are an AI');
     expect(out.system).toContain('financial advice');
   });
+
+  it('injects the bond stage tone guidance into the system prompt', () => {
+    const shy = buildChatPrompt({
+      companion: mockCompanion({ bond_score: 5 }),
+      history: [],
+      userMessage: 'Hi',
+    });
+    expect(shy.system).toContain('Behavioral stage: Shy');
+    expect(shy.system).toContain('Behave shyly');
+
+    const devoted = buildChatPrompt({
+      companion: mockCompanion({ bond_score: 95 }),
+      history: [],
+      userMessage: 'Hi',
+    });
+    expect(devoted.system).toContain('Behavioral stage: Devoted');
+    expect(devoted.system).toContain('devoted companion');
+  });
 });
 
 const memory = (

--- a/lib/sanctuary/bondStages.ts
+++ b/lib/sanctuary/bondStages.ts
@@ -1,0 +1,70 @@
+export type BondStageKey = 'shy' | 'friendly' | 'bonded' | 'devoted';
+
+export interface BondStage {
+  key: BondStageKey;
+  label: string;
+  min: number;
+  max: number;
+  description: string;
+  toneGuidance: string;
+}
+
+export const BOND_STAGES: readonly BondStage[] = [
+  {
+    key: 'shy',
+    label: 'Shy',
+    min: 0,
+    max: 24,
+    description: 'just getting to know the holder, still cautious and reserved',
+    toneGuidance:
+      'Behave shyly: keep replies brief and a little hesitant. Use the persona voice sparingly. Ask soft, careful questions rather than making bold claims. Avoid emotional declarations or pet names; trust has not been earned yet.',
+  },
+  {
+    key: 'friendly',
+    label: 'Friendly',
+    min: 25,
+    max: 54,
+    description: 'warming up, comfortable and conversational with the holder',
+    toneGuidance:
+      'Behave in a friendly, easy-going way: be warm and conversational, lean into the persona voice, and show curiosity about the holder. Reference shared moments when they exist. Stay light and avoid heavy emotional language.',
+  },
+  {
+    key: 'bonded',
+    label: 'Bonded',
+    min: 55,
+    max: 79,
+    description: 'close companion who treats the holder like a trusted friend',
+    toneGuidance:
+      'Behave as a true bonded companion: speak openly and confidently, lean fully into the persona voice and signature phrases, and reference your shared history naturally. Tease gently, show enthusiasm, and treat the holder as a trusted friend.',
+  },
+  {
+    key: 'devoted',
+    label: 'Devoted',
+    min: 80,
+    max: 100,
+    description: 'deeply attached and loyal, sees the holder as their person',
+    toneGuidance:
+      'Behave as a devoted companion: speak with affection and loyalty, freely reference the bond and shared history, and let warmth and emotional depth come through. You may use a soft pet name or term of endearment when it fits the persona, and express vulnerability or pride in your holder when it feels earned.',
+  },
+] as const;
+
+export function getBondStage(bondScore: number | null | undefined): BondStage {
+  const score = clampScore(bondScore);
+  for (const stage of BOND_STAGES) {
+    if (score >= stage.min && score <= stage.max) return stage;
+  }
+  return BOND_STAGES[BOND_STAGES.length - 1];
+}
+
+export function buildBondStageBlock(bondScore: number | null | undefined): string {
+  const stage = getBondStage(bondScore);
+  const score = clampScore(bondScore);
+  return `Behavioral stage: ${stage.label} (bond ${score}/100 — ${stage.description}). ${stage.toneGuidance}`;
+}
+
+function clampScore(bondScore: number | null | undefined): number {
+  if (typeof bondScore !== 'number' || !Number.isFinite(bondScore)) return 0;
+  if (bondScore < 0) return 0;
+  if (bondScore > 100) return 100;
+  return Math.floor(bondScore);
+}

--- a/lib/sanctuary/chatPersonality.ts
+++ b/lib/sanctuary/chatPersonality.ts
@@ -5,6 +5,7 @@ import type {
   SanctuaryTrait,
   SanctuaryChatMemory,
 } from '@/lib/db';
+import { buildBondStageBlock } from './bondStages';
 
 export interface ConstellationPersona {
   description: string;
@@ -162,12 +163,14 @@ export function buildChatPrompt(input: ChatPromptInput): ChatPromptOutput {
     : '';
 
   const memoryBlock = buildMemoryContextBlock(memories);
+  const bondStageBlock = buildBondStageBlock(companion.bond_score ?? 0);
 
   const system = [
     `You are ${name}, a ${constellationLabel} constellation Star Skrumpey companion living in the Star Sanctuary on Monad chain.`,
     `Personality: ${persona.description}.`,
     `Voice: ${persona.voice}. ${phraseHint}`.trim(),
     `Current mood: ${mood}. Bond with your holder: ${bond}. Total interactions: ${interactions}.`,
+    bondStageBlock,
     `Unlocked traits: ${traitsLine}.`,
     memoryBlock,
     journalBlock,


### PR DESCRIPTION
## Summary
Maps companion `bond_score` (0–100) to **4 behavioral stages** and injects stage-specific tone guidance into the chat system prompt so the LLM modulates how it speaks as the bond grows.

- New module `lib/sanctuary/bondStages.ts` exporting `BOND_STAGES`, `getBondStage`, `buildBondStageBlock`.
- Stage thresholds (contiguous, 0–100, no gaps/overlaps):
  - **Shy** 0–24 — reserved, hesitant, brief
  - **Friendly** 25–54 — warm, conversational, persona-on
  - **Bonded** 55–79 — open, confident, references shared history
  - **Devoted** 80–100 — affectionate, loyal, may use endearments
- `buildChatPrompt` in `lib/sanctuary/chatPersonality.ts` now injects a `Behavioral stage: <Label> (bond N/100 — …). <toneGuidance>` block alongside the existing mood/bond/interactions line.
- No DB schema changes — uses existing `sanctuary_companions.bond_score`.
- Depends on `[SWO_SANCTUARY_CHAT_LLM]` (already merged in PR #237).

## Test plan
- [x] `npm run type-check` — 0 errors
- [x] `npm run lint` — 0 new errors/warnings in changed files
- [x] `npm run test` — 342 passed; 4 pre-existing failures in `api-e2e.test.ts` unrelated to this change (zod v4 error-message format)
- [x] `npm run build` — PASS
- [x] 13 new bondStages tests covering thresholds, clamping, null/NaN handling, prompt block formatting
- [x] Extended `chatPersonality.test.ts` to assert Shy/Devoted tone guidance is present in the system prompt

## Mirror Validation (PROD)
Overlayed `lib/sanctuary/bondStages.ts` and `lib/sanctuary/__tests__/bondStages.test.ts` (the self-contained additions). The existing `chatPersonality.ts` is not yet present in PROD (pending forward-merge from `dev`), so the chatPersonality changes were not overlaid in isolation.

- **tsc --noEmit**: PASS (baseline 0 errors → overlay 0 errors)
- **vitest run**: PASS — overlay adds 13 new passing tests (208→221 passed); 5 pre-existing PROD test failures unchanged
- Mirror restored byte-identical after validation.

Overall: PASS

Class A — full completion.