### PR TITLE
feat(sanctuary v2.2): cosmetic shop backend + inventory + equip API

### DIFF
--- a/app/api/sanctuary/inventory/equip/route.ts
+++ b/app/api/sanctuary/inventory/equip/route.ts
@@ -1,0 +1,92 @@
+/**
+ * POST /api/sanctuary/inventory/equip
+ *
+ * Equip a cosmetic from the wallet's inventory onto a specific companion. The
+ * cosmetic's category determines the slot it occupies in the companion's
+ * `equipped_cosmetics` JSON. Pass `item_key: null` to unequip (and a `slot`
+ * indicating which slot to clear).
+ *
+ * Body: { address, token_id, item_key (string | null), slot? }
+ *
+ * Response:
+ *   200 { success: true, token_id, equipped_cosmetics }
+ *   400 validation
+ *   401 wallet auth failed
+ *   404 COMPANION_NOT_FOUND | ITEM_NOT_FOUND
+ *   409 ALREADY_EQUIPPED
+ *   422 LEVEL_TOO_LOW | NOT_OWNED
+ *   429 rate limited
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { equipCosmetic, type CosmeticCategory } from '@/lib/db';
+import { verifyWalletAccess } from '@/lib/walletAuth';
+import { applyRateLimit } from '@/lib/sanctuary/rateLimit';
+import { ethAddress, tokenId, parseBody, formatZodError } from '@/lib/sanctuary/validation';
+
+const slotEnum = z.enum(['hat', 'accessory', 'background', 'animation']);
+
+const bodySchema = z.object({
+  address: ethAddress,
+  token_id: tokenId,
+  item_key: z.union([
+    z.string().min(1).max(64).regex(/^[a-z0-9_]+$/),
+    z.null(),
+  ]),
+  slot: slotEnum.optional(),
+});
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const parsed = parseBody(bodySchema, body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { success: false, error: formatZodError(parsed.error) },
+        { status: 400 },
+      );
+    }
+    const { address, token_id, item_key, slot } = parsed.data;
+
+    if (item_key === null && !slot) {
+      return NextResponse.json(
+        { success: false, error: 'slot is required when unequipping (item_key=null)' },
+        { status: 400 },
+      );
+    }
+
+    const auth = await verifyWalletAccess(request, address);
+    if (!auth.valid) {
+      return NextResponse.json({ success: false, error: auth.error }, { status: 401 });
+    }
+
+    const rateLimited = applyRateLimit(address, 'inventory/equip');
+    if (rateLimited) return rateLimited;
+
+    const result = equipCosmetic(
+      address,
+      token_id,
+      item_key,
+      slot as CosmeticCategory | undefined,
+    );
+    return NextResponse.json({ success: true, ...result });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : 'Failed to equip cosmetic';
+    if (msg === 'COMPANION_NOT_FOUND' || msg === 'ITEM_NOT_FOUND') {
+      return NextResponse.json({ success: false, error: msg }, { status: 404 });
+    }
+    if (msg === 'ALREADY_EQUIPPED') {
+      return NextResponse.json({ success: false, error: 'Item already equipped' }, { status: 409 });
+    }
+    if (msg === 'NOT_OWNED') {
+      return NextResponse.json({ success: false, error: 'You do not own this item' }, { status: 422 });
+    }
+    if (msg.startsWith('LEVEL_TOO_LOW')) {
+      return NextResponse.json({ success: false, error: 'Wallet level too low for this item' }, { status: 422 });
+    }
+    if (msg === 'SLOT_REQUIRED') {
+      return NextResponse.json({ success: false, error: 'slot is required when unequipping' }, { status: 400 });
+    }
+    return NextResponse.json({ success: false, error: msg }, { status: 500 });
+  }
+}

--- a/app/api/sanctuary/inventory/route.ts
+++ b/app/api/sanctuary/inventory/route.ts
@@ -1,0 +1,47 @@
+/**
+ * GET /api/sanctuary/inventory?address=0x...
+ *
+ * Returns the wallet's owned cosmetic items, joined with the catalog metadata.
+ * Public read — ownership is already implied by on-chain wallet identity.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import {
+  getCompanionInventory,
+  getShopItem,
+  type SanctuaryCosmeticItem,
+  type SanctuaryInventoryEntry,
+} from '@/lib/db';
+import { ethAddress, parseSearchParams, formatZodError } from '@/lib/sanctuary/validation';
+
+const querySchema = z.object({
+  address: ethAddress,
+});
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const parsed = parseSearchParams(querySchema, searchParams);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { success: false, error: formatZodError(parsed.error) },
+        { status: 400 },
+      );
+    }
+    const { address } = parsed.data;
+    const entries = getCompanionInventory(address);
+    type EnrichedItem = SanctuaryCosmeticItem & {
+      source: SanctuaryInventoryEntry['source'];
+      acquired_at: string;
+    };
+    const items: EnrichedItem[] = [];
+    for (const e of entries) {
+      const meta = getShopItem(e.item_key);
+      if (meta) items.push({ ...meta, source: e.source, acquired_at: e.acquired_at });
+    }
+    return NextResponse.json({ success: true, items });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : 'Failed to read inventory';
+    return NextResponse.json({ success: false, error: msg }, { status: 500 });
+  }
+}

--- a/app/api/sanctuary/shop/buy/route.ts
+++ b/app/api/sanctuary/shop/buy/route.ts
@@ -1,0 +1,73 @@
+/**
+ * POST /api/sanctuary/shop/buy
+ *
+ * Purchase a cosmetic item from the Shop. Wallet-authenticated so the holder
+ * must consent to the STAR deduction. Atomically:
+ *   1. validates the item exists and the wallet meets `level_required`
+ *   2. ensures the wallet doesn't already own the item
+ *   3. deducts STAR via spendStar() (writes the ledger entry)
+ *   4. inserts the inventory row
+ *
+ * Body: { address, item_key }
+ *
+ * Response:
+ *   200 { success: true, item, balance, lifetime_earned, spent }
+ *   400 validation
+ *   401 wallet auth failed
+ *   402 Insufficient STAR balance
+ *   404 ITEM_NOT_FOUND
+ *   409 ALREADY_OWNED
+ *   422 LEVEL_TOO_LOW
+ *   429 rate limited
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { buyShopItem } from '@/lib/db';
+import { verifyWalletAccess } from '@/lib/walletAuth';
+import { applyRateLimit } from '@/lib/sanctuary/rateLimit';
+import { ethAddress, parseBody, formatZodError } from '@/lib/sanctuary/validation';
+
+const bodySchema = z.object({
+  address: ethAddress,
+  item_key: z.string().min(1).max(64).regex(/^[a-z0-9_]+$/),
+});
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const parsed = parseBody(bodySchema, body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { success: false, error: formatZodError(parsed.error) },
+        { status: 400 },
+      );
+    }
+    const { address, item_key } = parsed.data;
+
+    const auth = await verifyWalletAccess(request, address);
+    if (!auth.valid) {
+      return NextResponse.json({ success: false, error: auth.error }, { status: 401 });
+    }
+
+    const rateLimited = applyRateLimit(address, 'shop/buy');
+    if (rateLimited) return rateLimited;
+
+    const result = buyShopItem(address, item_key);
+    return NextResponse.json({ success: true, ...result });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : 'Failed to buy shop item';
+    if (msg === 'ITEM_NOT_FOUND') {
+      return NextResponse.json({ success: false, error: 'Item not found' }, { status: 404 });
+    }
+    if (msg === 'ALREADY_OWNED') {
+      return NextResponse.json({ success: false, error: 'Item already owned' }, { status: 409 });
+    }
+    if (msg.startsWith('LEVEL_TOO_LOW')) {
+      return NextResponse.json({ success: false, error: 'Wallet level too low for this item' }, { status: 422 });
+    }
+    if (msg.includes('Insufficient')) {
+      return NextResponse.json({ success: false, error: msg }, { status: 402 });
+    }
+    return NextResponse.json({ success: false, error: msg }, { status: 500 });
+  }
+}

--- a/app/api/sanctuary/shop/items/route.ts
+++ b/app/api/sanctuary/shop/items/route.ts
@@ -1,0 +1,42 @@
+/**
+ * GET /api/sanctuary/shop/items?category=hat&address=0x...
+ *
+ * Public catalog read. Returns the cosmetic items available in the Shop,
+ * sorted by price. When `address` is provided, each item includes an `owned`
+ * flag so the client can disable already-purchased items.
+ *
+ * Query:
+ *   category? — 'hat' | 'accessory' | 'background' | 'animation'
+ *   address?  — wallet address to enrich items with ownership info
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { listShopItems, type CosmeticCategory } from '@/lib/db';
+import { ethAddress, parseSearchParams, formatZodError } from '@/lib/sanctuary/validation';
+
+const querySchema = z.object({
+  category: z.enum(['hat', 'accessory', 'background', 'animation']).optional(),
+  address: ethAddress.optional(),
+});
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const parsed = parseSearchParams(querySchema, searchParams);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { success: false, error: formatZodError(parsed.error) },
+        { status: 400 },
+      );
+    }
+    const { category, address } = parsed.data;
+    const items = listShopItems({
+      category: category as CosmeticCategory | undefined,
+      walletAddress: address,
+    });
+    return NextResponse.json({ success: true, items });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : 'Failed to list shop items';
+    return NextResponse.json({ success: false, error: msg }, { status: 500 });
+  }
+}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -5804,6 +5804,11 @@ function initializeSanctuary(database: Database.Database): void {
     const sql = fs.readFileSync(v21Path, 'utf-8');
     database.exec(sql);
   }
+  const v22Path = path.join(process.cwd(), 'scripts', 'init-sanctuary-v2.2.sql');
+  if (fs.existsSync(v22Path)) {
+    const sql = fs.readFileSync(v22Path, 'utf-8');
+    database.exec(sql);
+  }
   // V1.7: per-companion XP/level columns (Training Grounds). ALTER TABLE IF NOT
   // EXISTS is not portable across SQLite versions, so wrap in try/catch.
   try { database.exec('ALTER TABLE sanctuary_companions ADD COLUMN xp INTEGER NOT NULL DEFAULT 0'); }
@@ -5818,6 +5823,7 @@ function initializeSanctuary(database: Database.Database): void {
   seedSanctuaryMapLocations(database);
   seedSanctuaryQuests(database);
   seedSkrumpeyMetadataFromCorpus(database);
+  seedSanctuaryCosmeticItems(database);
 }
 
 function seedSkrumpeyMetadataFromCorpus(database: Database.Database): void {
@@ -7672,4 +7678,305 @@ export function getStarLedger(
   return db.prepare(
     'SELECT * FROM sanctuary_star_ledger WHERE wallet_address = ? ORDER BY created_at DESC, id DESC LIMIT ?'
   ).all(addr, Math.max(1, Math.min(500, Math.floor(limit)))) as SanctuaryStarLedgerEntry[];
+}
+
+// ---------------------------------------------------------------------------
+// Cosmetic Shop + Inventory (V2.2) — see [SWO_V2_SHOP_BACKEND]
+// ---------------------------------------------------------------------------
+
+export type CosmeticCategory = 'hat' | 'accessory' | 'background' | 'animation';
+export type CosmeticRarity = 'common' | 'uncommon' | 'rare' | 'legendary';
+
+export const COSMETIC_CATEGORIES: readonly CosmeticCategory[] = [
+  'hat',
+  'accessory',
+  'background',
+  'animation',
+] as const;
+
+export interface SanctuaryCosmeticItem {
+  id: number;
+  item_key: string;
+  name: string;
+  category: CosmeticCategory;
+  rarity: CosmeticRarity;
+  star_cost: number;
+  level_required: number;
+  description: string | null;
+  asset_key: string;
+  created_at: string;
+}
+
+export interface SanctuaryInventoryEntry {
+  id: number;
+  wallet_address: string;
+  item_key: string;
+  source: 'shop' | 'quest' | 'event' | 'achievement' | 'gift';
+  acquired_at: string;
+}
+
+// 24 items spanning 4 categories (hat, accessory, background, animation) at
+// price points 10–50 STAR. Idempotent: only inserts on a fresh DB or rows
+// missing by item_key.
+const SANCTUARY_COSMETIC_SEED: ReadonlyArray<Omit<SanctuaryCosmeticItem, 'id' | 'created_at'>> = [
+  // Hats — 10–50 STAR
+  { item_key: 'hat_acorn_cap', name: 'Acorn Cap', category: 'hat', rarity: 'common', star_cost: 10, level_required: 1, description: 'A tiny acorn cap, perfect for forest strolls.', asset_key: 'hat_acorn_cap' },
+  { item_key: 'hat_star_beanie', name: 'Star Beanie', category: 'hat', rarity: 'common', star_cost: 15, level_required: 1, description: 'A cozy beanie embroidered with a single bright star.', asset_key: 'hat_star_beanie' },
+  { item_key: 'hat_witch_hat', name: 'Witch Hat', category: 'hat', rarity: 'uncommon', star_cost: 20, level_required: 3, description: 'A pointed hat that hums faintly with arcane energy.', asset_key: 'hat_witch_hat' },
+  { item_key: 'hat_gold_crown', name: 'Gold Crown', category: 'hat', rarity: 'rare', star_cost: 35, level_required: 5, description: 'Worn by the rulers of forgotten constellations.', asset_key: 'hat_gold_crown' },
+  { item_key: 'hat_cosmic_halo', name: 'Cosmic Halo', category: 'hat', rarity: 'rare', star_cost: 40, level_required: 7, description: 'A floating ring of starlight that orbits the wearer.', asset_key: 'hat_cosmic_halo' },
+  { item_key: 'hat_nebula_crown', name: 'Nebula Crown', category: 'hat', rarity: 'legendary', star_cost: 50, level_required: 10, description: 'A crown spun from raw nebula dust. Only the boldest dare wear it.', asset_key: 'hat_nebula_crown' },
+
+  // Accessories — 10–45 STAR
+  { item_key: 'acc_star_pendant', name: 'Star Pendant', category: 'accessory', rarity: 'common', star_cost: 10, level_required: 1, description: 'A simple pendant carved from meteorite glass.', asset_key: 'acc_star_pendant' },
+  { item_key: 'acc_comet_scarf', name: 'Comet Scarf', category: 'accessory', rarity: 'common', star_cost: 15, level_required: 1, description: 'A long scarf with a flowing comet-tail pattern.', asset_key: 'acc_comet_scarf' },
+  { item_key: 'acc_moon_glasses', name: 'Moon Glasses', category: 'accessory', rarity: 'uncommon', star_cost: 20, level_required: 2, description: 'Tinted spectacles that filter even the brightest sun.', asset_key: 'acc_moon_glasses' },
+  { item_key: 'acc_aura_ribbon', name: 'Aura Ribbon', category: 'accessory', rarity: 'uncommon', star_cost: 25, level_required: 3, description: 'A ribbon woven from threads of pure aura.', asset_key: 'acc_aura_ribbon' },
+  { item_key: 'acc_nebula_collar', name: 'Nebula Collar', category: 'accessory', rarity: 'rare', star_cost: 35, level_required: 5, description: 'A collar that shimmers with swirling cosmic gases.', asset_key: 'acc_nebula_collar' },
+  { item_key: 'acc_eclipse_pendant', name: 'Eclipse Pendant', category: 'accessory', rarity: 'legendary', star_cost: 45, level_required: 8, description: 'Forged during a total eclipse. Pulses with shadow-light.', asset_key: 'acc_eclipse_pendant' },
+
+  // Backgrounds — 10–50 STAR
+  { item_key: 'bg_starfield', name: 'Starfield', category: 'background', rarity: 'common', star_cost: 10, level_required: 1, description: 'A peaceful field of distant pinprick stars.', asset_key: 'bg_starfield' },
+  { item_key: 'bg_soft_aurora', name: 'Soft Aurora', category: 'background', rarity: 'common', star_cost: 20, level_required: 2, description: 'Pale curtains of green and pink light drifting overhead.', asset_key: 'bg_soft_aurora' },
+  { item_key: 'bg_cosmic_dawn', name: 'Cosmic Dawn', category: 'background', rarity: 'uncommon', star_cost: 25, level_required: 3, description: 'The first warm light of a galactic morning.', asset_key: 'bg_cosmic_dawn' },
+  { item_key: 'bg_stellar_meadow', name: 'Stellar Meadow', category: 'background', rarity: 'uncommon', star_cost: 30, level_required: 4, description: 'A field of glowing flowers under a dark crystal sky.', asset_key: 'bg_stellar_meadow' },
+  { item_key: 'bg_nebula_drift', name: 'Nebula Drift', category: 'background', rarity: 'rare', star_cost: 40, level_required: 6, description: 'Slow-rolling clouds of cyan and violet stardust.', asset_key: 'bg_nebula_drift' },
+  { item_key: 'bg_galaxy_swirl', name: 'Galaxy Swirl', category: 'background', rarity: 'legendary', star_cost: 50, level_required: 9, description: 'A full spiral galaxy spinning lazily behind your companion.', asset_key: 'bg_galaxy_swirl' },
+
+  // Animations — 10–50 STAR
+  { item_key: 'anim_gentle_bob', name: 'Gentle Bob', category: 'animation', rarity: 'common', star_cost: 10, level_required: 1, description: 'A soft up-and-down bob, like floating on calm water.', asset_key: 'anim_gentle_bob' },
+  { item_key: 'anim_star_sparkle', name: 'Star Sparkle', category: 'animation', rarity: 'common', star_cost: 15, level_required: 2, description: 'Tiny sparkles burst around the companion at random.', asset_key: 'anim_star_sparkle' },
+  { item_key: 'anim_moon_glow', name: 'Moon Glow', category: 'animation', rarity: 'uncommon', star_cost: 25, level_required: 3, description: 'A pulsing silver halo of moonlight.', asset_key: 'anim_moon_glow' },
+  { item_key: 'anim_comet_trail', name: 'Comet Trail', category: 'animation', rarity: 'uncommon', star_cost: 30, level_required: 4, description: 'A bright trail follows every step.', asset_key: 'anim_comet_trail' },
+  { item_key: 'anim_aurora_dance', name: 'Aurora Dance', category: 'animation', rarity: 'rare', star_cost: 40, level_required: 6, description: 'Aurora ribbons twirl rhythmically around the companion.', asset_key: 'anim_aurora_dance' },
+  { item_key: 'anim_constellation_burst', name: 'Constellation Burst', category: 'animation', rarity: 'legendary', star_cost: 50, level_required: 8, description: 'Periodic bursts of constellation glyphs orbit the companion.', asset_key: 'anim_constellation_burst' },
+];
+
+function seedSanctuaryCosmeticItems(database: Database.Database): void {
+  const insert = database.prepare(`
+    INSERT OR IGNORE INTO sanctuary_cosmetic_items
+      (item_key, name, category, rarity, star_cost, level_required, description, asset_key)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+  for (const item of SANCTUARY_COSMETIC_SEED) {
+    insert.run(
+      item.item_key,
+      item.name,
+      item.category,
+      item.rarity,
+      item.star_cost,
+      item.level_required,
+      item.description ?? null,
+      item.asset_key,
+    );
+  }
+}
+
+export interface ListShopItemsOptions {
+  category?: CosmeticCategory;
+  walletAddress?: string;
+}
+
+export interface ShopItemView extends SanctuaryCosmeticItem {
+  owned: boolean;
+}
+
+export function listShopItems(options: ListShopItemsOptions = {}): ShopItemView[] {
+  const db = getDatabase();
+  const { category, walletAddress } = options;
+
+  const ownedKeys = new Set<string>();
+  if (walletAddress) {
+    const rows = db.prepare(
+      'SELECT item_key FROM sanctuary_companion_inventory WHERE wallet_address = ?'
+    ).all(walletAddress.toLowerCase()) as Array<{ item_key: string }>;
+    for (const r of rows) ownedKeys.add(r.item_key);
+  }
+
+  const sql = category
+    ? 'SELECT * FROM sanctuary_cosmetic_items WHERE category = ? ORDER BY star_cost ASC, id ASC'
+    : 'SELECT * FROM sanctuary_cosmetic_items ORDER BY category ASC, star_cost ASC, id ASC';
+  const rows = (
+    category
+      ? db.prepare(sql).all(category)
+      : db.prepare(sql).all()
+  ) as SanctuaryCosmeticItem[];
+
+  return rows.map((r) => ({ ...r, owned: ownedKeys.has(r.item_key) }));
+}
+
+export function getShopItem(itemKey: string): SanctuaryCosmeticItem | null {
+  const db = getDatabase();
+  const row = db.prepare(
+    'SELECT * FROM sanctuary_cosmetic_items WHERE item_key = ?'
+  ).get(itemKey) as SanctuaryCosmeticItem | undefined;
+  return row ?? null;
+}
+
+export function getCompanionInventory(walletAddress: string): SanctuaryInventoryEntry[] {
+  const db = getDatabase();
+  return db.prepare(
+    'SELECT * FROM sanctuary_companion_inventory WHERE wallet_address = ? ORDER BY acquired_at DESC, id DESC'
+  ).all(walletAddress.toLowerCase()) as SanctuaryInventoryEntry[];
+}
+
+export function ownsCosmetic(walletAddress: string, itemKey: string): boolean {
+  const db = getDatabase();
+  const row = db.prepare(
+    'SELECT 1 as found FROM sanctuary_companion_inventory WHERE wallet_address = ? AND item_key = ? LIMIT 1'
+  ).get(walletAddress.toLowerCase(), itemKey) as { found: number } | undefined;
+  return !!row;
+}
+
+function getWalletLevel(database: Database.Database, walletAddress: string): number {
+  const row = database.prepare(
+    'SELECT COALESCE(level, 1) AS level FROM user_xp WHERE wallet_address = ?'
+  ).get(walletAddress.toLowerCase()) as { level: number } | undefined;
+  return row?.level ?? 1;
+}
+
+export interface BuyShopItemResult {
+  item: SanctuaryCosmeticItem;
+  balance: number;
+  lifetime_earned: number;
+  spent: number;
+}
+
+/**
+ * Buy a cosmetic item. Validates: item exists, level gate, not already owned,
+ * sufficient STAR balance. On success: deducts STAR via spendStar (which writes
+ * the ledger) and inserts an inventory row.
+ *
+ * Throws Error with codes: ITEM_NOT_FOUND, LEVEL_TOO_LOW, ALREADY_OWNED,
+ * "Insufficient STAR balance" (re-thrown from spendStar).
+ */
+export function buyShopItem(
+  walletAddress: string,
+  itemKey: string,
+): BuyShopItemResult {
+  const db = getDatabase();
+  const addr = walletAddress.toLowerCase();
+
+  const item = db.prepare(
+    'SELECT * FROM sanctuary_cosmetic_items WHERE item_key = ?'
+  ).get(itemKey) as SanctuaryCosmeticItem | undefined;
+  if (!item) throw new Error('ITEM_NOT_FOUND');
+
+  const level = getWalletLevel(db, addr);
+  if (level < item.level_required) {
+    throw new Error(`LEVEL_TOO_LOW:required=${item.level_required}:have=${level}`);
+  }
+
+  const already = db.prepare(
+    'SELECT 1 as found FROM sanctuary_companion_inventory WHERE wallet_address = ? AND item_key = ? LIMIT 1'
+  ).get(addr, itemKey) as { found: number } | undefined;
+  if (already) throw new Error('ALREADY_OWNED');
+
+  // spendStar runs its own transaction (deducts balance + writes ledger). The
+  // inventory insert runs after it succeeds; if the insert fails we re-credit.
+  const spendResult = spendStar(addr, item.star_cost, `shop:${itemKey}`);
+  try {
+    db.prepare(
+      'INSERT INTO sanctuary_companion_inventory (wallet_address, item_key, source) VALUES (?, ?, ?)'
+    ).run(addr, itemKey, 'shop');
+  } catch (e) {
+    // Roll back the STAR deduction by re-crediting the same amount via a raw
+    // ledger compensation. We don't use earnStar() because that clamps to the
+    // earn-rate band and the source isn't an earn source.
+    const txn = db.transaction(() => {
+      const cur = db.prepare(
+        'SELECT balance FROM sanctuary_star_balance WHERE wallet_address = ?'
+      ).get(addr) as { balance: number } | undefined;
+      const restored = (cur?.balance ?? 0) + item.star_cost;
+      db.prepare(
+        'UPDATE sanctuary_star_balance SET balance = ?, updated_at = CURRENT_TIMESTAMP WHERE wallet_address = ?'
+      ).run(restored, addr);
+      db.prepare(
+        'INSERT INTO sanctuary_star_ledger (wallet_address, delta, kind, source, balance_after) VALUES (?, ?, ?, ?, ?)'
+      ).run(addr, item.star_cost, 'earn', `refund:${itemKey}`, restored);
+    });
+    txn();
+    throw e;
+  }
+
+  return {
+    item,
+    balance: spendResult.balance,
+    lifetime_earned: spendResult.lifetime_earned,
+    spent: spendResult.spent,
+  };
+}
+
+export interface EquipCosmeticResult {
+  token_id: number;
+  equipped_cosmetics: Record<string, string | null>;
+}
+
+/**
+ * Equip (or unequip with itemKey === null) a cosmetic item on a companion.
+ * Validates: companion belongs to wallet, item is owned, item category matches
+ * a slot, and level gate. Only one item may be equipped per slot — equipping
+ * a new one swaps the old one out (no double-equip).
+ *
+ * Throws Error with codes: COMPANION_NOT_FOUND, ITEM_NOT_FOUND, NOT_OWNED,
+ * LEVEL_TOO_LOW, ALREADY_EQUIPPED.
+ */
+export function equipCosmetic(
+  walletAddress: string,
+  tokenId: number,
+  itemKey: string | null,
+  slot?: CosmeticCategory,
+): EquipCosmeticResult {
+  const db = getDatabase();
+  const addr = walletAddress.toLowerCase();
+
+  const companion = db.prepare(
+    'SELECT id, equipped_cosmetics FROM sanctuary_companions WHERE wallet_address = ? AND token_id = ?'
+  ).get(addr, tokenId) as { id: number; equipped_cosmetics: string | null } | undefined;
+  if (!companion) throw new Error('COMPANION_NOT_FOUND');
+
+  let equipped: Record<string, string | null> = {};
+  if (companion.equipped_cosmetics) {
+    try {
+      const parsed = JSON.parse(companion.equipped_cosmetics);
+      if (parsed && typeof parsed === 'object') equipped = parsed;
+    } catch { /* malformed — treat as empty */ }
+  }
+
+  if (itemKey === null) {
+    // Unequip: requires explicit slot.
+    if (!slot) throw new Error('SLOT_REQUIRED');
+    if (equipped[slot] === undefined || equipped[slot] === null) {
+      // No-op if nothing was equipped.
+      return { token_id: tokenId, equipped_cosmetics: equipped };
+    }
+    equipped[slot] = null;
+  } else {
+    const item = db.prepare(
+      'SELECT * FROM sanctuary_cosmetic_items WHERE item_key = ?'
+    ).get(itemKey) as SanctuaryCosmeticItem | undefined;
+    if (!item) throw new Error('ITEM_NOT_FOUND');
+
+    const owned = db.prepare(
+      'SELECT 1 as found FROM sanctuary_companion_inventory WHERE wallet_address = ? AND item_key = ? LIMIT 1'
+    ).get(addr, itemKey) as { found: number } | undefined;
+    if (!owned) throw new Error('NOT_OWNED');
+
+    const level = getWalletLevel(db, addr);
+    if (level < item.level_required) {
+      throw new Error(`LEVEL_TOO_LOW:required=${item.level_required}:have=${level}`);
+    }
+
+    const targetSlot = (slot ?? item.category) as CosmeticCategory;
+    if (equipped[targetSlot] === itemKey) {
+      throw new Error('ALREADY_EQUIPPED');
+    }
+    equipped[targetSlot] = itemKey;
+  }
+
+  db.prepare(
+    'UPDATE sanctuary_companions SET equipped_cosmetics = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?'
+  ).run(JSON.stringify(equipped), companion.id);
+
+  return { token_id: tokenId, equipped_cosmetics: equipped };
 }

--- a/lib/sanctuary/__tests__/api-e2e.test.ts
+++ b/lib/sanctuary/__tests__/api-e2e.test.ts
@@ -56,6 +56,13 @@ const db = vi.hoisted(() => ({
       starCapPerPlay: 10,
     },
   },
+  // Shop / Inventory (V2.2)
+  listShopItems: vi.fn(),
+  getShopItem: vi.fn(),
+  getCompanionInventory: vi.fn(),
+  buyShopItem: vi.fn(),
+  equipCosmetic: vi.fn(),
+  COSMETIC_CATEGORIES: ['hat', 'accessory', 'background', 'animation'],
 }));
 
 const walletAuth = vi.hoisted(() => ({
@@ -105,6 +112,10 @@ import { POST as completeActivityPOST } from '@/app/api/sanctuary/companion/comp
 import { GET as journalGET } from '@/app/api/sanctuary/companion/journal/route';
 import { POST as minigameScorePOST } from '@/app/api/sanctuary/minigame/score/route';
 import { GET as minigameLeaderboardGET } from '@/app/api/sanctuary/minigame/leaderboard/route';
+import { GET as shopItemsGET } from '@/app/api/sanctuary/shop/items/route';
+import { POST as shopBuyPOST } from '@/app/api/sanctuary/shop/buy/route';
+import { POST as inventoryEquipPOST } from '@/app/api/sanctuary/inventory/equip/route';
+import { GET as inventoryGET } from '@/app/api/sanctuary/inventory/route';
 
 // ─── Constants & helpers ────────────────────────────────────────────
 
@@ -1133,5 +1144,224 @@ describe('Flow: chat conversation', () => {
     expect(histRes.status).toBe(200);
     const hist = await histRes.json();
     expect(hist.messages).toHaveLength(2);
+  });
+});
+
+// =====================================================================
+// GET /api/sanctuary/shop/items
+// =====================================================================
+
+describe('GET /api/sanctuary/shop/items', () => {
+  it('returns full catalog when no filters', async () => {
+    db.listShopItems.mockReturnValue([
+      { item_key: 'hat_acorn_cap', category: 'hat', star_cost: 10, owned: false },
+      { item_key: 'acc_star_pendant', category: 'accessory', star_cost: 10, owned: false },
+    ]);
+    const res = await shopItemsGET(get('/api/sanctuary/shop/items'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.items).toHaveLength(2);
+    expect(db.listShopItems).toHaveBeenCalledWith({ category: undefined, walletAddress: undefined });
+  });
+
+  it('filters by category and includes ownership when address present', async () => {
+    db.listShopItems.mockReturnValue([
+      { item_key: 'hat_acorn_cap', category: 'hat', star_cost: 10, owned: true },
+    ]);
+    const res = await shopItemsGET(
+      get('/api/sanctuary/shop/items', { category: 'hat', address: ALICE }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.items[0].owned).toBe(true);
+    expect(db.listShopItems).toHaveBeenCalledWith({ category: 'hat', walletAddress: ALICE });
+  });
+
+  it('returns 400 for invalid category', async () => {
+    const res = await shopItemsGET(
+      get('/api/sanctuary/shop/items', { category: 'invalid' }),
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+// =====================================================================
+// POST /api/sanctuary/shop/buy
+// =====================================================================
+
+describe('POST /api/sanctuary/shop/buy', () => {
+  const ITEM = {
+    id: 1, item_key: 'hat_acorn_cap', name: 'Acorn Cap', category: 'hat', rarity: 'common',
+    star_cost: 10, level_required: 1, description: null, asset_key: 'hat_acorn_cap',
+    created_at: '2026-04-25',
+  };
+
+  it('successfully buys an item', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: true });
+    db.buyShopItem.mockReturnValue({ item: ITEM, balance: 90, lifetime_earned: 100, spent: 10 });
+    const res = await shopBuyPOST(
+      post('/api/sanctuary/shop/buy', { address: ALICE, item_key: 'hat_acorn_cap' }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.balance).toBe(90);
+    expect(body.spent).toBe(10);
+    expect(body.item.item_key).toBe('hat_acorn_cap');
+  });
+
+  it('returns 400 for invalid body', async () => {
+    const res = await shopBuyPOST(
+      post('/api/sanctuary/shop/buy', { address: ALICE }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 401 when wallet auth fails', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: false, error: 'bad sig' });
+    const res = await shopBuyPOST(
+      post('/api/sanctuary/shop/buy', { address: ALICE, item_key: 'hat_acorn_cap' }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 402 on insufficient balance', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: true });
+    db.buyShopItem.mockImplementation(() => { throw new Error('Insufficient STAR balance'); });
+    const res = await shopBuyPOST(
+      post('/api/sanctuary/shop/buy', { address: ALICE, item_key: 'hat_acorn_cap' }),
+    );
+    expect(res.status).toBe(402);
+  });
+
+  it('returns 404 when item not found', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: true });
+    db.buyShopItem.mockImplementation(() => { throw new Error('ITEM_NOT_FOUND'); });
+    const res = await shopBuyPOST(
+      post('/api/sanctuary/shop/buy', { address: ALICE, item_key: 'no_such_item' }),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 409 when item already owned', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: true });
+    db.buyShopItem.mockImplementation(() => { throw new Error('ALREADY_OWNED'); });
+    const res = await shopBuyPOST(
+      post('/api/sanctuary/shop/buy', { address: ALICE, item_key: 'hat_acorn_cap' }),
+    );
+    expect(res.status).toBe(409);
+  });
+
+  it('returns 422 when wallet level is too low', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: true });
+    db.buyShopItem.mockImplementation(() => { throw new Error('LEVEL_TOO_LOW:required=5:have=1'); });
+    const res = await shopBuyPOST(
+      post('/api/sanctuary/shop/buy', { address: ALICE, item_key: 'hat_witch_hat' }),
+    );
+    expect(res.status).toBe(422);
+  });
+});
+
+// =====================================================================
+// POST /api/sanctuary/inventory/equip
+// =====================================================================
+
+describe('POST /api/sanctuary/inventory/equip', () => {
+  it('equips an item successfully', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: true });
+    db.equipCosmetic.mockReturnValue({
+      token_id: TOKEN,
+      equipped_cosmetics: { hat: 'hat_acorn_cap' },
+    });
+    const res = await inventoryEquipPOST(
+      post('/api/sanctuary/inventory/equip', { address: ALICE, token_id: TOKEN, item_key: 'hat_acorn_cap' }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.equipped_cosmetics.hat).toBe('hat_acorn_cap');
+  });
+
+  it('unequips when item_key=null and slot provided', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: true });
+    db.equipCosmetic.mockReturnValue({ token_id: TOKEN, equipped_cosmetics: { hat: null } });
+    const res = await inventoryEquipPOST(
+      post('/api/sanctuary/inventory/equip', { address: ALICE, token_id: TOKEN, item_key: null, slot: 'hat' }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.equipped_cosmetics.hat).toBeNull();
+  });
+
+  it('returns 400 when unequipping without slot', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: true });
+    const res = await inventoryEquipPOST(
+      post('/api/sanctuary/inventory/equip', { address: ALICE, token_id: TOKEN, item_key: null }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 409 when already equipped', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: true });
+    db.equipCosmetic.mockImplementation(() => { throw new Error('ALREADY_EQUIPPED'); });
+    const res = await inventoryEquipPOST(
+      post('/api/sanctuary/inventory/equip', { address: ALICE, token_id: TOKEN, item_key: 'hat_acorn_cap' }),
+    );
+    expect(res.status).toBe(409);
+  });
+
+  it('returns 422 when item not owned', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: true });
+    db.equipCosmetic.mockImplementation(() => { throw new Error('NOT_OWNED'); });
+    const res = await inventoryEquipPOST(
+      post('/api/sanctuary/inventory/equip', { address: ALICE, token_id: TOKEN, item_key: 'hat_witch_hat' }),
+    );
+    expect(res.status).toBe(422);
+  });
+
+  it('returns 422 when level too low', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: true });
+    db.equipCosmetic.mockImplementation(() => { throw new Error('LEVEL_TOO_LOW:required=10:have=1'); });
+    const res = await inventoryEquipPOST(
+      post('/api/sanctuary/inventory/equip', { address: ALICE, token_id: TOKEN, item_key: 'hat_nebula_crown' }),
+    );
+    expect(res.status).toBe(422);
+  });
+
+  it('returns 404 when companion not found', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: true });
+    db.equipCosmetic.mockImplementation(() => { throw new Error('COMPANION_NOT_FOUND'); });
+    const res = await inventoryEquipPOST(
+      post('/api/sanctuary/inventory/equip', { address: ALICE, token_id: 999, item_key: 'hat_acorn_cap' }),
+    );
+    expect(res.status).toBe(404);
+  });
+});
+
+// =====================================================================
+// GET /api/sanctuary/inventory
+// =====================================================================
+
+describe('GET /api/sanctuary/inventory', () => {
+  it('returns owned items joined with catalog metadata', async () => {
+    db.getCompanionInventory.mockReturnValue([
+      { id: 1, wallet_address: ALICE, item_key: 'hat_acorn_cap', source: 'shop', acquired_at: '2026-04-25' },
+    ]);
+    db.getShopItem.mockReturnValue({
+      id: 1, item_key: 'hat_acorn_cap', name: 'Acorn Cap', category: 'hat', rarity: 'common',
+      star_cost: 10, level_required: 1, description: null, asset_key: 'hat_acorn_cap',
+      created_at: '2026-04-25',
+    });
+    const res = await inventoryGET(get('/api/sanctuary/inventory', { address: ALICE }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.items).toHaveLength(1);
+    expect(body.items[0].item_key).toBe('hat_acorn_cap');
+    expect(body.items[0].source).toBe('shop');
+  });
+
+  it('returns 400 when address missing', async () => {
+    const res = await inventoryGET(get('/api/sanctuary/inventory'));
+    expect(res.status).toBe(400);
   });
 });

--- a/lib/sanctuary/__tests__/shop.test.ts
+++ b/lib/sanctuary/__tests__/shop.test.ts
@@ -1,0 +1,402 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import fs from 'fs';
+import path from 'path';
+
+// Tests cover the shop catalog + buy + inventory + equip flows. They run
+// against an in-memory SQLite DB seeded with the V2.2 schema and replicate the
+// same SQL the helpers in `lib/db.ts` use, mirroring the pattern established
+// in `starCurrency.test.ts`.
+
+const ALICE = '0x' + 'a'.repeat(40);
+const TOKEN_ID = 3;
+
+interface BalanceRow { balance: number; lifetime_earned: number }
+interface ItemRow {
+  id: number;
+  item_key: string;
+  name: string;
+  category: string;
+  rarity: string;
+  star_cost: number;
+  level_required: number;
+  description: string | null;
+  asset_key: string;
+  created_at: string;
+}
+
+function loadSql(file: string): string {
+  return fs.readFileSync(path.join(process.cwd(), 'scripts', file), 'utf-8');
+}
+
+function createShopDb(): Database.Database {
+  const db = new Database(':memory:');
+  db.pragma('journal_mode = WAL');
+  db.pragma('foreign_keys = ON');
+
+  // Stand up minimal upstream tables so v1 sanctuary schema's FK on token_id
+  // and the user_xp lookup for level gating both resolve.
+  db.exec(`
+    CREATE TABLE star_skrumpey_metadata (
+      token_id INTEGER PRIMARY KEY,
+      name TEXT,
+      constellation TEXT,
+      aura TEXT,
+      form TEXT,
+      mood TEXT,
+      eyes TEXT,
+      background TEXT,
+      hat TEXT,
+      image_url TEXT,
+      rarity_rank INTEGER,
+      attributes_json TEXT
+    )
+  `);
+  db.exec(`
+    CREATE TABLE user_xp (
+      wallet_address TEXT PRIMARY KEY,
+      total_xp INTEGER DEFAULT 0,
+      level INTEGER DEFAULT 1
+    )
+  `);
+
+  db.exec(loadSql('init-sanctuary.sql'));
+  db.exec(loadSql('init-sanctuary-v2.1.sql'));
+  db.exec(loadSql('init-sanctuary-v2.2.sql'));
+
+  // Token + companion fixtures
+  db.prepare('INSERT INTO star_skrumpey_metadata (token_id, name) VALUES (?, ?)').run(TOKEN_ID, 'Star #3');
+  db.prepare(
+    "INSERT INTO sanctuary_companions (wallet_address, token_id, is_active, equipped_cosmetics) VALUES (?, ?, 1, '{}')"
+  ).run(ALICE, TOKEN_ID);
+
+  return db;
+}
+
+// Replicate the seed inserts (the lib/db seedSanctuaryCosmeticItems helper
+// requires the singleton DB; we inline it here so tests stay isolated).
+function seedItems(db: Database.Database): void {
+  const items: Array<[string, string, string, string, number, number, string]> = [
+    ['hat_acorn_cap', 'Acorn Cap', 'hat', 'common', 10, 1, 'hat_acorn_cap'],
+    ['hat_witch_hat', 'Witch Hat', 'hat', 'uncommon', 20, 3, 'hat_witch_hat'],
+    ['hat_nebula_crown', 'Nebula Crown', 'hat', 'legendary', 50, 10, 'hat_nebula_crown'],
+    ['acc_star_pendant', 'Star Pendant', 'accessory', 'common', 10, 1, 'acc_star_pendant'],
+    ['bg_starfield', 'Starfield', 'background', 'common', 10, 1, 'bg_starfield'],
+    ['anim_gentle_bob', 'Gentle Bob', 'animation', 'common', 10, 1, 'anim_gentle_bob'],
+  ];
+  const insert = db.prepare(`
+    INSERT INTO sanctuary_cosmetic_items
+      (item_key, name, category, rarity, star_cost, level_required, asset_key)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+  `);
+  for (const i of items) insert.run(...i);
+}
+
+function setBalance(db: Database.Database, addr: string, balance: number, lifetime?: number): void {
+  const lt = lifetime ?? balance;
+  db.prepare(
+    'INSERT OR REPLACE INTO sanctuary_star_balance (wallet_address, balance, lifetime_earned) VALUES (?, ?, ?)'
+  ).run(addr, balance, lt);
+}
+
+function setLevel(db: Database.Database, addr: string, level: number): void {
+  db.prepare(
+    'INSERT OR REPLACE INTO user_xp (wallet_address, total_xp, level) VALUES (?, 0, ?)'
+  ).run(addr, level);
+}
+
+// Replicates the spend logic used by `spendStar` in lib/db.ts.
+function spend(db: Database.Database, addr: string, amount: number, source: string): number {
+  return db.transaction(() => {
+    const row = db.prepare(
+      'SELECT balance FROM sanctuary_star_balance WHERE wallet_address = ?'
+    ).get(addr) as { balance: number } | undefined;
+    const cur = row?.balance ?? 0;
+    if (cur < amount) throw new Error('Insufficient STAR balance');
+    const newBal = cur - amount;
+    db.prepare(
+      'UPDATE sanctuary_star_balance SET balance = ?, updated_at = CURRENT_TIMESTAMP WHERE wallet_address = ?'
+    ).run(newBal, addr);
+    db.prepare(
+      'INSERT INTO sanctuary_star_ledger (wallet_address, delta, kind, source, balance_after) VALUES (?, ?, ?, ?, ?)'
+    ).run(addr, -amount, 'spend', source, newBal);
+    return newBal;
+  })();
+}
+
+function buy(db: Database.Database, addr: string, itemKey: string): { item: ItemRow; balance: number } {
+  const item = db.prepare(
+    'SELECT * FROM sanctuary_cosmetic_items WHERE item_key = ?'
+  ).get(itemKey) as ItemRow | undefined;
+  if (!item) throw new Error('ITEM_NOT_FOUND');
+
+  const lvl = (db.prepare('SELECT COALESCE(level, 1) AS level FROM user_xp WHERE wallet_address = ?').get(addr) as { level: number } | undefined)?.level ?? 1;
+  if (lvl < item.level_required) throw new Error(`LEVEL_TOO_LOW:required=${item.level_required}:have=${lvl}`);
+
+  const owned = db.prepare(
+    'SELECT 1 as found FROM sanctuary_companion_inventory WHERE wallet_address = ? AND item_key = ? LIMIT 1'
+  ).get(addr, itemKey) as { found: number } | undefined;
+  if (owned) throw new Error('ALREADY_OWNED');
+
+  const balance = spend(db, addr, item.star_cost, `shop:${itemKey}`);
+  db.prepare(
+    'INSERT INTO sanctuary_companion_inventory (wallet_address, item_key, source) VALUES (?, ?, ?)'
+  ).run(addr, itemKey, 'shop');
+
+  return { item, balance };
+}
+
+function equip(
+  db: Database.Database,
+  addr: string,
+  tokenId: number,
+  itemKey: string | null,
+  slot?: string,
+): Record<string, string | null> {
+  const comp = db.prepare(
+    'SELECT id, equipped_cosmetics FROM sanctuary_companions WHERE wallet_address = ? AND token_id = ?'
+  ).get(addr, tokenId) as { id: number; equipped_cosmetics: string | null } | undefined;
+  if (!comp) throw new Error('COMPANION_NOT_FOUND');
+
+  let equipped: Record<string, string | null> = {};
+  try {
+    const parsed = comp.equipped_cosmetics ? JSON.parse(comp.equipped_cosmetics) : {};
+    if (parsed && typeof parsed === 'object') equipped = parsed;
+  } catch { /* ignore */ }
+
+  if (itemKey === null) {
+    if (!slot) throw new Error('SLOT_REQUIRED');
+    equipped[slot] = null;
+  } else {
+    const item = db.prepare(
+      'SELECT * FROM sanctuary_cosmetic_items WHERE item_key = ?'
+    ).get(itemKey) as ItemRow | undefined;
+    if (!item) throw new Error('ITEM_NOT_FOUND');
+    const owned = db.prepare(
+      'SELECT 1 as found FROM sanctuary_companion_inventory WHERE wallet_address = ? AND item_key = ? LIMIT 1'
+    ).get(addr, itemKey) as { found: number } | undefined;
+    if (!owned) throw new Error('NOT_OWNED');
+
+    const lvl = (db.prepare('SELECT COALESCE(level, 1) AS level FROM user_xp WHERE wallet_address = ?').get(addr) as { level: number } | undefined)?.level ?? 1;
+    if (lvl < item.level_required) throw new Error(`LEVEL_TOO_LOW:required=${item.level_required}:have=${lvl}`);
+
+    const target = slot ?? item.category;
+    if (equipped[target] === itemKey) throw new Error('ALREADY_EQUIPPED');
+    equipped[target] = itemKey;
+  }
+
+  db.prepare(
+    'UPDATE sanctuary_companions SET equipped_cosmetics = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?'
+  ).run(JSON.stringify(equipped), comp.id);
+  return equipped;
+}
+
+// =====================================================================
+
+describe('shop catalog schema', () => {
+  let db: Database.Database;
+  beforeEach(() => { db = createShopDb(); });
+
+  it('creates cosmetic_items and companion_inventory tables', () => {
+    const tables = db.prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'sanctuary_%'"
+    ).all() as { name: string }[];
+    const names = tables.map((t) => t.name);
+    expect(names).toContain('sanctuary_cosmetic_items');
+    expect(names).toContain('sanctuary_companion_inventory');
+  });
+
+  it('enforces category check constraint', () => {
+    expect(() => {
+      db.prepare(
+        'INSERT INTO sanctuary_cosmetic_items (item_key, name, category, star_cost, asset_key) VALUES (?, ?, ?, ?, ?)'
+      ).run('bogus', 'Bogus', 'invalid_cat', 10, 'bogus');
+    }).toThrow();
+  });
+
+  it('enforces unique item_key', () => {
+    db.prepare(
+      'INSERT INTO sanctuary_cosmetic_items (item_key, name, category, star_cost, asset_key) VALUES (?, ?, ?, ?, ?)'
+    ).run('hat_one', 'One', 'hat', 10, 'hat_one');
+    expect(() => {
+      db.prepare(
+        'INSERT INTO sanctuary_cosmetic_items (item_key, name, category, star_cost, asset_key) VALUES (?, ?, ?, ?, ?)'
+      ).run('hat_one', 'Dup', 'hat', 20, 'hat_one');
+    }).toThrow();
+  });
+
+  it('enforces unique (wallet, item_key) on inventory', () => {
+    db.prepare(
+      'INSERT INTO sanctuary_cosmetic_items (item_key, name, category, star_cost, asset_key) VALUES (?, ?, ?, ?, ?)'
+    ).run('hat_one', 'One', 'hat', 10, 'hat_one');
+    db.prepare(
+      'INSERT INTO sanctuary_companion_inventory (wallet_address, item_key, source) VALUES (?, ?, ?)'
+    ).run(ALICE, 'hat_one', 'shop');
+    expect(() => {
+      db.prepare(
+        'INSERT INTO sanctuary_companion_inventory (wallet_address, item_key, source) VALUES (?, ?, ?)'
+      ).run(ALICE, 'hat_one', 'shop');
+    }).toThrow();
+  });
+});
+
+describe('shop buy flow', () => {
+  let db: Database.Database;
+  beforeEach(() => {
+    db = createShopDb();
+    seedItems(db);
+    setLevel(db, ALICE, 5);
+    setBalance(db, ALICE, 100);
+  });
+
+  it('debits STAR, writes ledger, and adds inventory row', () => {
+    const result = buy(db, ALICE, 'hat_acorn_cap');
+    expect(result.item.star_cost).toBe(10);
+    expect(result.balance).toBe(90);
+
+    const bal = db.prepare(
+      'SELECT balance, lifetime_earned FROM sanctuary_star_balance WHERE wallet_address = ?'
+    ).get(ALICE) as BalanceRow;
+    expect(bal.balance).toBe(90);
+    expect(bal.lifetime_earned).toBe(100);
+
+    const ledger = db.prepare(
+      "SELECT * FROM sanctuary_star_ledger WHERE wallet_address = ? AND kind = 'spend'"
+    ).all(ALICE) as Array<{ delta: number; source: string }>;
+    expect(ledger.length).toBe(1);
+    expect(ledger[0].delta).toBe(-10);
+    expect(ledger[0].source).toBe('shop:hat_acorn_cap');
+
+    const inv = db.prepare(
+      'SELECT item_key FROM sanctuary_companion_inventory WHERE wallet_address = ?'
+    ).all(ALICE) as Array<{ item_key: string }>;
+    expect(inv.map((r) => r.item_key)).toEqual(['hat_acorn_cap']);
+  });
+
+  it('rejects when balance is insufficient and leaves balance unchanged', () => {
+    setBalance(db, ALICE, 5);
+    expect(() => buy(db, ALICE, 'hat_acorn_cap')).toThrow(/Insufficient/);
+    const bal = db.prepare('SELECT balance FROM sanctuary_star_balance WHERE wallet_address = ?').get(ALICE) as BalanceRow;
+    expect(bal.balance).toBe(5);
+
+    const inv = db.prepare(
+      'SELECT 1 as f FROM sanctuary_companion_inventory WHERE wallet_address = ? AND item_key = ?'
+    ).get(ALICE, 'hat_acorn_cap');
+    expect(inv).toBeUndefined();
+  });
+
+  it('blocks repurchase of an already-owned item', () => {
+    buy(db, ALICE, 'hat_acorn_cap');
+    expect(() => buy(db, ALICE, 'hat_acorn_cap')).toThrow(/ALREADY_OWNED/);
+    const count = (db.prepare(
+      'SELECT COUNT(*) as c FROM sanctuary_companion_inventory WHERE wallet_address = ?'
+    ).get(ALICE) as { c: number }).c;
+    expect(count).toBe(1);
+  });
+
+  it('enforces level_required gating', () => {
+    setLevel(db, ALICE, 2); // Witch Hat needs level 3
+    setBalance(db, ALICE, 100);
+    expect(() => buy(db, ALICE, 'hat_witch_hat')).toThrow(/LEVEL_TOO_LOW/);
+    // No STAR debited on level reject
+    const bal = db.prepare('SELECT balance FROM sanctuary_star_balance WHERE wallet_address = ?').get(ALICE) as BalanceRow;
+    expect(bal.balance).toBe(100);
+  });
+
+  it('rejects unknown items', () => {
+    expect(() => buy(db, ALICE, 'not_a_real_item')).toThrow(/ITEM_NOT_FOUND/);
+  });
+});
+
+describe('shop equip flow', () => {
+  let db: Database.Database;
+  beforeEach(() => {
+    db = createShopDb();
+    seedItems(db);
+    setLevel(db, ALICE, 5);
+    setBalance(db, ALICE, 100);
+    buy(db, ALICE, 'hat_acorn_cap');
+    buy(db, ALICE, 'acc_star_pendant');
+    buy(db, ALICE, 'bg_starfield');
+  });
+
+  it('writes the item to the matching slot', () => {
+    const eq = equip(db, ALICE, TOKEN_ID, 'hat_acorn_cap');
+    expect(eq.hat).toBe('hat_acorn_cap');
+
+    const stored = db.prepare(
+      'SELECT equipped_cosmetics FROM sanctuary_companions WHERE wallet_address = ? AND token_id = ?'
+    ).get(ALICE, TOKEN_ID) as { equipped_cosmetics: string };
+    expect(JSON.parse(stored.equipped_cosmetics).hat).toBe('hat_acorn_cap');
+  });
+
+  it('rejects equipping an item the wallet does not own', () => {
+    expect(() => equip(db, ALICE, TOKEN_ID, 'hat_witch_hat')).toThrow(/NOT_OWNED/);
+  });
+
+  it('blocks equipping the same item twice into the same slot', () => {
+    equip(db, ALICE, TOKEN_ID, 'hat_acorn_cap');
+    expect(() => equip(db, ALICE, TOKEN_ID, 'hat_acorn_cap')).toThrow(/ALREADY_EQUIPPED/);
+  });
+
+  it('allows swapping items in the same slot when wallet owns both', () => {
+    // Buy a second hat with proper level (already 5)
+    db.prepare(
+      'INSERT INTO sanctuary_cosmetic_items (item_key, name, category, rarity, star_cost, level_required, asset_key) VALUES (?, ?, ?, ?, ?, ?, ?)'
+    ).run('hat_blue', 'Blue Cap', 'hat', 'common', 10, 1, 'hat_blue');
+    setBalance(db, ALICE, 100);
+    buy(db, ALICE, 'hat_blue');
+
+    equip(db, ALICE, TOKEN_ID, 'hat_acorn_cap');
+    const eq = equip(db, ALICE, TOKEN_ID, 'hat_blue');
+    expect(eq.hat).toBe('hat_blue');
+  });
+
+  it('supports unequip with item_key=null + slot', () => {
+    equip(db, ALICE, TOKEN_ID, 'hat_acorn_cap');
+    const eq = equip(db, ALICE, TOKEN_ID, null, 'hat');
+    expect(eq.hat).toBeNull();
+  });
+
+  it('keeps slots independent (equipping hat does not touch accessory)', () => {
+    equip(db, ALICE, TOKEN_ID, 'hat_acorn_cap');
+    const eq = equip(db, ALICE, TOKEN_ID, 'acc_star_pendant');
+    expect(eq.hat).toBe('hat_acorn_cap');
+    expect(eq.accessory).toBe('acc_star_pendant');
+  });
+
+  it('supports background and animation slots', () => {
+    setBalance(db, ALICE, 100);
+    buy(db, ALICE, 'anim_gentle_bob');
+    const eq1 = equip(db, ALICE, TOKEN_ID, 'bg_starfield');
+    expect(eq1.background).toBe('bg_starfield');
+    const eq2 = equip(db, ALICE, TOKEN_ID, 'anim_gentle_bob');
+    expect(eq2.animation).toBe('anim_gentle_bob');
+  });
+});
+
+describe('shop catalog query', () => {
+  let db: Database.Database;
+  beforeEach(() => {
+    db = createShopDb();
+    seedItems(db);
+  });
+
+  it('sorts items by price within a category', () => {
+    const rows = db.prepare(
+      "SELECT item_key, star_cost FROM sanctuary_cosmetic_items WHERE category = 'hat' ORDER BY star_cost ASC"
+    ).all() as Array<{ item_key: string; star_cost: number }>;
+    expect(rows[0].item_key).toBe('hat_acorn_cap');
+    expect(rows[rows.length - 1].item_key).toBe('hat_nebula_crown');
+    for (let i = 1; i < rows.length; i++) {
+      expect(rows[i].star_cost).toBeGreaterThanOrEqual(rows[i - 1].star_cost);
+    }
+  });
+});
+
+describe('seeded shop catalog (V2.2 lib helpers)', () => {
+  it('exports the expected COSMETIC_CATEGORIES list', async () => {
+    const { COSMETIC_CATEGORIES } = await import('@/lib/db');
+    expect([...COSMETIC_CATEGORIES]).toEqual(['hat', 'accessory', 'background', 'animation']);
+  });
+});

--- a/lib/sanctuary/rateLimit.ts
+++ b/lib/sanctuary/rateLimit.ts
@@ -17,6 +17,8 @@ const LIMITS: Record<string, RateLimitConfig> = {
   'companion/chat': { maxRequests: 30, windowSeconds: 60 },
   'quests/claim': { maxRequests: 10, windowSeconds: 60 },
   'minigame/score': { maxRequests: 30, windowSeconds: 60 },
+  'shop/buy': { maxRequests: 20, windowSeconds: 60 },
+  'inventory/equip': { maxRequests: 30, windowSeconds: 60 },
 };
 
 let cleanupCounter = 0;

--- a/scripts/init-sanctuary-v2.2.sql
+++ b/scripts/init-sanctuary-v2.2.sql
@@ -1,0 +1,43 @@
+-- Star Sanctuary — V2.2 Schema: Cosmetic shop + companion inventory
+-- Run from lib/db.ts initializeSanctuary()
+--
+-- Adds two tables that, together with sanctuary_star_balance (V2.1) and the
+-- equipped_cosmetics JSON column on sanctuary_companions (V1), implement the
+-- cosmetic shop loop:
+--   1. sanctuary_cosmetic_items  — catalog of buyable items (seeded)
+--   2. sanctuary_companion_inventory — per-wallet ownership of catalog items
+--
+-- Equip state continues to live on sanctuary_companions.equipped_cosmetics so
+-- two companions on the same wallet can wear different items from the shared
+-- inventory.
+
+CREATE TABLE IF NOT EXISTS sanctuary_cosmetic_items (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  item_key TEXT NOT NULL UNIQUE,
+  name TEXT NOT NULL,
+  category TEXT NOT NULL CHECK (category IN ('hat', 'accessory', 'background', 'animation')),
+  rarity TEXT NOT NULL DEFAULT 'common' CHECK (rarity IN ('common', 'uncommon', 'rare', 'legendary')),
+  star_cost INTEGER NOT NULL CHECK (star_cost >= 0),
+  level_required INTEGER NOT NULL DEFAULT 1 CHECK (level_required >= 1),
+  description TEXT,
+  asset_key TEXT NOT NULL,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_sanctuary_cosmetic_items_category
+  ON sanctuary_cosmetic_items(category, star_cost);
+
+-- Per-wallet inventory of owned cosmetic items. Items are wallet-scoped so
+-- the holder can equip them on any of their companions.
+CREATE TABLE IF NOT EXISTS sanctuary_companion_inventory (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  wallet_address TEXT NOT NULL,
+  item_key TEXT NOT NULL,
+  source TEXT NOT NULL DEFAULT 'shop' CHECK (source IN ('shop', 'quest', 'event', 'achievement', 'gift')),
+  acquired_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE(wallet_address, item_key),
+  FOREIGN KEY (item_key) REFERENCES sanctuary_cosmetic_items(item_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_sanctuary_inventory_wallet
+  ON sanctuary_companion_inventory(wallet_address, acquired_at DESC);


### PR DESCRIPTION
## Summary

Implements **[SWO_V2_SHOP_BACKEND]** — the cosmetic shop, inventory, and equip endpoints that complete the V2 STAR-currency economy loop on top of the existing V2.1 STAR ledger.

### Schema (`scripts/init-sanctuary-v2.2.sql`)
- `sanctuary_cosmetic_items` — catalog of buyable cosmetics with `category` (hat / accessory / background / animation), `rarity`, `star_cost`, `level_required`, `asset_key`
- `sanctuary_companion_inventory` — per-wallet ownership (UNIQUE on `wallet_address + item_key` to prevent double-ownership)

### Seed (24 items via `seedSanctuaryCosmeticItems`)
Six items per category, priced **10–50 STAR**, with rarity-aligned level requirements:
- **Hats**: Acorn Cap, Star Beanie, Witch Hat, Gold Crown, Cosmic Halo, Nebula Crown
- **Accessories**: Star Pendant, Comet Scarf, Moon Glasses, Aura Ribbon, Nebula Collar, Eclipse Pendant
- **Backgrounds**: Starfield, Soft Aurora, Cosmic Dawn, Stellar Meadow, Nebula Drift, Galaxy Swirl
- **Animations**: Gentle Bob, Star Sparkle, Moon Glow, Comet Trail, Aurora Dance, Constellation Burst

### Routes
| Method | Path | Auth | Purpose |
|---|---|---|---|
| GET  | `/api/sanctuary/shop/items` | — | Catalog (category filter, price-sorted, ownership flag if `address` query) |
| POST | `/api/sanctuary/shop/buy` | wallet | Validate item + level + ownership → `spendStar()` → insert inventory |
| GET  | `/api/sanctuary/inventory` | — | Owned items + catalog metadata |
| POST | `/api/sanctuary/inventory/equip` | wallet | Slot-based equip/unequip, writes to `sanctuary_companions.equipped_cosmetics` JSON |

### Status code map
| Code | Buy | Equip |
|---|---|---|
| 400 | invalid body | invalid body / unequip without slot |
| 401 | bad wallet sig | bad wallet sig |
| 402 | Insufficient STAR balance | — |
| 404 | ITEM_NOT_FOUND | COMPANION_NOT_FOUND / ITEM_NOT_FOUND |
| 409 | ALREADY_OWNED | ALREADY_EQUIPPED |
| 422 | LEVEL_TOO_LOW | LEVEL_TOO_LOW / NOT_OWNED |
| 429 | rate limited | rate limited |

### Atomicity
`buyShopItem` calls `spendStar()` (which is transaction-wrapped) and then inserts the inventory row. If the inventory insert fails, a compensating ledger entry re-credits the same amount so the wallet is never debited without receiving the item.

### Rate limits
Added to `lib/sanctuary/rateLimit.ts`:
- `shop/buy`: 20 req/min
- `inventory/equip`: 30 req/min

### Tests (37 new)
- **`lib/sanctuary/__tests__/shop.test.ts`** (18 tests): SQL/transaction-level — schema constraints, buy flow (success / insufficient balance / double-buy / level gate / unknown item), equip flow (slot writes / not-owned / double-equip / swap / unequip / slot independence / 4-slot support), price-sort
- **`lib/sanctuary/__tests__/api-e2e.test.ts`** (19 tests): Mocked Next route handlers — every status code path for `/shop/items`, `/shop/buy`, `/inventory/equip`, `/inventory`

### Test results
- **shop.test.ts**: 18/18 pass
- **api-e2e.test.ts** (shop+equip+inventory subset): 19/19 pass
- **Full suite**: 416 passed / 5 pre-existing failures (roomScene v3 game test, nft-traits, chat history limit, interact action — all unrelated to this PR)
- **type-check**: 0 errors
- **lint** (changed files): 0 errors (5 pre-existing warnings in `lib/db.ts` outside of changes)

## Mirror Validation (PROD)
- **tsc --noEmit**: SKIPPED — PROD mirror is at v1.5 sanctuary schema only; missing prerequisite modules (`lib/sanctuary/rateLimit.ts`, `lib/walletAuth.ts` shape, V2.0/V2.1 SQL, V2 sanctuary routes). PROD baseline is clean (exit 0); overlay would surface many pre-existing missing-module errors that the baseline-diff gate will correctly attribute to PROD.
- PROD restored byte-identical after baseline check.

## Test plan
- [x] SQL constraints (category check, unique item_key, unique wallet+item)
- [x] Atomic STAR debit + inventory insert
- [x] Insufficient balance → 402, no debit, no inventory row
- [x] Double-buy → 409
- [x] Level gating → 422 (no debit)
- [x] Slot-based equip with all 4 categories
- [x] Double-equip → 409
- [x] Swap items in same slot
- [x] Unequip with `item_key=null` + slot
- [x] Wallet auth required for buy + equip
- [x] Rate limits configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)