### PR TITLE
feat(sanctuary): in-world companion chat overlay (hotkey C)

### DIFF
--- a/app/sanctuary/SanctuaryV2.tsx
+++ b/app/sanctuary/SanctuaryV2.tsx
@@ -36,6 +36,11 @@ const ChatBubble = dynamic(
   { ssr: false }
 );
 
+const CompanionChatOverlay = dynamic(
+  () => import('@/components/sanctuary/overlays/CompanionChatOverlay'),
+  { ssr: false }
+);
+
 const QuestDialog = dynamic(
   () => import('@/components/sanctuary/overlays/QuestDialog'),
   { ssr: false }
@@ -163,6 +168,7 @@ export default function SanctuaryV2() {
         <WelcomeDialog walletAddress={address} />
         <LevelUpCelebration />
         <ChatBubble />
+        <CompanionChatOverlay walletAddress={address} tokenId={activeTokenId} />
         <ChatInput />
         {editMode && <DevMapEditor />}
       </div>

--- a/components/sanctuary/overlays/ChatBubble.tsx
+++ b/components/sanctuary/overlays/ChatBubble.tsx
@@ -8,6 +8,9 @@ import type { RemotePlayer } from '@/lib/colyseus/types';
 const BUBBLE_LIFETIME = 8000;
 const FADE_DURATION = 1000;
 const BUBBLE_OFFSET_Y = -20;
+const COMPANION_BUBBLE_LIFETIME = 6000;
+const COMPANION_BUBBLE_OFFSET_Y = -28;
+const COMPANION_SESSION_ID = '__companion__';
 
 interface ActiveBubble {
   id: number;
@@ -15,6 +18,7 @@ interface ActiveBubble {
   displayName: string;
   text: string;
   createdAt: number;
+  variant?: 'companion';
 }
 
 let bubbleIdCounter = 0;
@@ -45,6 +49,22 @@ export default function ChatBubble() {
     [],
   );
 
+  const addCompanionBubble = useCallback((msg: { text: string }) => {
+    if (!msg?.text) return;
+    const bubble: ActiveBubble = {
+      id: ++bubbleIdCounter,
+      sessionId: COMPANION_SESSION_ID,
+      displayName: 'Companion',
+      text: msg.text,
+      createdAt: Date.now(),
+      variant: 'companion',
+    };
+    setBubbles((prev) => {
+      const existing = prev.filter((b) => b.sessionId !== COMPANION_SESSION_ID);
+      return [...existing, bubble];
+    });
+  }, []);
+
   useEffect(() => {
     const handlePlayerAdd = (p: RemotePlayer) => {
       playerPositions.current.set(p.sessionId, { x: p.x, y: p.y });
@@ -58,24 +78,29 @@ export default function ChatBubble() {
     };
 
     EventBus.on('chat-message', addBubble);
+    EventBus.on('companion-bubble', addCompanionBubble);
     EventBus.on('remote-player-add', handlePlayerAdd);
     EventBus.on('remote-player-update', handlePlayerUpdate);
     EventBus.on('remote-player-remove', handlePlayerRemove);
 
     return () => {
       EventBus.off('chat-message', addBubble);
+      EventBus.off('companion-bubble', addCompanionBubble);
       EventBus.off('remote-player-add', handlePlayerAdd);
       EventBus.off('remote-player-update', handlePlayerUpdate);
       EventBus.off('remote-player-remove', handlePlayerRemove);
     };
-  }, [addBubble]);
+  }, [addBubble, addCompanionBubble]);
 
   useEffect(() => {
     const tick = () => {
       const now = Date.now();
 
       setBubbles((prev) => {
-        const alive = prev.filter((b) => now - b.createdAt < BUBBLE_LIFETIME);
+        const alive = prev.filter((b) => {
+          const lifetime = b.variant === 'companion' ? COMPANION_BUBBLE_LIFETIME : BUBBLE_LIFETIME;
+          return now - b.createdAt < lifetime;
+        });
         if (alive.length !== prev.length) return alive;
         return prev;
       });
@@ -86,8 +111,12 @@ export default function ChatBubble() {
 
         let worldX: number;
         let worldY: number;
+        const offsetY = bubble.variant === 'companion' ? COMPANION_BUBBLE_OFFSET_Y : BUBBLE_OFFSET_Y;
 
-        if (bubble.sessionId === localSessionId.current) {
+        if (bubble.variant === 'companion') {
+          worldX = cameraState.companionX;
+          worldY = cameraState.companionY;
+        } else if (bubble.sessionId === localSessionId.current) {
           worldX = cameraState.localPlayerX;
           worldY = cameraState.localPlayerY;
         } else {
@@ -97,12 +126,13 @@ export default function ChatBubble() {
           worldY = pos.y;
         }
 
-        const screen = worldToScreen(worldX, worldY + BUBBLE_OFFSET_Y);
+        const screen = worldToScreen(worldX, worldY + offsetY);
         el.style.left = `${screen.x}px`;
         el.style.top = `${screen.y}px`;
 
+        const lifetime = bubble.variant === 'companion' ? COMPANION_BUBBLE_LIFETIME : BUBBLE_LIFETIME;
         const age = now - bubble.createdAt;
-        const fadeStart = BUBBLE_LIFETIME - FADE_DURATION;
+        const fadeStart = lifetime - FADE_DURATION;
         if (age > fadeStart) {
           el.style.opacity = String(1 - (age - fadeStart) / FADE_DURATION);
         } else {
@@ -129,34 +159,48 @@ export default function ChatBubble() {
 
   return (
     <div ref={containerRef} className="absolute inset-0 z-25 pointer-events-none overflow-hidden">
-      {bubbles.map((bubble) => (
-        <div
-          key={bubble.id}
-          ref={(el) => setBubbleRef(bubble.id, el)}
-          className="absolute -translate-x-1/2 -translate-y-full"
-          style={{ willChange: 'left, top, opacity' }}
-        >
-          <div className="relative max-w-[200px]">
-            <div
-              className="px-2 py-1.5 rounded-lg bg-[#0a0a1a]/95 border border-[#00f7ff]/20
-                          shadow-[0_0_6px_rgba(0,247,255,0.1)]"
-            >
-              <div className="text-[5px] text-[#00f7ff]/70 font-['Press_Start_2P'] mb-0.5 truncate">
-                {bubble.displayName}
+      {bubbles.map((bubble) => {
+        const isCompanion = bubble.variant === 'companion';
+        return (
+          <div
+            key={bubble.id}
+            ref={(el) => setBubbleRef(bubble.id, el)}
+            className="absolute -translate-x-1/2 -translate-y-full"
+            style={{ willChange: 'left, top, opacity' }}
+          >
+            <div className="relative max-w-[200px]">
+              <div
+                className={`px-2 py-1.5 rounded-lg bg-[#0a0a1a]/95 border ${
+                  isCompanion
+                    ? 'border-[#9966ff]/40 shadow-[0_0_8px_rgba(153,102,255,0.25)]'
+                    : 'border-[#00f7ff]/20 shadow-[0_0_6px_rgba(0,247,255,0.1)]'
+                }`}
+              >
+                <div
+                  className={`text-[5px] font-['Press_Start_2P'] mb-0.5 truncate ${
+                    isCompanion ? 'text-[#9966ff]/80' : 'text-[#00f7ff]/70'
+                  }`}
+                >
+                  {bubble.displayName}
+                </div>
+                <div
+                  className={`text-[6px] font-['Press_Start_2P'] break-words leading-relaxed ${
+                    isCompanion ? 'text-[#e8d8ff]' : 'text-white'
+                  }`}
+                >
+                  {bubble.text}
+                </div>
               </div>
-              <div className="text-[6px] text-white font-['Press_Start_2P'] break-words leading-relaxed">
-                {bubble.text}
-              </div>
+              <div
+                className="absolute left-1/2 -translate-x-1/2 -bottom-1 w-0 h-0
+                            border-l-[4px] border-l-transparent
+                            border-r-[4px] border-r-transparent
+                            border-t-[4px] border-t-[#0a0a1a]/95"
+              />
             </div>
-            <div
-              className="absolute left-1/2 -translate-x-1/2 -bottom-1 w-0 h-0
-                          border-l-[4px] border-l-transparent
-                          border-r-[4px] border-r-transparent
-                          border-t-[4px] border-t-[#0a0a1a]/95"
-            />
           </div>
-        </div>
-      ))}
+        );
+      })}
     </div>
   );
 }

--- a/components/sanctuary/overlays/CompanionChatOverlay.tsx
+++ b/components/sanctuary/overlays/CompanionChatOverlay.tsx
@@ -1,0 +1,366 @@
+'use client';
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import EventBus from '@/components/sanctuary/EventBus';
+import { worldToScreen, cameraState } from '@/game/systems/CameraState';
+import { getWalletAuthHeader } from '@/lib/clientWalletAuth';
+
+const MAX_LENGTH = 500;
+const PANEL_WIDTH = 240;
+const PANEL_OFFSET_Y = -110;
+const HISTORY_LIMIT = 6;
+const TYPING_MIN_MS = 800;
+const TYPING_MAX_MS = 4000;
+const TYPING_WPM = 45;
+
+type Role = 'user' | 'companion';
+
+interface ChatLine {
+  id: number;
+  role: Role;
+  text: string;
+}
+
+interface DailyLimit {
+  used: number;
+  limit: number;
+  remaining: number;
+}
+
+interface ChatApiMeta {
+  mode?: string;
+  dailyLimit?: DailyLimit;
+}
+
+interface ChatApiResponse {
+  success: boolean;
+  error?: string;
+  userMessage?: { id: number; content: string };
+  companionReply?: { id: number; content: string };
+  meta?: ChatApiMeta;
+}
+
+let lineIdCounter = 0;
+
+function computeTypingDelay(text: string): number {
+  const words = text.trim().split(/\s+/).filter(Boolean).length || 1;
+  const ms = (words / TYPING_WPM) * 60_000;
+  return Math.min(TYPING_MAX_MS, Math.max(TYPING_MIN_MS, ms));
+}
+
+export default function CompanionChatOverlay({
+  walletAddress,
+  tokenId,
+}: {
+  walletAddress: string | undefined;
+  tokenId: number | null;
+}) {
+  const [open, setOpen] = useState(false);
+  const [draft, setDraft] = useState('');
+  const [lines, setLines] = useState<ChatLine[]>([]);
+  const [sending, setSending] = useState(false);
+  const [typing, setTyping] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [dailyLimit, setDailyLimit] = useState<DailyLimit | null>(null);
+
+  const panelRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const rafRef = useRef<number>(0);
+  const typingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const close = useCallback(() => {
+    setOpen(false);
+    setError(null);
+  }, []);
+
+  const openChat = useCallback(() => {
+    if (!walletAddress || tokenId === null) return;
+    setOpen(true);
+    setError(null);
+  }, [walletAddress, tokenId]);
+
+  // Hotkey C and Talk action open the overlay
+  useEffect(() => {
+    const onTalk = () => openChat();
+    EventBus.on('companion-chat-open', onTalk);
+
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && open) {
+        e.preventDefault();
+        close();
+        return;
+      }
+      if (open) return;
+      const target = e.target as HTMLElement | null;
+      const tag = target?.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || target?.isContentEditable) return;
+      if ((e.key === 'c' || e.key === 'C') && !e.metaKey && !e.ctrlKey && !e.altKey) {
+        e.preventDefault();
+        openChat();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+
+    return () => {
+      EventBus.off('companion-chat-open', onTalk);
+      window.removeEventListener('keydown', onKey);
+    };
+  }, [openChat, close, open]);
+
+  // Auto-focus input when opened
+  useEffect(() => {
+    if (open) {
+      const t = setTimeout(() => inputRef.current?.focus(), 50);
+      return () => clearTimeout(t);
+    }
+  }, [open]);
+
+  // Click outside closes
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        close();
+      }
+    };
+    const t = setTimeout(() => document.addEventListener('mousedown', onDown), 50);
+    return () => {
+      clearTimeout(t);
+      document.removeEventListener('mousedown', onDown);
+    };
+  }, [open, close]);
+
+  // Scroll history to bottom on new lines
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [lines, typing]);
+
+  // Position the panel above the companion sprite
+  useEffect(() => {
+    if (!open) return;
+    const tick = () => {
+      const el = panelRef.current;
+      if (el) {
+        const screen = worldToScreen(cameraState.companionX, cameraState.companionY);
+        el.style.left = `${screen.x}px`;
+        el.style.top = `${screen.y + PANEL_OFFSET_Y}px`;
+      }
+      rafRef.current = requestAnimationFrame(tick);
+    };
+    rafRef.current = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(rafRef.current);
+  }, [open]);
+
+  // Cleanup typing timer on unmount
+  useEffect(() => {
+    return () => {
+      if (typingTimerRef.current) clearTimeout(typingTimerRef.current);
+    };
+  }, []);
+
+  const appendLine = useCallback((role: Role, text: string) => {
+    setLines((prev) => {
+      const next = [...prev, { id: ++lineIdCounter, role, text }];
+      return next.length > HISTORY_LIMIT ? next.slice(next.length - HISTORY_LIMIT) : next;
+    });
+  }, []);
+
+  const send = useCallback(async () => {
+    if (sending || typing) return;
+    const message = draft.trim();
+    if (!message) return;
+    if (!walletAddress || tokenId === null) return;
+
+    setSending(true);
+    setError(null);
+    appendLine('user', message);
+    setDraft('');
+
+    try {
+      const authHeader = await getWalletAuthHeader(walletAddress);
+      if (!authHeader) {
+        setError('Wallet auth required');
+        setSending(false);
+        return;
+      }
+
+      const res = await fetch('/api/sanctuary/companion/chat', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-wallet-auth': authHeader,
+        },
+        body: JSON.stringify({ address: walletAddress, token_id: tokenId, message }),
+      });
+
+      const data: ChatApiResponse = await res.json();
+      setSending(false);
+
+      if (!res.ok || !data.success) {
+        setError(data.error || 'Companion is quiet right now…');
+        return;
+      }
+
+      if (data.meta?.dailyLimit) setDailyLimit(data.meta.dailyLimit);
+
+      const replyText = data.companionReply?.content?.trim() || '…';
+      const delay = computeTypingDelay(replyText);
+      setTyping(true);
+
+      typingTimerRef.current = setTimeout(() => {
+        setTyping(false);
+        appendLine('companion', replyText);
+        EventBus.emit('companion-bubble', { text: replyText });
+      }, delay);
+    } catch (err) {
+      setSending(false);
+      setError(err instanceof Error ? err.message : 'Failed to send');
+    }
+  }, [draft, walletAddress, tokenId, sending, typing, appendLine]);
+
+  const onInputKey = useCallback(
+    (e: React.KeyboardEvent) => {
+      e.stopPropagation();
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        void send();
+      }
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        close();
+      }
+    },
+    [send, close],
+  );
+
+  if (!open) return null;
+
+  const remainingLabel = dailyLimit
+    ? `${dailyLimit.remaining}/${dailyLimit.limit}`
+    : null;
+
+  return (
+    <div className="absolute inset-0 z-30 pointer-events-none">
+      <div
+        ref={panelRef}
+        className="absolute pointer-events-auto -translate-x-1/2"
+        style={{
+          width: PANEL_WIDTH,
+          willChange: 'left, top',
+        }}
+      >
+        <div
+          className="relative rounded-lg bg-[#0a0a1a]/95 border border-[#9966ff]/50
+                     shadow-[0_0_12px_rgba(153,102,255,0.4)] overflow-hidden"
+        >
+          {/* Header */}
+          <div className="flex items-center justify-between px-2 py-1.5 border-b border-[#9966ff]/20 bg-[#1a0033]/60">
+            <span className="text-[7px] font-['Press_Start_2P'] text-[#9966ff] uppercase tracking-wider">
+              💬 Talk
+            </span>
+            <div className="flex items-center gap-2">
+              {remainingLabel && (
+                <span
+                  className="text-[6px] font-['Press_Start_2P'] text-[#ffd700]"
+                  title="Daily LLM chat remaining"
+                >
+                  {remainingLabel}
+                </span>
+              )}
+              <button
+                onClick={close}
+                aria-label="Close chat"
+                className="text-[8px] text-gray-400 hover:text-white leading-none"
+              >
+                ✕
+              </button>
+            </div>
+          </div>
+
+          {/* History */}
+          <div
+            ref={scrollRef}
+            className="max-h-32 overflow-y-auto px-2 py-1.5 space-y-1.5"
+          >
+            {lines.length === 0 && !typing && (
+              <div className="text-[6px] text-gray-500 font-['Press_Start_2P'] text-center py-1">
+                Say hello to your companion…
+              </div>
+            )}
+            {lines.map((line) => (
+              <div
+                key={line.id}
+                className={`flex ${line.role === 'user' ? 'justify-end' : 'justify-start'}`}
+              >
+                <div
+                  className={`max-w-[85%] px-1.5 py-1 rounded text-[6px] leading-relaxed font-['Press_Start_2P'] break-words ${
+                    line.role === 'user'
+                      ? 'bg-[#00f7ff]/15 border border-[#00f7ff]/30 text-white'
+                      : 'bg-[#9966ff]/15 border border-[#9966ff]/30 text-[#e8d8ff]'
+                  }`}
+                >
+                  {line.text}
+                </div>
+              </div>
+            ))}
+            {typing && (
+              <div className="flex justify-start">
+                <div
+                  className="px-2 py-1 rounded bg-[#9966ff]/15 border border-[#9966ff]/30 inline-flex items-center gap-1"
+                  aria-label="Companion is typing"
+                >
+                  <span className="sanctuary-typing-dot" />
+                  <span className="sanctuary-typing-dot" />
+                  <span className="sanctuary-typing-dot" />
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Error */}
+          {error && (
+            <div className="px-2 py-1 text-[6px] font-['Press_Start_2P'] text-[#ff6677] border-t border-[#ff6677]/20 bg-[#330011]/40">
+              {error}
+            </div>
+          )}
+
+          {/* Input */}
+          <div className="flex gap-1 px-2 py-1.5 border-t border-[#9966ff]/20 bg-[#0a0015]/60">
+            <input
+              ref={inputRef}
+              value={draft}
+              onChange={(e) => setDraft(e.target.value.slice(0, MAX_LENGTH))}
+              onKeyDown={onInputKey}
+              placeholder={typing ? 'Companion is typing…' : 'Press Enter to send'}
+              maxLength={MAX_LENGTH}
+              disabled={sending || typing}
+              className="flex-1 px-1.5 py-1 rounded bg-[#0a0a1a]/80 border border-[#9966ff]/30
+                         text-[7px] text-white font-['Press_Start_2P'] placeholder:text-gray-500
+                         outline-none focus:border-[#9966ff]/70 disabled:opacity-50"
+            />
+            <button
+              onClick={() => void send()}
+              disabled={!draft.trim() || sending || typing}
+              className="px-2 py-1 rounded bg-[#9966ff]/20 border border-[#9966ff]/40
+                         text-[#9966ff] text-[7px] font-['Press_Start_2P']
+                         hover:bg-[#9966ff]/30 transition-all disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              {sending ? '…' : 'Send'}
+            </button>
+          </div>
+        </div>
+
+        {/* Tail pointing down toward companion */}
+        <div
+          className="absolute left-1/2 -translate-x-1/2 -bottom-1 w-0 h-0
+                     border-l-[5px] border-l-transparent
+                     border-r-[5px] border-r-transparent
+                     border-t-[5px] border-t-[#9966ff]/50"
+        />
+      </div>
+    </div>
+  );
+}

--- a/components/sanctuary/overlays/CompanionMenu.tsx
+++ b/components/sanctuary/overlays/CompanionMenu.tsx
@@ -120,6 +120,12 @@ export default function CompanionMenu({
   const handleAction = useCallback(async (action: InteractAction) => {
     if (!walletAddress || tokenId === null || interacting) return;
 
+    if (action === 'talk') {
+      EventBus.emit('companion-chat-open');
+      closeMenu();
+      return;
+    }
+
     setInteracting(action);
     const pos = menuPos!;
 

--- a/game/scenes/WorldScene.ts
+++ b/game/scenes/WorldScene.ts
@@ -397,6 +397,8 @@ export class WorldScene extends Phaser.Scene {
     cameraState.zoom = cam.zoom;
     cameraState.localPlayerX = this.player.x;
     cameraState.localPlayerY = this.player.y;
+    cameraState.companionX = this.companion.x;
+    cameraState.companionY = this.companion.y;
     if (this.currentDoor && Phaser.Input.Keyboard.JustDown(this.interactKey)) {
       this.enterDoor(this.currentDoor);
     }

--- a/game/systems/CameraState.ts
+++ b/game/systems/CameraState.ts
@@ -4,6 +4,8 @@ export const cameraState = {
   zoom: 2,
   localPlayerX: 0,
   localPlayerY: 0,
+  companionX: 0,
+  companionY: 0,
 };
 
 export function worldToScreen(worldX: number, worldY: number): { x: number; y: number } {


### PR DESCRIPTION
## Summary
Convert sanctuary chat from a generic input bar into an in-world conversation. The **Talk** action in the companion radial menu (or pressing **C**) opens a compact chat panel anchored above the companion sprite. LLM replies appear inside the panel **and** as a fading speech bubble above the companion.

Implements `[SWO_V2_COMPANION_CHAT_OVERLAY]` (depends on the existing `[SWO_SANCTUARY_CHAT_LLM]` `/api/sanctuary/companion/chat` endpoint).

## Changes
- **New** `components/sanctuary/overlays/CompanionChatOverlay.tsx`
  - Mounts inside the Phaser canvas wrapper, auto-positions over the companion via RAF
  - Hotkey **C** opens it (ignored when typing in another input or modifier keys held); **Esc** closes
  - Posts to `/api/sanctuary/companion/chat` with the existing wallet auth header
  - Daily rate-limit display **X/15 remaining** sourced from `meta.dailyLimit` returned by the chat route
  - Typing simulation: word-count → delay at ~45 WPM, clamped 800–4000 ms; reuses existing `.sanctuary-typing-dot` CSS animation
  - On reply, emits `companion-bubble` so ChatBubble renders an in-world speech bubble
- **`game/systems/CameraState.ts`**: add `companionX/Y`
- **`game/scenes/WorldScene.ts`**: populate `companionX/Y` in `update()` for overlay/bubble positioning
- **`components/sanctuary/overlays/CompanionMenu.tsx`**: `talk` action now emits `companion-chat-open` and closes the menu (it previously routed through `/interact`)
- **`components/sanctuary/overlays/ChatBubble.tsx`**: add a `companion` bubble variant — virtual `__companion__` session, anchored at `cameraState.companionX/Y`, styled with the violet (#9966ff) palette to differentiate from player chat bubbles
- **`app/sanctuary/SanctuaryV2.tsx`**: dynamic-import and mount the overlay alongside the existing chat components

## Validations (workspace)
- `npm run type-check`: PASS (0 errors)
- `npm run lint`: no new errors in changed files (project has 205 pre-existing problems unchanged)
- `npm run test`: 342 passed, 4 pre-existing failures in `lib/sanctuary/__tests__/api-e2e.test.ts` (unrelated — assertion text drift on `/interact` zod error format)
- `npm run build`: PASS

## Mirror Validation (PROD)
- **Baseline (PROD before overlay)**: `tsc --noEmit` PASS (0 errors), `vitest run` 208 passed / 5 pre-existing failures
- **After overlay**: tsc surfaces ~77 errors and additional vitest deltas — **all caused by PROD not yet having the Sanctuary V2 stack deployed** (no `phaser` / `colyseus` deps, missing `components/sanctuary/EventBus`, `PhaserGame`, the dozen sibling overlays, `lib/colyseus/types`, etc.). None of the new errors are caused by the chat overlay code itself; they are pre-existing PROD gaps that exist for any V2 file overlaid into the mirror.
- Overall: PASS (workspace) / N/A (PROD lacks V2 substrate)

Mirror restored byte-identical (no leftover files or directories).

## Test plan
- [ ] Open `/sanctuary`, click companion → radial menu → **Talk** opens the chat panel above the companion
- [ ] Press **C** anywhere on the page (with no input focused) → opens the panel
- [ ] Press **Esc** or click outside → closes
- [ ] Send a message → typing dots appear, reply appears in panel + as a violet bubble above companion
- [ ] Daily limit pill **X/15** updates after each LLM reply
- [ ] Hotkey **C** does NOT trigger when typing in the global ChatInput

🤖 Generated with [Claude Code](https://claude.com/claude-code)