### PR TITLE
feat(sanctuary): seed 5 daily errands + 3 weekly adventures via JSON

### DIFF
--- a/data/sanctuary/quests.json
+++ b/data/sanctuary/quests.json
@@ -1,0 +1,88 @@
+{
+  "$comment": "Sanctuary quest seed data. Maps to the sanctuary_quests SQLite table (see scripts/init-sanctuary-v1.5.sql and lib/db.ts). The requirement_type field maps to an NPC source via game/config/questSourceMap.ts; that source resolves to NPC name + zone + room defined in game/config/npcDefinitions.ts (V2) and game/v3/config/npcDefinitionsV3.ts (V3). The same rows drive the QuestDialog overlay for both renderers.",
+  "season": "spring-2026",
+  "daily_quests": [
+    {
+      "title": "Sunrise Watch",
+      "description": "Astris is charting dawn-light over the lattice. Visit the Observatory to log a sunrise reading.",
+      "quest_type": "daily",
+      "requirement_type": "observatory",
+      "requirement_count": 1,
+      "reward_xp": 15,
+      "reward_bond": 1.0,
+      "reward_trait": null
+    },
+    {
+      "title": "Morning Steam",
+      "description": "Ember keeps the Hot Springs at the perfect simmer. Soak with your companion to start the day warm.",
+      "quest_type": "daily",
+      "requirement_type": "springs",
+      "requirement_count": 1,
+      "reward_xp": 15,
+      "reward_bond": 1.0,
+      "reward_trait": null
+    },
+    {
+      "title": "Daily Drill",
+      "description": "Valor wants every Skrumpey to break a sweat. Run a single drill at the Training Grounds.",
+      "quest_type": "daily",
+      "requirement_type": "training",
+      "requirement_count": 1,
+      "reward_xp": 15,
+      "reward_bond": 1.0,
+      "reward_trait": null
+    },
+    {
+      "title": "Pantry Run",
+      "description": "Chef Cosmo needs a taster for today's special. Pop into the Nebula Kitchen for a sample.",
+      "quest_type": "daily",
+      "requirement_type": "kitchen",
+      "requirement_count": 1,
+      "reward_xp": 15,
+      "reward_bond": 1.0,
+      "reward_trait": null
+    },
+    {
+      "title": "Stacks Patrol",
+      "description": "The Lorekeeper noticed a few books out of place. Browse the Cosmic Library to help reshelve.",
+      "quest_type": "daily",
+      "requirement_type": "library",
+      "requirement_count": 1,
+      "reward_xp": 15,
+      "reward_bond": 1.0,
+      "reward_trait": null
+    }
+  ],
+  "weekly_quests": [
+    {
+      "title": "Trial by Fire",
+      "description": "Pyrix is tempering a new alloy and needs help working the bellows. Visit the Aura Forge five times this week.",
+      "quest_type": "weekly",
+      "requirement_type": "forge",
+      "requirement_count": 5,
+      "reward_xp": 90,
+      "reward_bond": 7.0,
+      "reward_trait": "Ironheart"
+    },
+    {
+      "title": "Lullaby Marathon",
+      "description": "Somnia is mapping the slow tides of sleep. Drop by Dream Hollow five times to dream alongside her.",
+      "quest_type": "weekly",
+      "requirement_type": "dream",
+      "requirement_count": 5,
+      "reward_xp": 80,
+      "reward_bond": 6.0,
+      "reward_trait": "Dreamwalker"
+    },
+    {
+      "title": "Botanical Survey",
+      "description": "Flora is cataloguing star-blooms before the seasonal fade. Help survey the Star Garden five times this week.",
+      "quest_type": "weekly",
+      "requirement_type": "garden",
+      "requirement_count": 5,
+      "reward_xp": 70,
+      "reward_bond": 5.0,
+      "reward_trait": "Greenthumb"
+    }
+  ]
+}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -7370,26 +7370,69 @@ export interface SanctuaryQuestProgress {
 
 export type QuestWithProgress = SanctuaryQuest & { progress: SanctuaryQuestProgress | null };
 
+interface QuestSeed {
+  season: string;
+  title: string;
+  description: string;
+  quest_type: string;
+  requirement_type: string;
+  requirement_count: number;
+  reward_xp: number;
+  reward_bond: number;
+  reward_trait: string | null;
+}
+
+const SEASONAL_QUEST_SEEDS: QuestSeed[] = [
+  { season: 'spring-2026', title: 'First Steps', description: 'Interact with your companion 5 times.', quest_type: 'seasonal', requirement_type: 'interact', requirement_count: 5, reward_xp: 25, reward_bond: 2.0, reward_trait: null },
+  { season: 'spring-2026', title: 'Cosmic Cuisine', description: 'Feed your Skrumpey 10 times.', quest_type: 'seasonal', requirement_type: 'feed', requirement_count: 10, reward_xp: 50, reward_bond: 5.0, reward_trait: null },
+  { season: 'spring-2026', title: 'Explorer\'s Spirit', description: 'Send your companion on 5 activities.', quest_type: 'seasonal', requirement_type: 'explore', requirement_count: 5, reward_xp: 40, reward_bond: 3.0, reward_trait: null },
+  { season: 'spring-2026', title: 'Heart to Heart', description: 'Chat with your Skrumpey 15 times.', quest_type: 'seasonal', requirement_type: 'chat', requirement_count: 15, reward_xp: 60, reward_bond: 4.0, reward_trait: 'Chatterbox' },
+  { season: 'spring-2026', title: 'Stargazer\'s Vigil', description: 'Visit the Observatory 3 times.', quest_type: 'seasonal', requirement_type: 'observatory', requirement_count: 3, reward_xp: 35, reward_bond: 3.5, reward_trait: null },
+  { season: 'spring-2026', title: 'Warm Welcome', description: 'Relax in the Hot Springs 5 times.', quest_type: 'seasonal', requirement_type: 'springs', requirement_count: 5, reward_xp: 30, reward_bond: 2.5, reward_trait: null },
+  { season: 'spring-2026', title: 'Bonded', description: 'Reach 50 bond score with your companion.', quest_type: 'seasonal', requirement_type: 'bond_threshold', requirement_count: 50, reward_xp: 100, reward_bond: 0, reward_trait: 'Loyal Companion' },
+  { season: 'spring-2026', title: 'Daily Devotion', description: 'Interact with your companion 3 days in a row.', quest_type: 'weekly', requirement_type: 'daily_streak', requirement_count: 3, reward_xp: 30, reward_bond: 2.0, reward_trait: null },
+];
+
+function loadQuestSeedsFromJson(): QuestSeed[] {
+  try {
+    const seedPath = path.join(process.cwd(), 'data', 'sanctuary', 'quests.json');
+    if (!fs.existsSync(seedPath)) return [];
+    const raw = JSON.parse(fs.readFileSync(seedPath, 'utf8')) as {
+      season?: string;
+      daily_quests?: Partial<QuestSeed>[];
+      weekly_quests?: Partial<QuestSeed>[];
+    };
+    const defaultSeason = raw.season ?? 'spring-2026';
+    const fromGroup = (group: Partial<QuestSeed>[] | undefined): QuestSeed[] =>
+      (group ?? []).map((q) => ({
+        season: q.season ?? defaultSeason,
+        title: String(q.title ?? ''),
+        description: String(q.description ?? ''),
+        quest_type: String(q.quest_type ?? 'daily'),
+        requirement_type: String(q.requirement_type ?? 'interact'),
+        requirement_count: Number(q.requirement_count ?? 1),
+        reward_xp: Number(q.reward_xp ?? 0),
+        reward_bond: Number(q.reward_bond ?? 0),
+        reward_trait: q.reward_trait ?? null,
+      }));
+    return [...fromGroup(raw.daily_quests), ...fromGroup(raw.weekly_quests)];
+  } catch {
+    return [];
+  }
+}
+
 function seedSanctuaryQuests(database: Database.Database): void {
-  const count = (database.prepare('SELECT COUNT(*) as count FROM sanctuary_quests').get() as { count: number }).count;
-  if (count > 0) return;
+  const allSeeds: QuestSeed[] = [...SEASONAL_QUEST_SEEDS, ...loadQuestSeedsFromJson()];
 
-  const quests = [
-    { season: 'spring-2026', title: 'First Steps', description: 'Interact with your companion 5 times.', quest_type: 'seasonal', requirement_type: 'interact', requirement_count: 5, reward_xp: 25, reward_bond: 2.0, reward_trait: null },
-    { season: 'spring-2026', title: 'Cosmic Cuisine', description: 'Feed your Skrumpey 10 times.', quest_type: 'seasonal', requirement_type: 'feed', requirement_count: 10, reward_xp: 50, reward_bond: 5.0, reward_trait: null },
-    { season: 'spring-2026', title: 'Explorer\'s Spirit', description: 'Send your companion on 5 activities.', quest_type: 'seasonal', requirement_type: 'explore', requirement_count: 5, reward_xp: 40, reward_bond: 3.0, reward_trait: null },
-    { season: 'spring-2026', title: 'Heart to Heart', description: 'Chat with your Skrumpey 15 times.', quest_type: 'seasonal', requirement_type: 'chat', requirement_count: 15, reward_xp: 60, reward_bond: 4.0, reward_trait: 'Chatterbox' },
-    { season: 'spring-2026', title: 'Stargazer\'s Vigil', description: 'Visit the Observatory 3 times.', quest_type: 'seasonal', requirement_type: 'observatory', requirement_count: 3, reward_xp: 35, reward_bond: 3.5, reward_trait: null },
-    { season: 'spring-2026', title: 'Warm Welcome', description: 'Relax in the Hot Springs 5 times.', quest_type: 'seasonal', requirement_type: 'springs', requirement_count: 5, reward_xp: 30, reward_bond: 2.5, reward_trait: null },
-    { season: 'spring-2026', title: 'Bonded', description: 'Reach 50 bond score with your companion.', quest_type: 'seasonal', requirement_type: 'bond_threshold', requirement_count: 50, reward_xp: 100, reward_bond: 0, reward_trait: 'Loyal Companion' },
-    { season: 'spring-2026', title: 'Daily Devotion', description: 'Interact with your companion 3 days in a row.', quest_type: 'weekly', requirement_type: 'daily_streak', requirement_count: 3, reward_xp: 30, reward_bond: 2.0, reward_trait: null },
-  ];
-
+  const exists = database.prepare(
+    'SELECT id FROM sanctuary_quests WHERE season = ? AND title = ?'
+  );
   const insert = database.prepare(`
     INSERT INTO sanctuary_quests (season, title, description, quest_type, requirement_type, requirement_count, reward_xp, reward_bond, reward_trait)
     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
   `);
-  for (const q of quests) {
+  for (const q of allSeeds) {
+    if (exists.get(q.season, q.title)) continue;
     insert.run(q.season, q.title, q.description, q.quest_type, q.requirement_type, q.requirement_count, q.reward_xp, q.reward_bond, q.reward_trait);
   }
 }


### PR DESCRIPTION
## Summary
- Adds `data/sanctuary/quests.json` as the canonical content source for sanctuary quest content (5 daily errands + 3 weekly adventures), aligned to the `sanctuary_quests` schema.
- Refactors `seedSanctuaryQuests` in `lib/db.ts` to merge JSON content with the in-code seasonal seeds idempotently (skip by `season + title`), so existing DBs backfill the new rows without duplicates.
- Same data drives both V2 (`game/config/npcDefinitions.ts`) and V3 (`game/v3/config/npcDefinitionsV3.ts`) renderers via `questSourceMap.ts` → QuestDialog overlay.

## Quest content
**Daily errands** (1-visit, 15 XP / 1.0 bond each):
- Sunrise Watch → `observatory` (Astris)
- Morning Steam → `springs` (Ember)
- Daily Drill → `training` (Valor)
- Pantry Run → `kitchen` (Chef Cosmo)
- Stacks Patrol → `library` (Lorekeeper)

**Weekly adventures** (5-visit, scaling XP/bond + trait):
- Trial by Fire → `forge` (Pyrix) — 90 XP, 7.0 bond, trait `Ironheart`
- Lullaby Marathon → `dream` (Somnia) — 80 XP, 6.0 bond, trait `Dreamwalker`
- Botanical Survey → `garden` (Flora) — 70 XP, 5.0 bond, trait `Greenthumb`

Combined with the existing seasonal seeds, every NPC mapped in `questSourceMap.ts` now has at least one quest pointing to it.

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS — 412 lines unchanged after overlay (zero new errors; all pre-existing PROD errors excluded).
- **vitest run**: PASS — 416 passed, 5 pre-existing failures unrelated (api-e2e nft-traits, chat history limit, interact action message, roomScene v3) — identical to baseline.
- Mirror restored byte-identical (`git status` clean, untracked file removed).

Overall: PASS

## Test plan
- [x] `npm run type-check` — clean
- [x] `npx eslint lib/db.ts` — 0 errors (5 pre-existing warnings unrelated)
- [x] `npx vitest run` — 416 passed; 5 pre-existing failures unrelated
- [x] PROD mirror baseline-diff: tsc PASS, vitest PASS
- [ ] Smoke: open QuestDialog at each room NPC and confirm new quests appear under DAILY/WEEKLY badges

🤖 Generated with [Claude Code](https://claude.com/claude-code)