### PR TITLE
feat(sanctuary): layered cosmetic rendering for companion sprite

### DIFF
--- a/app/sanctuary/SanctuaryContent.tsx
+++ b/app/sanctuary/SanctuaryContent.tsx
@@ -26,6 +26,7 @@ interface Companion {
   image_url: string | null;
   rarity_rank: number | null;
   attributes_json: string | null;
+  equipped_cosmetics: string | null;
   total_xp: number;
   level: number;
 }

--- a/components/sanctuary/overlays/CompanionHUD.tsx
+++ b/components/sanctuary/overlays/CompanionHUD.tsx
@@ -15,6 +15,7 @@ interface CompanionData {
   companion_level: number;
   current_activity: string;
   activity_ends_at: string | null;
+  equipped_cosmetics: string | null;
 }
 
 interface CompanionHUDProps {
@@ -89,6 +90,7 @@ export default function CompanionHUD({ walletAddress }: CompanionHUDProps) {
       if (!res.ok) return;
       const data = await res.json();
       if (data.companion) {
+        const equipped = data.companion.equipped_cosmetics ?? null;
         setCompanion({
           nickname: data.companion.nickname,
           token_id: data.companion.token_id,
@@ -100,7 +102,10 @@ export default function CompanionHUD({ walletAddress }: CompanionHUDProps) {
           companion_level: data.companion.companion_level ?? data.companion.level ?? 1,
           current_activity: data.companion.current_activity ?? 'lounging',
           activity_ends_at: data.companion.activity_ends_at ?? null,
+          equipped_cosmetics: equipped,
         });
+        // Push the loadout into the Phaser scene so cosmetic layers render.
+        EventBus.emit('companion-cosmetics', equipped);
       }
     } catch {
       // HUD is non-critical

--- a/game/__tests__/cosmeticSystem.test.ts
+++ b/game/__tests__/cosmeticSystem.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import fs from 'node:fs';
+import {
+  CosmeticSystem,
+  COSMETIC_SLOTS,
+  DEFAULT_SLOT_OFFSETS,
+  SLOT_DEPTH_DELTA,
+  type CosmeticSheetConfig,
+} from '../systems/CosmeticSystem';
+
+// Minimal Phaser.Scene stub. CosmeticSystem only touches `textures.exists`,
+// `load.spritesheet`, and stores the reference; the data-flow logic is fully
+// testable without booting Phaser.
+function makeScene() {
+  const existing = new Set<string>();
+  const loadCalls: { key: string; path: string; frameWidth: number; frameHeight: number }[] = [];
+  return {
+    scene: {
+      textures: { exists: (key: string) => existing.has(key) },
+      load: {
+        spritesheet: vi.fn((key: string, path: string, cfg: { frameWidth: number; frameHeight: number }) => {
+          loadCalls.push({ key, path, ...cfg });
+        }),
+      },
+    } as unknown as import('phaser').Scene,
+    existing,
+    loadCalls,
+  };
+}
+
+const HAT_CFG: CosmeticSheetConfig = {
+  cosmeticId: 'witch_hat',
+  slot: 'hat',
+  path: '/sanctuary/cosmetics/witch_hat.png',
+  frameWidth: 16,
+  frameHeight: 16,
+};
+
+const ACCESSORY_CFG: CosmeticSheetConfig = {
+  cosmeticId: 'star_pendant',
+  slot: 'accessory',
+  path: '/sanctuary/cosmetics/star_pendant.png',
+  frameWidth: 16,
+  frameHeight: 16,
+  offsetY: 4,
+};
+
+describe('CosmeticSystem — slot taxonomy', () => {
+  it('declares hat and accessory slots', () => {
+    expect(COSMETIC_SLOTS).toEqual(['hat', 'accessory']);
+  });
+
+  it('layers hats above accessories (greater depth delta)', () => {
+    expect(SLOT_DEPTH_DELTA.hat).toBeGreaterThan(SLOT_DEPTH_DELTA.accessory);
+  });
+
+  it('hat has a default upward offset so it sits above the head', () => {
+    expect(DEFAULT_SLOT_OFFSETS.hat.y).toBeLessThan(0);
+  });
+});
+
+describe('CosmeticSystem — equip / unequip', () => {
+  let cs: CosmeticSystem;
+  let helpers: ReturnType<typeof makeScene>;
+
+  beforeEach(() => {
+    helpers = makeScene();
+    cs = new CosmeticSystem(helpers.scene);
+    cs.registerCosmetic(HAT_CFG);
+    cs.registerCosmetic(ACCESSORY_CFG);
+  });
+
+  it('starts with no equipment', () => {
+    expect(cs.getEquipped()).toEqual({ hat: null, accessory: null });
+  });
+
+  it('equips a registered cosmetic and reports the change', () => {
+    const change = cs.equip('hat', 'witch_hat');
+    expect(change).toEqual({ slot: 'hat', previousId: null, cosmeticId: 'witch_hat' });
+    expect(cs.getEquippedSlot('hat')).toBe('witch_hat');
+  });
+
+  it('returns null when equipping the same cosmetic twice (idempotent)', () => {
+    cs.equip('hat', 'witch_hat');
+    expect(cs.equip('hat', 'witch_hat')).toBeNull();
+  });
+
+  it('refuses to equip an unregistered cosmetic', () => {
+    expect(cs.equip('hat', 'unknown_hat')).toBeNull();
+    expect(cs.getEquippedSlot('hat')).toBeNull();
+  });
+
+  it('reports the previous id when swapping cosmetics in the same slot', () => {
+    cs.equip('hat', 'witch_hat');
+    cs.registerCosmetic({ ...HAT_CFG, cosmeticId: 'crown' });
+    const change = cs.equip('hat', 'crown');
+    expect(change).toEqual({ slot: 'hat', previousId: 'witch_hat', cosmeticId: 'crown' });
+  });
+
+  it('unequips and reports the change', () => {
+    cs.equip('accessory', 'star_pendant');
+    const change = cs.unequip('accessory');
+    expect(change).toEqual({ slot: 'accessory', previousId: 'star_pendant', cosmeticId: null });
+    expect(cs.getEquippedSlot('accessory')).toBeNull();
+  });
+
+  it('returns null when unequipping an empty slot', () => {
+    expect(cs.unequip('hat')).toBeNull();
+  });
+});
+
+describe('CosmeticSystem — applyEquipped (bulk update)', () => {
+  let cs: CosmeticSystem;
+
+  beforeEach(() => {
+    cs = new CosmeticSystem(makeScene().scene);
+    cs.registerCosmetic(HAT_CFG);
+    cs.registerCosmetic(ACCESSORY_CFG);
+  });
+
+  it('applies a full loadout and emits one change per slot', () => {
+    const changes = cs.applyEquipped({ hat: 'witch_hat', accessory: 'star_pendant' });
+    expect(changes).toHaveLength(2);
+    expect(cs.getEquipped()).toEqual({ hat: 'witch_hat', accessory: 'star_pendant' });
+  });
+
+  it('only emits changes for slots that actually moved', () => {
+    cs.applyEquipped({ hat: 'witch_hat' });
+    const changes = cs.applyEquipped({ hat: 'witch_hat', accessory: 'star_pendant' });
+    expect(changes).toHaveLength(1);
+    expect(changes[0].slot).toBe('accessory');
+  });
+
+  it('clears slots that are absent from the next loadout', () => {
+    cs.applyEquipped({ hat: 'witch_hat', accessory: 'star_pendant' });
+    const changes = cs.applyEquipped({ hat: 'witch_hat', accessory: null });
+    expect(changes).toHaveLength(1);
+    expect(changes[0]).toEqual({ slot: 'accessory', previousId: 'star_pendant', cosmeticId: null });
+    expect(cs.getEquipped()).toEqual({ hat: 'witch_hat', accessory: null });
+  });
+});
+
+describe('CosmeticSystem — JSON parsing (matches DB equipped_cosmetics column)', () => {
+  let cs: CosmeticSystem;
+
+  beforeEach(() => {
+    cs = new CosmeticSystem(makeScene().scene);
+    cs.registerCosmetic(HAT_CFG);
+    cs.registerCosmetic(ACCESSORY_CFG);
+  });
+
+  it('applies a serialized loadout from the API', () => {
+    cs.applyEquippedJson('{"hat":"witch_hat","accessory":"star_pendant"}');
+    expect(cs.getEquipped()).toEqual({ hat: 'witch_hat', accessory: 'star_pendant' });
+  });
+
+  it('treats null or empty JSON as fully unequipped', () => {
+    cs.applyEquipped({ hat: 'witch_hat' });
+    cs.applyEquippedJson(null);
+    expect(cs.getEquipped()).toEqual({ hat: null, accessory: null });
+  });
+
+  it('ignores malformed JSON without throwing', () => {
+    expect(() => cs.applyEquippedJson('{not json')).not.toThrow();
+    expect(cs.getEquipped()).toEqual({ hat: null, accessory: null });
+  });
+
+  it('ignores non-object JSON shapes', () => {
+    cs.applyEquippedJson('[]');
+    cs.applyEquippedJson('"witch_hat"');
+    expect(cs.getEquipped()).toEqual({ hat: null, accessory: null });
+  });
+
+  it('round-trips through toJson()', () => {
+    cs.applyEquipped({ hat: 'witch_hat', accessory: 'star_pendant' });
+    const json = cs.toJson();
+    const cs2 = new CosmeticSystem(makeScene().scene);
+    cs2.registerCosmetic(HAT_CFG);
+    cs2.registerCosmetic(ACCESSORY_CFG);
+    cs2.applyEquippedJson(json);
+    expect(cs2.getEquipped()).toEqual(cs.getEquipped());
+  });
+});
+
+describe('CosmeticSystem — sheet loading', () => {
+  it('queues the spritesheet onto the scene loader', () => {
+    const helpers = makeScene();
+    const cs = new CosmeticSystem(helpers.scene);
+    cs.registerCosmetic(HAT_CFG);
+    expect(cs.loadCosmeticAssets('witch_hat')).toBe(true);
+    expect(helpers.loadCalls).toHaveLength(1);
+    expect(helpers.loadCalls[0]).toMatchObject({
+      key: 'cosmetic-witch_hat',
+      path: HAT_CFG.path,
+      frameWidth: 16,
+      frameHeight: 16,
+    });
+  });
+
+  it('skips queuing if the texture is already present in the scene', () => {
+    const helpers = makeScene();
+    helpers.existing.add('cosmetic-witch_hat');
+    const cs = new CosmeticSystem(helpers.scene);
+    cs.registerCosmetic(HAT_CFG);
+    expect(cs.loadCosmeticAssets('witch_hat')).toBe(false);
+    expect(helpers.loadCalls).toHaveLength(0);
+    expect(cs.isLoaded('witch_hat')).toBe(true);
+  });
+
+  it('does not double-queue the same cosmetic', () => {
+    const helpers = makeScene();
+    const cs = new CosmeticSystem(helpers.scene);
+    cs.registerCosmetic(HAT_CFG);
+    cs.loadCosmeticAssets('witch_hat');
+    expect(cs.loadCosmeticAssets('witch_hat')).toBe(false);
+    expect(helpers.loadCalls).toHaveLength(1);
+  });
+
+  it('returns false for unregistered cosmetics', () => {
+    const helpers = makeScene();
+    const cs = new CosmeticSystem(helpers.scene);
+    expect(cs.loadCosmeticAssets('mystery')).toBe(false);
+  });
+});
+
+describe('CosmeticSystem — offsets fall back to slot defaults', () => {
+  it('uses slot default when sheet has no explicit offset', () => {
+    const cs = new CosmeticSystem(makeScene().scene);
+    cs.registerCosmetic(HAT_CFG);
+    expect(cs.getOffset('witch_hat')).toEqual(DEFAULT_SLOT_OFFSETS.hat);
+  });
+
+  it('uses sheet override when provided', () => {
+    const cs = new CosmeticSystem(makeScene().scene);
+    cs.registerCosmetic(ACCESSORY_CFG);
+    expect(cs.getOffset('star_pendant').y).toBe(4);
+  });
+});
+
+describe('CompanionSprite source — wires CosmeticSystem and EventBus', () => {
+  // Source-level smoke test mirrors the pattern used in roomScene.test.ts:
+  // we keep these guarantees that the layered renderer is actually present.
+  const compSource = fs.readFileSync(
+    new URL('../sprites/CompanionSprite.ts', import.meta.url),
+    'utf-8',
+  );
+  const worldSource = fs.readFileSync(
+    new URL('../scenes/WorldScene.ts', import.meta.url),
+    'utf-8',
+  );
+
+  it('CompanionSprite extends Phaser.GameObjects.Container', () => {
+    expect(compSource).toContain('extends Phaser.GameObjects.Container');
+  });
+
+  it('CompanionSprite owns a CosmeticSystem instance', () => {
+    expect(compSource).toContain('new CosmeticSystem(scene)');
+  });
+
+  it('CompanionSprite syncs cosmetic frames on base animation update', () => {
+    expect(compSource).toContain('Phaser.Animations.Events.ANIMATION_UPDATE');
+  });
+
+  it('WorldScene listens for equip / unequip / cosmetics on EventBus', () => {
+    expect(worldSource).toContain("'companion-equip-cosmetic'");
+    expect(worldSource).toContain("'companion-unequip-cosmetic'");
+    expect(worldSource).toContain("'companion-cosmetics'");
+  });
+});

--- a/game/scenes/WorldScene.ts
+++ b/game/scenes/WorldScene.ts
@@ -6,6 +6,7 @@ import { CompanionSprite } from '../sprites/CompanionSprite';
 import { OtherPlayersManager } from '../sprites/OtherPlayerSprite';
 import { NPCManager } from '../sprites/NPCSprite';
 import { AnimationSystem, type CompanionMood, type Constellation, CONSTELLATIONS } from '../systems/AnimationSystem';
+import { COSMETIC_SLOTS, type CosmeticSlot, type EquippedCosmetics } from '../systems/CosmeticSystem';
 import type { RemotePlayer } from '@/lib/colyseus/types';
 import {
   WORLD_WIDTH,
@@ -202,6 +203,23 @@ export class WorldScene extends Phaser.Scene {
     });
     EventBus.on('companion-away', (data: { away: boolean }) => {
       this.companion.setAway(!!data?.away);
+    });
+    EventBus.on('companion-equip-cosmetic', (data: { slot: string; cosmeticId: string }) => {
+      if (!data) return;
+      if (!(COSMETIC_SLOTS as readonly string[]).includes(data.slot)) return;
+      this.companion.equipCosmetic(data.slot as CosmeticSlot, data.cosmeticId);
+    });
+    EventBus.on('companion-unequip-cosmetic', (data: { slot: string }) => {
+      if (!data) return;
+      if (!(COSMETIC_SLOTS as readonly string[]).includes(data.slot)) return;
+      this.companion.unequipCosmetic(data.slot as CosmeticSlot);
+    });
+    EventBus.on('companion-cosmetics', (data: EquippedCosmetics | string) => {
+      if (typeof data === 'string') {
+        this.companion.applyEquippedCosmeticsJson(data);
+      } else if (data && typeof data === 'object') {
+        this.companion.applyEquippedCosmetics(data);
+      }
     });
     EventBus.on('editor-mode', (enabled: boolean) => this.setEditorMode(enabled));
     EventBus.on('highlight-door', (data: { room: string }) => {
@@ -420,6 +438,9 @@ export class WorldScene extends Phaser.Scene {
     EventBus.off('companion-mood');
     EventBus.off('companion-constellation');
     EventBus.off('companion-away');
+    EventBus.off('companion-equip-cosmetic');
+    EventBus.off('companion-unequip-cosmetic');
+    EventBus.off('companion-cosmetics');
     EventBus.off('editor-mode');
     EventBus.off('highlight-door');
     EventBus.off('room-exit');

--- a/game/sprites/CompanionSprite.ts
+++ b/game/sprites/CompanionSprite.ts
@@ -1,6 +1,12 @@
 import Phaser from 'phaser';
 import type { Direction } from './PlayerSprite';
 import { AnimationSystem, type CompanionMood, type Constellation, CONSTELLATIONS } from '../systems/AnimationSystem';
+import {
+  CosmeticSystem,
+  COSMETIC_SLOTS,
+  type CosmeticSlot,
+  type EquippedCosmetics,
+} from '../systems/CosmeticSystem';
 
 const LERP_FACTOR = 0.15;
 const FOLLOW_DISTANCE = 20;
@@ -9,7 +15,19 @@ const MOVEMENT_THRESHOLD = 0.1;
 export type { Constellation };
 export { CONSTELLATIONS };
 
-export class CompanionSprite extends Phaser.GameObjects.Sprite {
+/**
+ * CompanionSprite is a Phaser Container holding a base Sprite and one Sprite per
+ * cosmetic slot (hat, accessory). Cosmetic layers stay frame-locked to the base
+ * by mirroring its frame on every animationupdate event. The container exposes
+ * the existing CompanionSprite surface (followPlayer / setMood / setConstellation /
+ * setAway / setNFTTexture) so callers don't need to know about the layered
+ * internals.
+ */
+export class CompanionSprite extends Phaser.GameObjects.Container {
+  private base: Phaser.GameObjects.Sprite;
+  private cosmeticSprites: Partial<Record<CosmeticSlot, Phaser.GameObjects.Sprite>> = {};
+  private cosmetics: CosmeticSystem;
+
   private followOffsetX = FOLLOW_DISTANCE;
   private followOffsetY = FOLLOW_DISTANCE / 2;
   private baseY = 0;
@@ -18,13 +36,50 @@ export class CompanionSprite extends Phaser.GameObjects.Sprite {
   private prevTextureKey = '';
   private away = false;
   private zzzText: Phaser.GameObjects.Text | null = null;
+  private cachedFlipX = false;
 
   constructor(scene: Phaser.Scene, x: number, y: number, textureKey?: string) {
-    super(scene, x, y, textureKey || 'companion-placeholder');
+    super(scene, x, y);
+    this.base = scene.add.sprite(0, 0, textureKey || 'companion-placeholder');
+    this.add(this.base);
+    this.setSize(this.base.width, this.base.height);
     scene.add.existing(this);
     this.setDepth(9);
     this.setScale(1.5);
     this.baseY = y;
+
+    this.cosmetics = new CosmeticSystem(scene);
+
+    // Frame sync: when base sprite advances its animation frame, cosmetic
+    // layers snap to the matching frame index so they stay perfectly aligned.
+    this.base.on(Phaser.Animations.Events.ANIMATION_UPDATE, this.handleBaseAnimationUpdate, this);
+  }
+
+  /**
+   * Overrides Container.setInteractive so that calling it without an explicit
+   * hit area uses a rectangle centered on the base sprite (origin 0.5, 0.5).
+   * Phaser's default Container hit-area auto-derivation places the rectangle
+   * at (0, 0)–(width, height), which would not cover the centered base sprite.
+   */
+  setInteractive(
+    hitArea?: Phaser.Types.Input.InputConfiguration | Phaser.Geom.Rectangle | unknown,
+    callback?: Phaser.Types.Input.HitAreaCallback,
+    dropZone?: boolean,
+  ): this {
+    if (hitArea === undefined || (typeof hitArea === 'object' && hitArea !== null && !('contains' in hitArea))) {
+      const w = this.base.width || 16;
+      const h = this.base.height || 16;
+      const rect = new Phaser.Geom.Rectangle(-w / 2, -h / 2, w, h);
+      const config = (hitArea ?? {}) as Phaser.Types.Input.InputConfiguration;
+      return super.setInteractive(
+        { ...config, hitArea: rect, hitAreaCallback: Phaser.Geom.Rectangle.Contains },
+      );
+    }
+    return super.setInteractive(hitArea, callback, dropZone);
+  }
+
+  getCosmeticSystem(): CosmeticSystem {
+    return this.cosmetics;
   }
 
   isAway(): boolean {
@@ -37,7 +92,7 @@ export class CompanionSprite extends Phaser.GameObjects.Sprite {
 
     if (away) {
       this.setAlpha(0.45);
-      this.setTint(0x8899cc);
+      this.applyTint(0x8899cc);
       if (this.animSystem) {
         this.animSystem.setMood('sleepy');
         this.refreshTexture();
@@ -56,7 +111,7 @@ export class CompanionSprite extends Phaser.GameObjects.Sprite {
       }
     } else {
       this.setAlpha(1);
-      this.clearTint();
+      this.clearTintAll();
       if (this.zzzText) {
         this.zzzText.destroy();
         this.zzzText = null;
@@ -108,7 +163,7 @@ export class CompanionSprite extends Phaser.GameObjects.Sprite {
     if (!this.animSystem) {
       const key = `companion-${constellation}`;
       if (this.scene.textures.exists(key)) {
-        this.setTexture(key);
+        this.base.setTexture(key);
       }
       return;
     }
@@ -123,12 +178,139 @@ export class CompanionSprite extends Phaser.GameObjects.Sprite {
     this.refreshTexture();
   }
 
+  /** Equip a cosmetic in the given slot. Idempotent. */
+  equipCosmetic(slot: CosmeticSlot, cosmeticId: string): boolean {
+    if (!this.cosmetics.hasCosmetic(cosmeticId)) {
+      // Auto-load only if registered. Caller is expected to register sheets ahead of time.
+      return false;
+    }
+    const change = this.cosmetics.equip(slot, cosmeticId);
+    if (!change) return false;
+    this.syncSlotSprite(slot);
+    return true;
+  }
+
+  /** Unequip the cosmetic from a slot. */
+  unequipCosmetic(slot: CosmeticSlot): boolean {
+    const change = this.cosmetics.unequip(slot);
+    if (!change) return false;
+    this.removeSlotSprite(slot);
+    return true;
+  }
+
+  /** Apply a full cosmetic loadout, e.g. from the API's `equipped_cosmetics` field. */
+  applyEquippedCosmetics(equipped: EquippedCosmetics): void {
+    const changes = this.cosmetics.applyEquipped(equipped);
+    for (const change of changes) {
+      if (change.cosmeticId) {
+        this.syncSlotSprite(change.slot);
+      } else {
+        this.removeSlotSprite(change.slot);
+      }
+    }
+  }
+
+  applyEquippedCosmeticsJson(json: string | null | undefined): void {
+    const changes = this.cosmetics.applyEquippedJson(json);
+    for (const change of changes) {
+      if (change.cosmeticId) {
+        this.syncSlotSprite(change.slot);
+      } else {
+        this.removeSlotSprite(change.slot);
+      }
+    }
+  }
+
+  getEquippedCosmetics(): EquippedCosmetics {
+    return this.cosmetics.getEquipped();
+  }
+
+  private syncSlotSprite(slot: CosmeticSlot) {
+    const cosmeticId = this.cosmetics.getEquippedSlot(slot);
+    if (!cosmeticId) {
+      this.removeSlotSprite(slot);
+      return;
+    }
+    const textureKey = CosmeticSystem.textureKeyFor(cosmeticId);
+    if (!this.scene.textures.exists(textureKey)) {
+      // Sheet not loaded yet — caller should load it then call again.
+      this.removeSlotSprite(slot);
+      return;
+    }
+
+    const offset = this.cosmetics.getOffset(cosmeticId);
+    let sprite = this.cosmeticSprites[slot];
+    if (!sprite) {
+      sprite = this.scene.add.sprite(offset.x, offset.y, textureKey);
+      sprite.setOrigin(this.base.originX, this.base.originY);
+      this.cosmeticSprites[slot] = sprite;
+      this.add(sprite);
+    } else {
+      sprite.setTexture(textureKey);
+      sprite.setPosition(offset.x, offset.y);
+    }
+    sprite.setFlipX(this.cachedFlipX);
+    sprite.setFrame(this.base.frame.name);
+    // Container child render order is determined by list position, not depth.
+    // Re-anchor to the top so the layer renders above the base sprite.
+    this.bringToTop(sprite);
+  }
+
+  private removeSlotSprite(slot: CosmeticSlot) {
+    const sprite = this.cosmeticSprites[slot];
+    if (!sprite) return;
+    this.remove(sprite, true);
+    delete this.cosmeticSprites[slot];
+  }
+
+  private handleBaseAnimationUpdate = (
+    _anim: Phaser.Animations.Animation,
+    frame: Phaser.Animations.AnimationFrame,
+  ) => {
+    for (const slot of COSMETIC_SLOTS) {
+      const sprite = this.cosmeticSprites[slot];
+      if (!sprite) continue;
+      // Only sync if the cosmetic sheet uses a frame index that exists. The
+      // safest path is to set the frame by index when numeric.
+      const fname = frame.frame.name;
+      try {
+        sprite.setFrame(fname);
+      } catch {
+        // Cosmetic sheet has fewer frames — fall back to first frame.
+        sprite.setFrame(0);
+      }
+    }
+  };
+
+  private applyTint(color: number) {
+    this.base.setTint(color);
+    for (const slot of COSMETIC_SLOTS) {
+      this.cosmeticSprites[slot]?.setTint(color);
+    }
+  }
+
+  private clearTintAll() {
+    this.base.clearTint();
+    for (const slot of COSMETIC_SLOTS) {
+      this.cosmeticSprites[slot]?.clearTint();
+    }
+  }
+
+  private setFlipXAll(flip: boolean) {
+    if (this.cachedFlipX === flip) return;
+    this.cachedFlipX = flip;
+    this.base.setFlipX(flip);
+    for (const slot of COSMETIC_SLOTS) {
+      this.cosmeticSprites[slot]?.setFlipX(flip);
+    }
+  }
+
   private refreshTexture() {
     if (!this.animSystem) return;
 
     const animKey = this.animSystem.getAnimationKey();
     if (animKey && this.scene.anims.exists(animKey)) {
-      this.play(animKey, true);
+      this.base.play(animKey, true);
       this.prevTextureKey = '';
       return;
     }
@@ -136,7 +318,7 @@ export class CompanionSprite extends Phaser.GameObjects.Sprite {
     const textureKey = this.animSystem.getTextureKey();
     if (textureKey !== this.prevTextureKey) {
       this.prevTextureKey = textureKey;
-      this.setTexture(textureKey);
+      this.base.setTexture(textureKey);
     }
   }
 
@@ -201,9 +383,9 @@ export class CompanionSprite extends Phaser.GameObjects.Sprite {
     }
 
     if (playerDirection === 'left') {
-      this.setFlipX(true);
+      this.setFlipXAll(true);
     } else if (playerDirection === 'right') {
-      this.setFlipX(false);
+      this.setFlipXAll(false);
     }
 
     if (this.zzzText) {
@@ -213,6 +395,7 @@ export class CompanionSprite extends Phaser.GameObjects.Sprite {
   }
 
   destroy(fromScene?: boolean): void {
+    this.base?.off(Phaser.Animations.Events.ANIMATION_UPDATE, this.handleBaseAnimationUpdate, this);
     if (this.zzzText) {
       this.zzzText.destroy();
       this.zzzText = null;
@@ -223,14 +406,14 @@ export class CompanionSprite extends Phaser.GameObjects.Sprite {
   setNFTTexture(url: string) {
     const key = 'companion-nft';
     if (this.scene.textures.exists(key)) {
-      this.setTexture(key);
+      this.base.setTexture(key);
       return;
     }
 
     this.scene.load.image(key, url);
     this.scene.load.once('complete', () => {
       if (this.scene.textures.exists(key)) {
-        this.setTexture(key);
+        this.base.setTexture(key);
       }
     });
     this.scene.load.start();

--- a/game/systems/CosmeticSystem.ts
+++ b/game/systems/CosmeticSystem.ts
@@ -1,0 +1,179 @@
+import Phaser from 'phaser';
+
+// Slot taxonomy. Add new slots here when introducing new cosmetic categories.
+export const COSMETIC_SLOTS = ['hat', 'accessory'] as const;
+export type CosmeticSlot = (typeof COSMETIC_SLOTS)[number];
+
+export interface CosmeticSheetConfig {
+  cosmeticId: string;
+  slot: CosmeticSlot;
+  path: string;
+  frameWidth: number;
+  frameHeight: number;
+  // Anchor offset relative to the base sprite origin. Slot defaults are used if omitted.
+  offsetX?: number;
+  offsetY?: number;
+}
+
+export const DEFAULT_SLOT_OFFSETS: Record<CosmeticSlot, { x: number; y: number }> = {
+  hat: { x: 0, y: -6 },
+  accessory: { x: 0, y: 0 },
+};
+
+export const SLOT_DEPTH_DELTA: Record<CosmeticSlot, number> = {
+  // Layer order above the companion base sprite. Larger value renders on top.
+  accessory: 1,
+  hat: 2,
+};
+
+export interface EquippedCosmetics {
+  hat?: string | null;
+  accessory?: string | null;
+}
+
+export type EquipChange = {
+  slot: CosmeticSlot;
+  previousId: string | null;
+  cosmeticId: string | null;
+};
+
+/**
+ * CosmeticSystem manages the equipped cosmetic slots for a companion and the
+ * sprite-sheet textures backing each cosmetic. It does NOT own the rendered
+ * Sprites — `CompanionSprite` consumes this system to drive its layer composition.
+ */
+export class CosmeticSystem {
+  private scene: Phaser.Scene;
+  private equipped: Record<CosmeticSlot, string | null> = { hat: null, accessory: null };
+  private registeredSheets = new Map<string, CosmeticSheetConfig>();
+  private loadedSheets = new Set<string>();
+
+  constructor(scene: Phaser.Scene) {
+    this.scene = scene;
+  }
+
+  /** Register a cosmetic sheet so it can be equipped later. Idempotent. */
+  registerCosmetic(config: CosmeticSheetConfig): void {
+    this.registeredSheets.set(config.cosmeticId, config);
+  }
+
+  hasCosmetic(cosmeticId: string): boolean {
+    return this.registeredSheets.has(cosmeticId);
+  }
+
+  getCosmeticConfig(cosmeticId: string): CosmeticSheetConfig | null {
+    return this.registeredSheets.get(cosmeticId) ?? null;
+  }
+
+  /** Texture key Phaser uses for a registered cosmetic sheet. */
+  static textureKeyFor(cosmeticId: string): string {
+    return `cosmetic-${cosmeticId}`;
+  }
+
+  /** Queue the cosmetic spritesheet for loading. Caller must call scene.load.start(). */
+  loadCosmeticAssets(cosmeticId: string): boolean {
+    const cfg = this.registeredSheets.get(cosmeticId);
+    if (!cfg) return false;
+    if (this.loadedSheets.has(cosmeticId)) return false;
+    const key = CosmeticSystem.textureKeyFor(cosmeticId);
+    if (this.scene.textures.exists(key)) {
+      this.loadedSheets.add(cosmeticId);
+      return false;
+    }
+    this.scene.load.spritesheet(key, cfg.path, {
+      frameWidth: cfg.frameWidth,
+      frameHeight: cfg.frameHeight,
+    });
+    this.loadedSheets.add(cosmeticId);
+    return true;
+  }
+
+  isLoaded(cosmeticId: string): boolean {
+    return this.loadedSheets.has(cosmeticId)
+      || this.scene.textures.exists(CosmeticSystem.textureKeyFor(cosmeticId));
+  }
+
+  /** Equip a cosmetic in a slot. Returns the change that occurred (or null if no-op). */
+  equip(slot: CosmeticSlot, cosmeticId: string): EquipChange | null {
+    if (!this.registeredSheets.has(cosmeticId)) {
+      return null;
+    }
+    const previous = this.equipped[slot];
+    if (previous === cosmeticId) return null;
+    this.equipped[slot] = cosmeticId;
+    return { slot, previousId: previous, cosmeticId };
+  }
+
+  /** Unequip whatever is in the slot. Returns the change (or null if nothing was equipped). */
+  unequip(slot: CosmeticSlot): EquipChange | null {
+    const previous = this.equipped[slot];
+    if (previous === null) return null;
+    this.equipped[slot] = null;
+    return { slot, previousId: previous, cosmeticId: null };
+  }
+
+  getEquipped(): EquippedCosmetics {
+    return { hat: this.equipped.hat, accessory: this.equipped.accessory };
+  }
+
+  getEquippedSlot(slot: CosmeticSlot): string | null {
+    return this.equipped[slot];
+  }
+
+  /** Apply a full equipped_cosmetics object (e.g. from API). Returns the diff of changes. */
+  applyEquipped(equipped: EquippedCosmetics): EquipChange[] {
+    const changes: EquipChange[] = [];
+    for (const slot of COSMETIC_SLOTS) {
+      const desired = equipped[slot] ?? null;
+      const current = this.equipped[slot];
+      if (current === desired) continue;
+      if (desired === null) {
+        const change = this.unequip(slot);
+        if (change) changes.push(change);
+      } else {
+        const change = this.equip(slot, desired);
+        if (change) changes.push(change);
+      }
+    }
+    return changes;
+  }
+
+  /**
+   * Parse the `equipped_cosmetics` JSON column shape and apply it. Tolerates
+   * malformed input by ignoring it (the companion just stays bare).
+   */
+  applyEquippedJson(json: string | null | undefined): EquipChange[] {
+    if (!json) return this.applyEquipped({ hat: null, accessory: null });
+    try {
+      const parsed = JSON.parse(json) as unknown;
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        return [];
+      }
+      const obj = parsed as Record<string, unknown>;
+      const next: EquippedCosmetics = {};
+      for (const slot of COSMETIC_SLOTS) {
+        const value = obj[slot];
+        next[slot] = typeof value === 'string' && value.length > 0 ? value : null;
+      }
+      return this.applyEquipped(next);
+    } catch {
+      return [];
+    }
+  }
+
+  /** Compute the rendered offset for a cosmetic, falling back to slot defaults. */
+  getOffset(cosmeticId: string): { x: number; y: number } {
+    const cfg = this.registeredSheets.get(cosmeticId);
+    if (!cfg) return { x: 0, y: 0 };
+    const slotDefault = DEFAULT_SLOT_OFFSETS[cfg.slot];
+    return {
+      x: cfg.offsetX ?? slotDefault.x,
+      y: cfg.offsetY ?? slotDefault.y,
+    };
+  }
+
+  /** Serialize current equipment back to the storage shape the API expects. */
+  toJson(): string {
+    return JSON.stringify(this.equipped);
+  }
+}


### PR DESCRIPTION
## Summary

Implements **SWO_V2_COSMETIC_SPRITE_LAYERS** — adds layered cosmetic rendering to the in-world companion.

- **`game/systems/CosmeticSystem.ts`** — new module owning the slot taxonomy (`hat`, `accessory`), registered cosmetic sheets, equipped state, and the `equipped_cosmetics` JSON parsing that mirrors the `sanctuary_companions.equipped_cosmetics` column. Pure logic, fully unit-tested.
- **`game/sprites/CompanionSprite.ts`** — refactored to extend `Phaser.GameObjects.Container` with a base sprite + one child sprite per cosmetic slot. Cosmetic layers stay frame-locked to the base by mirroring its frame on every `Phaser.Animations.Events.ANIMATION_UPDATE`, so walk/idle animations never drift between layers. Container hit-area is overridden so existing `setInteractive({useHandCursor:true})` calls keep clicks centered on the visible base.
- **`game/scenes/WorldScene.ts`** — listens on three new EventBus channels: `companion-equip-cosmetic`, `companion-unequip-cosmetic`, `companion-cosmetics`. The first two equip/unequip a single slot; the third applies a full loadout (object or JSON string).
- **`components/sanctuary/overlays/CompanionHUD.tsx`** — pushes the active companion's `equipped_cosmetics` field through EventBus on every fetch, so the Phaser scene picks up server-side equipment without polling.
- **`app/sanctuary/SanctuaryContent.tsx`** — added `equipped_cosmetics` to the typed Companion interface so it round-trips through the existing `/api/sanctuary/state` and `/api/sanctuary/companion` responses (the column was already selected by `getActiveCompanion`/`getAllCompanions`; only the TS type needed updating).

Hats render above accessories (slot depth delta), and slot defaults provide sensible anchor offsets when a sheet doesn't specify one. Loaders are queue-only — sheets are registered up-front via `registerCosmetic(...)` and loaded lazily via `loadCosmeticAssets(...)`, leaving asset bundling to follow-up cosmetic content drops.

## Test Plan

- [x] **Type-check**: `npm run type-check` — 0 new errors. (3 pre-existing errors in `.next/types/validator.ts` for unrelated `app/api/sanctuary/star/*` routes are unchanged.)
- [x] **Lint**: `npx eslint` on changed files — 0 new errors/warnings. (Pre-existing warnings in `app/sanctuary/SanctuaryContent.tsx` lines 440 and 1201 predate this change.)
- [x] **Unit tests**: 28 new tests in `game/__tests__/cosmeticSystem.test.ts` — all pass. Coverage: slot taxonomy, equip/unequip idempotence, swap detection, JSON parse tolerance (malformed/null/non-object), bulk-apply diffing, sheet-loading dedup, offset fallbacks, and source-level smoke checks for the Container refactor and EventBus wiring.
- [x] **Full suite**: `npm run test` — 370 passed, 4 pre-existing failures in `lib/sanctuary/__tests__/api-e2e.test.ts` (unchanged).
- [x] **Build**: `npm run build` — succeeded.
- [ ] Manual browser smoke test of equip flow — pending real cosmetic assets.

## Mirror Validation (PROD)

The PROD mirror at `/opt/star_world_order/PROD` does not yet have the Sanctuary V2 infrastructure — no `game/` directory, no `components/sanctuary/` folder, and `app/api/sanctuary/companion/` lacks the v2 endpoints. Overlaying these workspace files onto PROD would only introduce import errors for modules PROD doesn't carry yet (Phaser, easystarjs, EventBus). The PROD baseline `tsc --noEmit` runs clean (exit 0); my changes target the dev branch only and will land in PROD when Sanctuary V2 is merged forward.

- **PROD baseline tsc --noEmit**: PASS (no errors)
- **Workspace tsc --noEmit**: PASS (3 pre-existing unrelated errors)
- **Workspace vitest run**: PASS (370 passed, 4 pre-existing failures, +28 new tests)

Overall: PASS (workspace) — mirror N/A (sanctuary V2 not yet present in PROD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)