### PR TITLE
feat(sanctuary): STAR currency storage + earn/spend/balance API

### DIFF
--- a/app/api/sanctuary/star/balance/route.ts
+++ b/app/api/sanctuary/star/balance/route.ts
@@ -1,0 +1,36 @@
+/**
+ * GET /api/sanctuary/star/balance?wallet=0x...
+ *
+ * Returns the wallet's current STAR balance and lifetime earned. Public read
+ * — anyone can query any wallet's balance (it's already on a public ledger).
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getStarBalance } from '@/lib/db';
+import { ethAddress, parseSearchParams, formatZodError } from '@/lib/sanctuary/validation';
+
+const querySchema = z.object({
+  wallet: ethAddress,
+});
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const parsed = parseSearchParams(querySchema, searchParams);
+    if (!parsed.success) {
+      return NextResponse.json({ success: false, error: formatZodError(parsed.error) }, { status: 400 });
+    }
+    const { wallet } = parsed.data;
+    const row = getStarBalance(wallet);
+    return NextResponse.json({
+      success: true,
+      wallet: row.wallet_address,
+      balance: row.balance,
+      lifetime_earned: row.lifetime_earned,
+      updated_at: row.updated_at,
+    });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : 'Failed to get STAR balance';
+    return NextResponse.json({ success: false, error: msg }, { status: 500 });
+  }
+}

--- a/app/api/sanctuary/star/earn/route.ts
+++ b/app/api/sanctuary/star/earn/route.ts
@@ -1,0 +1,63 @@
+/**
+ * POST /api/sanctuary/star/earn
+ *
+ * Internal-only endpoint that credits STAR to a wallet. Called by quest /
+ * activity / minigame completion handlers (server-side). NOT public — requires
+ * a Bearer token matching `STAR_INTERNAL_SECRET` (or CRON_SECRET as fallback)
+ * so that no client can mint STAR by hitting this URL directly.
+ *
+ * Body: { address, source, amount, detail? }
+ *   source: 'quest' | 'minigame_first' | 'daily_login' | 'activity' | 'levelup'
+ *   amount is clamped into the per-source [min, max] band defined in
+ *   STAR_EARN_RATES.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { earnStar, type StarEarnSource } from '@/lib/db';
+import { ethAddress, parseBody, formatZodError } from '@/lib/sanctuary/validation';
+import { logger } from '@/lib/logger';
+
+const bodySchema = z.object({
+  address: ethAddress,
+  source: z.enum(['quest', 'minigame_first', 'daily_login', 'activity', 'levelup']),
+  amount: z.coerce.number().int().min(1),
+  detail: z.string().max(64).optional(),
+});
+
+function validateInternalSecret(request: Request): { valid: boolean; error?: string } {
+  if (process.env.NODE_ENV === 'development' && !process.env.STAR_INTERNAL_SECRET) {
+    return { valid: true };
+  }
+  const secret = process.env.STAR_INTERNAL_SECRET ?? process.env.CRON_SECRET;
+  if (!secret) {
+    logger.error('star/earn: STAR_INTERNAL_SECRET / CRON_SECRET not configured');
+    return { valid: false, error: 'Internal secret not configured' };
+  }
+  const header = request.headers.get('Authorization');
+  if (!header) return { valid: false, error: 'Missing Authorization header' };
+  const token = header.startsWith('Bearer ') ? header.slice(7) : header;
+  if (token !== secret) return { valid: false, error: 'Invalid internal token' };
+  return { valid: true };
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const auth = validateInternalSecret(request);
+    if (!auth.valid) {
+      return NextResponse.json({ success: false, error: auth.error }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const parsed = parseBody(bodySchema, body);
+    if (!parsed.success) {
+      return NextResponse.json({ success: false, error: formatZodError(parsed.error) }, { status: 400 });
+    }
+
+    const { address, source, amount, detail } = parsed.data;
+    const result = earnStar(address, source as StarEarnSource, amount, detail);
+    return NextResponse.json({ success: true, ...result });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : 'Failed to earn STAR';
+    return NextResponse.json({ success: false, error: msg }, { status: 500 });
+  }
+}

--- a/app/api/sanctuary/star/spend/route.ts
+++ b/app/api/sanctuary/star/spend/route.ts
@@ -1,0 +1,45 @@
+/**
+ * POST /api/sanctuary/star/spend
+ *
+ * Spend STAR from a wallet's balance. Called by the Shop buy flow once the
+ * shop validates the item. Wallet-authenticated so the holder must consent
+ * to the deduction. Returns 402 (Payment Required) when balance < cost.
+ *
+ * Body: { address, amount, source }
+ *   source: short tag like `shop:hat_acorn` for ledger / analytics.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { spendStar } from '@/lib/db';
+import { verifyWalletAccess } from '@/lib/walletAuth';
+import { ethAddress, parseBody, formatZodError } from '@/lib/sanctuary/validation';
+
+const bodySchema = z.object({
+  address: ethAddress,
+  amount: z.coerce.number().int().min(1).max(1_000_000),
+  source: z.string().min(1).max(64),
+});
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const parsed = parseBody(bodySchema, body);
+    if (!parsed.success) {
+      return NextResponse.json({ success: false, error: formatZodError(parsed.error) }, { status: 400 });
+    }
+
+    const { address, amount, source } = parsed.data;
+
+    const auth = await verifyWalletAccess(request, address);
+    if (!auth.valid) {
+      return NextResponse.json({ success: false, error: auth.error }, { status: 401 });
+    }
+
+    const result = spendStar(address, amount, source);
+    return NextResponse.json({ success: true, ...result });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : 'Failed to spend STAR';
+    const status = msg.includes('Insufficient') ? 402 : 500;
+    return NextResponse.json({ success: false, error: msg }, { status });
+  }
+}

--- a/components/sanctuary/overlays/CompanionHUD.tsx
+++ b/components/sanctuary/overlays/CompanionHUD.tsx
@@ -75,12 +75,27 @@ function isOnQuest(activity: string | null | undefined, endsAt: string | null | 
 
 export default function CompanionHUD({ walletAddress }: CompanionHUDProps) {
   const [companion, setCompanion] = useState<CompanionData | null>(null);
+  const [starBalance, setStarBalance] = useState<number | null>(null);
   const [locationName, setLocationName] = useState<string | null>(null);
   const [locationVisible, setLocationVisible] = useState(false);
   const [tick, setTick] = useState(0);
   const [claiming, setClaiming] = useState(false);
   const [claimFeedback, setClaimFeedback] = useState<string | null>(null);
   const prevAwayRef = useRef<boolean>(false);
+
+  const fetchStarBalance = useCallback(async () => {
+    if (!walletAddress) return;
+    try {
+      const res = await fetch(`/api/sanctuary/star/balance?wallet=${walletAddress}`);
+      if (!res.ok) return;
+      const data = await res.json();
+      if (data.success) {
+        setStarBalance(data.balance ?? 0);
+      }
+    } catch {
+      // HUD is non-critical
+    }
+  }, [walletAddress]);
 
   const fetchCompanion = useCallback(async () => {
     if (!walletAddress) return;
@@ -110,18 +125,25 @@ export default function CompanionHUD({ walletAddress }: CompanionHUDProps) {
   useEffect(() => {
     if (!walletAddress) return;
     fetchCompanion();
-  }, [walletAddress, fetchCompanion]);
+    fetchStarBalance();
+  }, [walletAddress, fetchCompanion, fetchStarBalance]);
 
   useEffect(() => {
     const onQuestStarted = () => fetchCompanion();
-    const onQuestClaimed = () => fetchCompanion();
+    const onQuestClaimed = () => {
+      fetchCompanion();
+      fetchStarBalance();
+    };
+    const onStarChanged = () => fetchStarBalance();
     EventBus.on('companion-quest-started', onQuestStarted);
     EventBus.on('companion-quest-claimed', onQuestClaimed);
+    EventBus.on('star-balance-changed', onStarChanged);
     return () => {
       EventBus.off('companion-quest-started', onQuestStarted);
       EventBus.off('companion-quest-claimed', onQuestClaimed);
+      EventBus.off('star-balance-changed', onStarChanged);
     };
-  }, [fetchCompanion]);
+  }, [fetchCompanion, fetchStarBalance]);
 
   const onQuest = isOnQuest(companion?.current_activity, companion?.activity_ends_at);
 
@@ -230,6 +252,20 @@ export default function CompanionHUD({ walletAddress }: CompanionHUDProps) {
 
   return (
     <>
+      {/* STAR currency badge */}
+      {starBalance !== null && (
+        <div
+          className="absolute top-2 right-2 z-20 flex items-center gap-1.5 bg-black/80 border border-[#ffd700]/50 rounded px-2.5 py-1 pointer-events-none select-none shadow-[0_0_8px_rgba(255,215,0,0.2)]"
+          aria-label={`STAR balance: ${starBalance}`}
+          title={`STAR balance: ${starBalance.toLocaleString()}`}
+        >
+          <span className="text-[10px] leading-none">⭐</span>
+          <span className="text-[8px] text-[#ffd700] font-['Press_Start_2P'] tabular-nums">
+            {starBalance.toLocaleString()}
+          </span>
+        </div>
+      )}
+
       {/* Companion status bar */}
       <div className="absolute top-2 left-2 z-20 flex items-center gap-2 bg-black/80 border border-[#2a2a4e] rounded px-3 py-1.5 pointer-events-none select-none">
         <span className="text-base leading-none">{moodEmoji}</span>

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -5799,6 +5799,11 @@ function initializeSanctuary(database: Database.Database): void {
     const sql = fs.readFileSync(v20Path, 'utf-8');
     database.exec(sql);
   }
+  const v21Path = path.join(process.cwd(), 'scripts', 'init-sanctuary-v2.1.sql');
+  if (fs.existsSync(v21Path)) {
+    const sql = fs.readFileSync(v21Path, 'utf-8');
+    database.exec(sql);
+  }
   // V1.7: per-companion XP/level columns (Training Grounds). ALTER TABLE IF NOT
   // EXISTS is not portable across SQLite versions, so wrap in try/catch.
   try { database.exec('ALTER TABLE sanctuary_companions ADD COLUMN xp INTEGER NOT NULL DEFAULT 0'); }
@@ -7518,4 +7523,153 @@ export function completeActivityV15(
   }
 
   return result;
+}
+
+// ---------------------------------------------------------------------------
+// STAR currency (V2.1) — see docs/STAR_SANCTUARY_PLAN.md
+// ---------------------------------------------------------------------------
+
+export interface SanctuaryStarBalance {
+  wallet_address: string;
+  balance: number;
+  lifetime_earned: number;
+  updated_at: string;
+}
+
+export interface SanctuaryStarLedgerEntry {
+  id: number;
+  wallet_address: string;
+  delta: number;
+  kind: 'earn' | 'spend';
+  source: string;
+  balance_after: number;
+  created_at: string;
+}
+
+export type StarEarnSource =
+  | 'quest'
+  | 'minigame_first'
+  | 'daily_login'
+  | 'activity'
+  | 'levelup';
+
+// Earn-rate guardrails. Earn endpoint clamps the requested amount into the
+// `[min, max]` band for its source so a single misbehaving caller cannot
+// accidentally mint a million STAR. See task spec [SWO_V2_STAR_CURRENCY].
+export const STAR_EARN_RATES: Record<StarEarnSource, { min: number; max: number }> = {
+  quest: { min: 10, max: 50 },
+  minigame_first: { min: 25, max: 25 },
+  daily_login: { min: 5, max: 5 },
+  activity: { min: 5, max: 20 },
+  levelup: { min: 50, max: 50 },
+};
+
+export function getStarBalance(walletAddress: string): SanctuaryStarBalance {
+  const db = getDatabase();
+  const addr = walletAddress.toLowerCase();
+  const row = db.prepare(
+    'SELECT * FROM sanctuary_star_balance WHERE wallet_address = ?'
+  ).get(addr) as SanctuaryStarBalance | undefined;
+  if (row) return row;
+  return {
+    wallet_address: addr,
+    balance: 0,
+    lifetime_earned: 0,
+    updated_at: new Date().toISOString(),
+  };
+}
+
+export function earnStar(
+  walletAddress: string,
+  source: StarEarnSource,
+  amount: number,
+  detail?: string,
+): { balance: number; lifetime_earned: number; gained: number } {
+  if (!Number.isFinite(amount) || amount <= 0) {
+    throw new Error('STAR earn amount must be positive');
+  }
+  const rates = STAR_EARN_RATES[source];
+  if (!rates) throw new Error(`Unknown STAR earn source: ${source}`);
+  const clamped = Math.max(rates.min, Math.min(rates.max, Math.floor(amount)));
+
+  const db = getDatabase();
+  const addr = walletAddress.toLowerCase();
+  const sourceTag = detail ? `${source}:${detail}` : source;
+
+  const txn = db.transaction(() => {
+    const existing = db.prepare(
+      'SELECT balance, lifetime_earned FROM sanctuary_star_balance WHERE wallet_address = ?'
+    ).get(addr) as { balance: number; lifetime_earned: number } | undefined;
+
+    const newBalance = (existing?.balance ?? 0) + clamped;
+    const newLifetime = (existing?.lifetime_earned ?? 0) + clamped;
+
+    if (existing) {
+      db.prepare(
+        'UPDATE sanctuary_star_balance SET balance = ?, lifetime_earned = ?, updated_at = CURRENT_TIMESTAMP WHERE wallet_address = ?'
+      ).run(newBalance, newLifetime, addr);
+    } else {
+      db.prepare(
+        'INSERT INTO sanctuary_star_balance (wallet_address, balance, lifetime_earned) VALUES (?, ?, ?)'
+      ).run(addr, newBalance, newLifetime);
+    }
+
+    db.prepare(
+      'INSERT INTO sanctuary_star_ledger (wallet_address, delta, kind, source, balance_after) VALUES (?, ?, ?, ?, ?)'
+    ).run(addr, clamped, 'earn', sourceTag, newBalance);
+
+    return { balance: newBalance, lifetime_earned: newLifetime, gained: clamped };
+  });
+
+  return txn();
+}
+
+export function spendStar(
+  walletAddress: string,
+  amount: number,
+  source: string,
+): { balance: number; lifetime_earned: number; spent: number } {
+  if (!Number.isFinite(amount) || amount <= 0) {
+    throw new Error('STAR spend amount must be positive');
+  }
+  const cost = Math.floor(amount);
+
+  const db = getDatabase();
+  const addr = walletAddress.toLowerCase();
+
+  const txn = db.transaction(() => {
+    const existing = db.prepare(
+      'SELECT balance, lifetime_earned FROM sanctuary_star_balance WHERE wallet_address = ?'
+    ).get(addr) as { balance: number; lifetime_earned: number } | undefined;
+
+    const currentBalance = existing?.balance ?? 0;
+    if (currentBalance < cost) {
+      throw new Error('Insufficient STAR balance');
+    }
+    const newBalance = currentBalance - cost;
+    const lifetime = existing?.lifetime_earned ?? 0;
+
+    db.prepare(
+      'UPDATE sanctuary_star_balance SET balance = ?, updated_at = CURRENT_TIMESTAMP WHERE wallet_address = ?'
+    ).run(newBalance, addr);
+
+    db.prepare(
+      'INSERT INTO sanctuary_star_ledger (wallet_address, delta, kind, source, balance_after) VALUES (?, ?, ?, ?, ?)'
+    ).run(addr, -cost, 'spend', source, newBalance);
+
+    return { balance: newBalance, lifetime_earned: lifetime, spent: cost };
+  });
+
+  return txn();
+}
+
+export function getStarLedger(
+  walletAddress: string,
+  limit: number = 50,
+): SanctuaryStarLedgerEntry[] {
+  const db = getDatabase();
+  const addr = walletAddress.toLowerCase();
+  return db.prepare(
+    'SELECT * FROM sanctuary_star_ledger WHERE wallet_address = ? ORDER BY created_at DESC, id DESC LIMIT ?'
+  ).all(addr, Math.max(1, Math.min(500, Math.floor(limit)))) as SanctuaryStarLedgerEntry[];
 }

--- a/lib/sanctuary/__tests__/starCurrency.test.ts
+++ b/lib/sanctuary/__tests__/starCurrency.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import fs from 'fs';
+import path from 'path';
+
+// We test the SQL/logic for STAR currency by replicating the helpers'
+// transactions against an in-memory DB. This mirrors the pattern used by
+// `sanctuary.test.ts` and avoids reaching into the singleton `getDatabase()`.
+
+const ALICE = '0x' + 'a'.repeat(40);
+const BOB = '0x' + 'b'.repeat(40);
+
+function createStarDb(): Database.Database {
+  const db = new Database(':memory:');
+  db.pragma('journal_mode = WAL');
+  db.pragma('foreign_keys = ON');
+  const sqlPath = path.join(process.cwd(), 'scripts', 'init-sanctuary-v2.1.sql');
+  db.exec(fs.readFileSync(sqlPath, 'utf-8'));
+  return db;
+}
+
+interface BalanceRow { balance: number; lifetime_earned: number }
+interface LedgerRow { id: number; delta: number; kind: string; source: string; balance_after: number }
+
+function earn(db: Database.Database, addr: string, amount: number, source: string) {
+  return db.transaction(() => {
+    const existing = db.prepare(
+      'SELECT balance, lifetime_earned FROM sanctuary_star_balance WHERE wallet_address = ?'
+    ).get(addr) as BalanceRow | undefined;
+    const newBalance = (existing?.balance ?? 0) + amount;
+    const newLifetime = (existing?.lifetime_earned ?? 0) + amount;
+    if (existing) {
+      db.prepare(
+        'UPDATE sanctuary_star_balance SET balance = ?, lifetime_earned = ?, updated_at = CURRENT_TIMESTAMP WHERE wallet_address = ?'
+      ).run(newBalance, newLifetime, addr);
+    } else {
+      db.prepare(
+        'INSERT INTO sanctuary_star_balance (wallet_address, balance, lifetime_earned) VALUES (?, ?, ?)'
+      ).run(addr, newBalance, newLifetime);
+    }
+    db.prepare(
+      'INSERT INTO sanctuary_star_ledger (wallet_address, delta, kind, source, balance_after) VALUES (?, ?, ?, ?, ?)'
+    ).run(addr, amount, 'earn', source, newBalance);
+    return { balance: newBalance, lifetime_earned: newLifetime };
+  })();
+}
+
+function spend(db: Database.Database, addr: string, amount: number, source: string) {
+  return db.transaction(() => {
+    const existing = db.prepare(
+      'SELECT balance, lifetime_earned FROM sanctuary_star_balance WHERE wallet_address = ?'
+    ).get(addr) as BalanceRow | undefined;
+    const cur = existing?.balance ?? 0;
+    if (cur < amount) throw new Error('Insufficient STAR balance');
+    const newBalance = cur - amount;
+    db.prepare(
+      'UPDATE sanctuary_star_balance SET balance = ?, updated_at = CURRENT_TIMESTAMP WHERE wallet_address = ?'
+    ).run(newBalance, addr);
+    db.prepare(
+      'INSERT INTO sanctuary_star_ledger (wallet_address, delta, kind, source, balance_after) VALUES (?, ?, ?, ?, ?)'
+    ).run(addr, -amount, 'spend', source, newBalance);
+    return { balance: newBalance, lifetime_earned: existing?.lifetime_earned ?? 0 };
+  })();
+}
+
+describe('STAR currency schema', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createStarDb();
+  });
+
+  it('creates the balance table with expected columns and PK', () => {
+    const cols = db.prepare(`PRAGMA table_info(sanctuary_star_balance)`).all() as Array<{ name: string; pk: number }>;
+    const names = cols.map((c) => c.name).sort();
+    expect(names).toEqual(['balance', 'lifetime_earned', 'updated_at', 'wallet_address']);
+    const pk = cols.find((c) => c.pk === 1);
+    expect(pk?.name).toBe('wallet_address');
+  });
+
+  it('creates the ledger table with kind constraint', () => {
+    expect(() => {
+      db.prepare(
+        'INSERT INTO sanctuary_star_ledger (wallet_address, delta, kind, source, balance_after) VALUES (?, ?, ?, ?, ?)'
+      ).run(ALICE, 10, 'invalid_kind', 'test', 10);
+    }).toThrow();
+  });
+
+  it('returns zero for a wallet with no balance row', () => {
+    const row = db.prepare('SELECT * FROM sanctuary_star_balance WHERE wallet_address = ?').get(ALICE);
+    expect(row).toBeUndefined();
+  });
+});
+
+describe('STAR earn flow', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createStarDb();
+  });
+
+  it('credits balance and lifetime_earned, writes a ledger entry', () => {
+    const result = earn(db, ALICE, 25, 'quest:1');
+    expect(result.balance).toBe(25);
+    expect(result.lifetime_earned).toBe(25);
+
+    const ledger = db.prepare('SELECT * FROM sanctuary_star_ledger WHERE wallet_address = ?').all(ALICE) as LedgerRow[];
+    expect(ledger.length).toBe(1);
+    expect(ledger[0].kind).toBe('earn');
+    expect(ledger[0].delta).toBe(25);
+    expect(ledger[0].balance_after).toBe(25);
+    expect(ledger[0].source).toBe('quest:1');
+  });
+
+  it('accumulates multiple earns', () => {
+    earn(db, ALICE, 10, 'daily_login');
+    earn(db, ALICE, 25, 'minigame_first:dodge');
+    const r = earn(db, ALICE, 50, 'levelup');
+    expect(r.balance).toBe(85);
+    expect(r.lifetime_earned).toBe(85);
+
+    const count = (db.prepare('SELECT COUNT(*) as c FROM sanctuary_star_ledger WHERE wallet_address = ?').get(ALICE) as { c: number }).c;
+    expect(count).toBe(3);
+  });
+
+  it('isolates wallets', () => {
+    earn(db, ALICE, 30, 'quest:2');
+    earn(db, BOB, 5, 'daily_login');
+    const aliceBal = (db.prepare('SELECT balance FROM sanctuary_star_balance WHERE wallet_address = ?').get(ALICE) as BalanceRow).balance;
+    const bobBal = (db.prepare('SELECT balance FROM sanctuary_star_balance WHERE wallet_address = ?').get(BOB) as BalanceRow).balance;
+    expect(aliceBal).toBe(30);
+    expect(bobBal).toBe(5);
+  });
+});
+
+describe('STAR spend flow', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createStarDb();
+    earn(db, ALICE, 50, 'quest:3');
+  });
+
+  it('deducts from balance but leaves lifetime_earned untouched', () => {
+    const r = spend(db, ALICE, 20, 'shop:hat_acorn');
+    expect(r.balance).toBe(30);
+    expect(r.lifetime_earned).toBe(50);
+  });
+
+  it('rejects spend that exceeds balance and leaves balance unchanged', () => {
+    expect(() => spend(db, ALICE, 100, 'shop:bg_galaxy')).toThrow(/Insufficient/);
+    const bal = (db.prepare('SELECT balance, lifetime_earned FROM sanctuary_star_balance WHERE wallet_address = ?').get(ALICE) as BalanceRow);
+    expect(bal.balance).toBe(50);
+    expect(bal.lifetime_earned).toBe(50);
+  });
+
+  it('writes a negative-delta spend entry to the ledger', () => {
+    spend(db, ALICE, 15, 'shop:accessory_scarf');
+    const ledger = db.prepare(
+      "SELECT * FROM sanctuary_star_ledger WHERE wallet_address = ? AND kind = 'spend'"
+    ).all(ALICE) as LedgerRow[];
+    expect(ledger.length).toBe(1);
+    expect(ledger[0].delta).toBe(-15);
+    expect(ledger[0].balance_after).toBe(35);
+    expect(ledger[0].source).toBe('shop:accessory_scarf');
+  });
+});
+
+describe('STAR earn-rate guardrails (constants)', () => {
+  it('exports the documented earn rate ranges', async () => {
+    const { STAR_EARN_RATES } = await import('@/lib/db');
+    expect(STAR_EARN_RATES.quest).toEqual({ min: 10, max: 50 });
+    expect(STAR_EARN_RATES.minigame_first).toEqual({ min: 25, max: 25 });
+    expect(STAR_EARN_RATES.daily_login).toEqual({ min: 5, max: 5 });
+    expect(STAR_EARN_RATES.activity).toEqual({ min: 5, max: 20 });
+    expect(STAR_EARN_RATES.levelup).toEqual({ min: 50, max: 50 });
+  });
+});

--- a/scripts/init-sanctuary-v2.1.sql
+++ b/scripts/init-sanctuary-v2.1.sql
@@ -1,0 +1,42 @@
+-- Star Sanctuary — V2.1 Schema: STAR currency storage
+-- Run from lib/db.ts initializeSanctuary()
+--
+-- STAR is the in-Sanctuary soft currency awarded for quest completion,
+-- minigame first-plays, daily login, activity completion, and level-ups.
+-- It is spent in the cosmetic Shop (see [SWO_V2_SHOP_BACKEND]).
+--
+-- Notes
+--  • One row per wallet (PRIMARY KEY) — STAR is wallet-scoped, not per-companion.
+--  • `lifetime_earned` is monotonic (never decremented on spend) for analytics
+--    and future achievement gating.
+--  • Earn endpoint is server-internal only (called by quest/activity/minigame
+--    completion handlers). Spend is invoked by the Shop buy endpoint.
+
+CREATE TABLE IF NOT EXISTS sanctuary_star_balance (
+  wallet_address TEXT PRIMARY KEY,
+  balance INTEGER NOT NULL DEFAULT 0,
+  lifetime_earned INTEGER NOT NULL DEFAULT 0,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_sanctuary_star_balance_lifetime
+  ON sanctuary_star_balance(lifetime_earned DESC);
+
+-- Audit log of every earn/spend event for debugging, anti-fraud, and analytics.
+-- Earn `source` examples: quest:<id>, minigame:<name>:first, login:daily,
+-- activity:<name>, levelup:<level>. Spend `source`: shop:<item_id>.
+CREATE TABLE IF NOT EXISTS sanctuary_star_ledger (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  wallet_address TEXT NOT NULL,
+  delta INTEGER NOT NULL,
+  kind TEXT NOT NULL CHECK (kind IN ('earn', 'spend')),
+  source TEXT NOT NULL,
+  balance_after INTEGER NOT NULL,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_sanctuary_star_ledger_wallet
+  ON sanctuary_star_ledger(wallet_address, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_sanctuary_star_ledger_source
+  ON sanctuary_star_ledger(source, created_at DESC);


### PR DESCRIPTION
## Summary

Foundation for the Sanctuary cosmetic shop economy ([SWO_V2_STAR_CURRENCY]). STAR is the in-Sanctuary soft currency awarded for quest / activity / minigame / login / level-up events and spent in the upcoming cosmetic Shop.

- New \`sanctuary_star_balance\` table (\`wallet_address PK, balance, lifetime_earned, updated_at\`)
- New \`sanctuary_star_ledger\` audit table for every earn/spend event
- DB helpers in \`lib/db.ts\`: \`getStarBalance\`, \`earnStar\` (amount clamped into per-source band), \`spendStar\` (throws on insufficient balance), \`getStarLedger\`
- \`POST /api/sanctuary/star/earn\` — server-internal only, Bearer-auth against \`STAR_INTERNAL_SECRET\` (falls back to \`CRON_SECRET\`); never callable by browser clients
- \`POST /api/sanctuary/star/spend\` — wallet-authed (holder must consent); returns **402 Payment Required** when balance < cost
- \`GET /api/sanctuary/star/balance?wallet=0x…\` — public read
- \`CompanionHUD\`: ⭐ STAR badge in the top-right, refreshes on quest claim and on a new \`star-balance-changed\` EventBus event for shop integrations
- Earn rates per spec: quest 10-50, minigame_first 25, daily_login 5, activity 5-20, levelup 50

Prerequisite for [SWO_V2_SHOP_BACKEND].

## Test plan

- [x] Unit tests: 10 new tests in \`lib/sanctuary/__tests__/starCurrency.test.ts\` cover schema, earn accumulation, wallet isolation, spend semantics, insufficient-balance rejection, ledger entries, and earn-rate constants — all pass
- [x] Pre-existing sanctuary suite: 241/245 still passing (4 failures are pre-existing on \`api-e2e\`, unrelated to this change)
- [x] \`tsc --noEmit\` clean
- [x] \`eslint\` clean on touched files
- [x] \`next build\` succeeds; all 3 routes appear in the compiled route table
- [ ] Smoke-test against staging once deployed: \`curl -X POST /api/sanctuary/star/earn\` (with secret), \`/balance\`, \`/spend\`
- [ ] Verify HUD badge renders and updates after a quest claim

🤖 Generated with [Claude Code](https://claude.com/claude-code)