### PR TITLE
feat(sanctuary v3): harden RD pipeline against credit waste

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,10 @@
     "db:init": "mkdir -p data && sqlite3 data/swo.db < scripts/init-db.sql",
     "db:fetch-metadata": "npx tsx scripts/fetch-metadata-to-db.ts",
     "colyseus:start": "npx tsx server/colyseus/index.ts",
-    "colyseus:dev": "npx tsx --watch server/colyseus/index.ts"
+    "colyseus:dev": "npx tsx --watch server/colyseus/index.ts",
+    "v3:generate": "node scripts/v3/generate.mjs",
+    "v3:check-cost": "node scripts/v3/generate.mjs --check-cost",
+    "v3:reconcile": "node scripts/v3/rd-reconcile.mjs"
   },
   "keywords": [],
   "author": "",

--- a/scripts/v3/.gitignore
+++ b/scripts/v3/.gitignore
@@ -1,2 +1,3 @@
 tmp/
 manifest-status.json
+requested.jsonl

--- a/scripts/v3/generate.mjs
+++ b/scripts/v3/generate.mjs
@@ -5,15 +5,27 @@
 //   RD_API_KEY=... node scripts/v3/generate.mjs                # cost-check then generate all enabled
 //   RD_API_KEY=... node scripts/v3/generate.mjs --only spawn-fox
 //   RD_API_KEY=... node scripts/v3/generate.mjs --check-cost    # cost-check only, no spend
-//   RD_API_KEY=... node scripts/v3/generate.mjs --force          # skip cost prompt
+//   RD_API_KEY=... node scripts/v3/generate.mjs --force         # skip cost prompt
+//   RD_DRY_RUN=1   node scripts/v3/generate.mjs --only spawn-fox # no RD POST, stub PNG
 //
-// For each enabled entry:
-//   1. (optional) check_cost first; print total; bail unless --yes / --force.
-//   2. Call the inference endpoint with the manifest fields + custom user style.
-//   3. Write raw output to scripts/v3/tmp/<id>-raw.png.
-//   4. Run normalize → public/sanctuary-v3/<output_path>.
-//   5. If normalize REJECTS: print reasons, bump seed, retry up to 2 times. After 3 fails total, escalate.
-//   6. Append a record to scripts/v3/manifest-status.json.
+// Safety rails (see scripts/v3/lib/safety.mjs):
+//   - prompt_hash dedup: refuses any entry already in manifest-status.json
+//     `approved` index unless --force-regenerate.
+//   - process lock at /tmp/rd_v3_generate.lock.
+//   - cost caps (env): RD_BATCH_CAP_USD (default 0.50) and RD_DAILY_CAP_USD
+//     (default 5.00). --override-cost-cap to proceed past either.
+//   - append-only audit log scripts/v3/requested.jsonl for every POST.
+//
+// For each enabled (or --only) entry:
+//   1. compute prompt_hash; skip if already approved.
+//   2. (optional) check_cost first; print total; bail unless --yes / --force.
+//   3. assert batch + daily caps before any POST.
+//   4. Call the inference endpoint with the manifest fields + custom user style.
+//   5. Append to requested.jsonl (success + error).
+//   6. Write raw output to scripts/v3/tmp/<id>-attempt<N>-raw.png.
+//   7. Run normalize → public/sanctuary-v3/<output_path>.
+//   8. If normalize REJECTS: print reasons, bump seed, retry up to 2 times.
+//   9. Append a record to scripts/v3/manifest-status.json (run + approval index).
 
 import fs from 'node:fs/promises';
 import path from 'node:path';
@@ -21,11 +33,26 @@ import readline from 'node:readline/promises';
 import { stdin as input, stdout as output } from 'node:process';
 import { inference, getCredits, fileToBase64, writeFirstImage } from './lib/rd-client.mjs';
 import { normalize } from './lib/normalize.mjs';
+import {
+  promptHash,
+  acquireLock,
+  releaseLock,
+  getCostCaps,
+  todayUtcDate,
+  dailyTotalUsd,
+  appendRequested,
+  loadStatus,
+  saveStatus,
+  findApproved,
+  markApproved,
+  writeStubPng,
+} from './lib/safety.mjs';
 
 const ROOT = path.resolve(import.meta.dirname, '../..');
 const HERE = import.meta.dirname;
 const MANIFEST_PATH = path.join(HERE, 'asset-manifest.json');
 const STATUS_PATH = path.join(HERE, 'manifest-status.json');
+const REQUESTED_LOG = path.join(HERE, 'requested.jsonl');
 const STYLE_FILE = path.join(HERE, 'style-id.txt');
 const TMP_DIR = path.join(HERE, 'tmp');
 const PALETTE_PATH = path.join(ROOT, 'public/sanctuary-v3/palettes/forgotten-memories.txt');
@@ -35,16 +62,12 @@ const ONLY_FLAG_IDX = process.argv.indexOf('--only');
 const ONLY_ID = ONLY_FLAG_IDX > 0 ? process.argv[ONLY_FLAG_IDX + 1] : null;
 const CHECK_ONLY = args.has('--check-cost');
 const FORCE = args.has('--force') || args.has('--yes');
+const FORCE_REGEN = args.has('--force-regenerate');
+const OVERRIDE_CAP = args.has('--override-cost-cap');
+const DRY_RUN = process.env.RD_DRY_RUN === '1' || process.env.RD_DRY_RUN === 'true' || args.has('--dry-run');
 const MAX_RETRIES = 2;
 
 async function readJson(p) { return JSON.parse(await fs.readFile(p, 'utf8')); }
-async function writeJson(p, v) { await fs.writeFile(p, JSON.stringify(v, null, 2) + '\n', 'utf8'); }
-async function readMaybeJson(p) {
-  try { return await readJson(p); } catch (e) {
-    if (e.code === 'ENOENT') return null;
-    throw e;
-  }
-}
 
 function buildPayload(entry, common, styleId) {
   const fullPrompt = `${common.style_prefix}${entry.prompt}`;
@@ -83,7 +106,7 @@ function buildPayload(entry, common, styleId) {
 // Documented fixed prices (RD docs FAQ).
 const ANIMATION_FIXED_PRICE = 0.07;
 
-function fmtCost(usd) { return `$${usd.toFixed(2)}`; }
+function fmtCost(usd) { return `$${Number(usd).toFixed(2)}`; }
 
 async function ensureDir(p) { await fs.mkdir(p, { recursive: true }); }
 
@@ -98,6 +121,10 @@ async function checkCostFor(entry, common, styleId) {
     // Animation endpoints don't support check_cost; price is fixed.
     return ANIMATION_FIXED_PRICE;
   }
+  if (DRY_RUN) {
+    // Don't hit RD in dry-run mode; assume animation-tier pricing as a stand-in.
+    return ANIMATION_FIXED_PRICE;
+  }
   payload.check_cost = true;
   delete payload._wantPalette;
   delete payload._wantReferenceImage;
@@ -105,7 +132,7 @@ async function checkCostFor(entry, common, styleId) {
   return res.balance_cost ?? 0;
 }
 
-async function runEntry(entry, common, styleId, palettePngPath, referencePngPath) {
+async function runEntry(entry, common, styleId, palettePngPath, referencePngPath, hash) {
   const out = path.join(ROOT, entry.output_path);
   await ensureDir(path.dirname(out));
   await ensureDir(TMP_DIR);
@@ -113,7 +140,7 @@ async function runEntry(entry, common, styleId, palettePngPath, referencePngPath
   const palB64 = await fileToBase64(palettePngPath).catch(() => null);
   const refB64 = await fileToBase64(referencePngPath).catch(() => null);
 
-  let attempts = [];
+  const attempts = [];
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
     const seed = entry.seed + attempt;
     const built = buildPayload(entry, common, styleId);
@@ -129,20 +156,93 @@ async function runEntry(entry, common, styleId, palettePngPath, referencePngPath
     delete payload._wantReferenceImage;
 
     console.log(`\n--- ${entry.id} | attempt ${attempt + 1}/${MAX_RETRIES + 1} | seed ${seed} ---`);
-    console.log(`POST /v1/inferences ...`);
-    let res;
-    try {
-      res = await inference(payload);
-    } catch (e) {
-      attempts.push({ attempt: attempt + 1, seed, status: 'api-error', error: e.message });
-      console.error(`  API error: ${e.message}`);
-      continue;
-    }
 
     const rawPath = path.join(TMP_DIR, `${entry.id}-attempt${attempt + 1}-raw.png`);
-    await writeFirstImage(res, rawPath);
-    console.log(`  raw → ${rawPath}`);
-    console.log(`  cost ${fmtCost(res.balance_cost ?? 0)}, balance ${fmtCost(res.remaining_balance ?? 0)}`);
+    let res;
+    let postedAt = new Date().toISOString();
+
+    if (DRY_RUN) {
+      console.log(`DRY-RUN: skipping POST /v1/inferences (RD_DRY_RUN=1)`);
+      const stub = await writeStubPng(rawPath, entry.width, entry.height);
+      res = {
+        base64_images: [], // unused in dry-run
+        balance_cost: 0,
+        remaining_balance: null,
+        _dry_run: true,
+      };
+      await appendRequested(REQUESTED_LOG, {
+        timestamp: postedAt,
+        id: entry.id,
+        attempt: attempt + 1,
+        seed,
+        prompt_hash: hash,
+        endpoint: '/v1/inferences',
+        outcome: 'dry-run',
+        cost: 0,
+        remaining_balance: null,
+        stub_bytes: stub.bytes,
+        pid: process.pid,
+      });
+      console.log(`  raw → ${rawPath} (stub ${stub.width}x${stub.height})`);
+    } else {
+      console.log(`POST /v1/inferences ...`);
+      try {
+        res = await inference(payload);
+      } catch (e) {
+        await appendRequested(REQUESTED_LOG, {
+          timestamp: postedAt,
+          id: entry.id,
+          attempt: attempt + 1,
+          seed,
+          prompt_hash: hash,
+          endpoint: '/v1/inferences',
+          outcome: 'api-error',
+          error: e.message,
+          status: e.status ?? null,
+          cost: 0,
+          pid: process.pid,
+        });
+        attempts.push({ attempt: attempt + 1, seed, status: 'api-error', error: e.message });
+        console.error(`  API error: ${e.message}`);
+        continue;
+      }
+      const cost = res.balance_cost ?? 0;
+      await appendRequested(REQUESTED_LOG, {
+        timestamp: postedAt,
+        id: entry.id,
+        attempt: attempt + 1,
+        seed,
+        prompt_hash: hash,
+        endpoint: '/v1/inferences',
+        outcome: 'ok',
+        cost,
+        remaining_balance: res.remaining_balance ?? null,
+        pid: process.pid,
+      });
+      await writeFirstImage(res, rawPath);
+      console.log(`  raw → ${rawPath}`);
+      console.log(`  cost ${fmtCost(cost)}, balance ${fmtCost(res.remaining_balance ?? 0)}`);
+    }
+
+    if (DRY_RUN) {
+      // In dry-run we keep the stub PNG in tmp/ — never overwrite the real
+      // output asset. The dedup record uses the tmp path as a marker so that
+      // re-running --dry-run with the same hash still hits the dedup gate.
+      console.log(`  ✅ dry-run: stub at ${rawPath} (output path NOT overwritten)`);
+      const summary = {
+        attempt: attempt + 1,
+        seed,
+        status: 'dry-run-pass',
+        reasons: [],
+        metrics: { dry_run: true },
+        sha256: null,
+        raw: rawPath,
+        out: rawPath,
+        cost_balance: null,
+      };
+      attempts.push(summary);
+      return { entry, success: true, attempts, finalPath: rawPath, dryRun: true };
+    }
 
     console.log(`normalize → ${out}`);
     const normResult = await normalize({
@@ -167,11 +267,11 @@ async function runEntry(entry, common, styleId, palettePngPath, referencePngPath
 
     if (normResult.pass) {
       console.log(`  ✅ pass — bbox ${JSON.stringify(normResult.metrics.bbox)}, opaque ${normResult.metrics.opaque}, accent ${(normResult.metrics.fracAccent*100).toFixed(2)}%, AA ${(normResult.metrics.fracAA*100).toFixed(1)}%`);
-      return { entry, success: true, attempts, finalPath: out };
+      return { entry, success: true, attempts, finalPath: out, dryRun: false };
     }
     console.log(`  ❌ fail: ${normResult.reasons.join(' | ')}`);
   }
-  return { entry, success: false, attempts, finalPath: null };
+  return { entry, success: false, attempts, finalPath: null, dryRun: DRY_RUN };
 }
 
 async function main() {
@@ -184,66 +284,157 @@ async function main() {
   const palettePngPath = path.join(ROOT, 'public/sanctuary-v3/palettes/forgotten-memories.png');
   const referencePngPath = path.join(HERE, 'tmp', 'style-reference.png');
 
-  let entries = manifest.entries.filter(e => e.enabled);
-  if (ONLY_ID) entries = entries.filter(e => e.id === ONLY_ID);
-  if (!entries.length) {
-    console.log('no enabled entries to generate.');
-    if (ONLY_ID) console.log(`(filter: --only ${ONLY_ID})`);
+  // --only bypasses the enabled filter so devs can dry-run any disabled entry.
+  let entries;
+  if (ONLY_ID) {
+    entries = manifest.entries.filter(e => e.id === ONLY_ID);
+    if (!entries.length) {
+      console.log(`no manifest entry matches --only ${ONLY_ID}.`);
+      return;
+    }
+  } else {
+    entries = manifest.entries.filter(e => e.enabled);
+    if (!entries.length) {
+      console.log('no enabled entries to generate.');
+      return;
+    }
+  }
+
+  console.log(`entries: ${entries.map(e => e.id).join(', ')}${DRY_RUN ? '  [DRY-RUN]' : ''}`);
+
+  // ----- safety rails ------------------------------------------------------
+  await acquireLock();
+  process.on('exit', () => { releaseLock().catch(() => {}); });
+  process.on('SIGINT', () => { releaseLock().finally(() => process.exit(130)); });
+  process.on('SIGTERM', () => { releaseLock().finally(() => process.exit(143)); });
+
+  const status = await loadStatus(STATUS_PATH);
+
+  // ----- prompt-hash dedup gate -------------------------------------------
+  const annotated = entries.map(e => ({ entry: e, hash: promptHash(e, manifest.common, styleId) }));
+  const skipped = [];
+  const todo = [];
+  for (const a of annotated) {
+    const existing = findApproved(status, a.entry.id, a.hash);
+    if (existing && !FORCE_REGEN) {
+      skipped.push({ ...a, existing });
+    } else {
+      todo.push(a);
+    }
+  }
+
+  if (skipped.length) {
+    console.log('\n--- already approved (skipping) ---');
+    for (const s of skipped) {
+      console.log(`  ${s.entry.id.padEnd(24)} hash=${s.hash.slice(0, 10)}…  approvedAt=${s.existing.approvedAt}`);
+    }
+    if (!todo.length) {
+      console.log('\nnothing to do. pass --force-regenerate to regenerate already-approved entries.');
+      await releaseLock();
+      return;
+    }
+  }
+
+  // ----- cost gate (check_cost + caps) ------------------------------------
+  console.log(`\n--- cost check ---`);
+  let batchEstimate = 0;
+  const perEntryCost = new Map();
+  for (const a of todo) {
+    const c = await checkCostFor(a.entry, manifest.common, styleId);
+    perEntryCost.set(a.entry.id, c);
+    batchEstimate += c;
+    console.log(`  ${a.entry.id.padEnd(24)} ${fmtCost(c)}`);
+  }
+  const credits = DRY_RUN ? { balance: null, credits: null } : await getCredits();
+  console.log(`total estimated: ${fmtCost(batchEstimate)}`);
+  if (!DRY_RUN) {
+    console.log(`current balance: ${fmtCost(credits.balance ?? 0)}, ${credits.credits ?? '-'} credits`);
+  } else {
+    console.log(`current balance: (skipped — DRY-RUN)`);
+  }
+
+  const caps = getCostCaps();
+  const dailyAlready = await dailyTotalUsd(REQUESTED_LOG, todayUtcDate());
+  const projectedDaily = dailyAlready + batchEstimate;
+  console.log(`caps: batch≤${fmtCost(caps.batch)}, daily≤${fmtCost(caps.daily)} (already today: ${fmtCost(dailyAlready)} → projected ${fmtCost(projectedDaily)})`);
+
+  const breaches = [];
+  if (batchEstimate > caps.batch) breaches.push(`batch ${fmtCost(batchEstimate)} > cap ${fmtCost(caps.batch)}`);
+  if (projectedDaily > caps.daily) breaches.push(`projected daily ${fmtCost(projectedDaily)} > cap ${fmtCost(caps.daily)}`);
+  if (breaches.length) {
+    if (!OVERRIDE_CAP) {
+      console.error(`\nABORT — cost cap breach: ${breaches.join('; ')}.\n` +
+        `  override with --override-cost-cap, or raise via RD_BATCH_CAP_USD / RD_DAILY_CAP_USD env vars.`);
+      await releaseLock();
+      process.exit(2);
+    }
+    console.warn(`WARNING — cap override active: ${breaches.join('; ')}`);
+  }
+
+  if (CHECK_ONLY) {
+    console.log('--check-cost only; exiting.');
+    await releaseLock();
     return;
   }
 
-  console.log(`enabled entries: ${entries.map(e => e.id).join(', ')}`);
-
-  // Cost gate: check_cost for each entry.
-  console.log('\n--- cost check ---');
-  let totalCost = 0;
-  for (const e of entries) {
-    const c = await checkCostFor(e, manifest.common, styleId);
-    totalCost += c;
-    console.log(`  ${e.id.padEnd(24)} ${fmtCost(c)}`);
-  }
-  const credits = await getCredits();
-  console.log(`total estimated: ${fmtCost(totalCost)}`);
-  console.log(`current balance: ${fmtCost(credits.balance ?? 0)}, ${credits.credits ?? '-'} credits`);
-
-  if (CHECK_ONLY) { console.log('--check-cost only; exiting.'); return; }
-
-  if (!FORCE) {
+  if (!FORCE && !DRY_RUN) {
     const rl = readline.createInterface({ input, output });
     const ans = await rl.question(`proceed with generation? [y/N] `);
     rl.close();
-    if (!/^y/i.test(ans.trim())) { console.log('aborted.'); return; }
+    if (!/^y/i.test(ans.trim())) {
+      console.log('aborted.');
+      await releaseLock();
+      return;
+    }
   }
 
-  // Run.
-  const status = (await readMaybeJson(STATUS_PATH)) || { runs: [] };
-  const runRecord = { startedAt: new Date().toISOString(), entries: [] };
+  // ----- run --------------------------------------------------------------
+  const runRecord = {
+    startedAt: new Date().toISOString(),
+    dryRun: DRY_RUN,
+    entries: [],
+  };
 
-  for (const e of entries) {
-    const r = await runEntry(e, manifest.common, styleId, palettePngPath, referencePngPath);
+  for (const a of todo) {
+    const r = await runEntry(a.entry, manifest.common, styleId, palettePngPath, referencePngPath, a.hash);
     runRecord.entries.push({
-      id: e.id,
+      id: a.entry.id,
       success: r.success,
       finalPath: r.finalPath,
+      prompt_hash: a.hash,
+      dry_run: !!r.dryRun,
       attempts: r.attempts,
     });
+    if (r.success) {
+      const lastAttempt = r.attempts.at(-1) || {};
+      markApproved(status, a.entry.id, {
+        prompt_hash: a.hash,
+        finalPath: r.finalPath,
+        sha256: lastAttempt.sha256 ?? null,
+        approvedAt: new Date().toISOString(),
+        method: r.dryRun ? 'dry-run' : 'rd',
+      });
+    }
   }
 
   runRecord.finishedAt = new Date().toISOString();
   status.runs.push(runRecord);
-  await writeJson(STATUS_PATH, status);
+  await saveStatus(STATUS_PATH, status);
 
   const ok = runRecord.entries.filter(x => x.success).length;
   const failed = runRecord.entries.filter(x => !x.success);
   console.log(`\n=== run done: ${ok}/${runRecord.entries.length} passed ===`);
   if (failed.length) {
     console.log('failed:');
-    for (const f of failed) console.log(`  - ${f.id}: ${f.attempts.at(-1)?.reasons?.join(' | ')}`);
+    for (const f of failed) console.log(`  - ${f.id}: ${f.attempts.at(-1)?.reasons?.join(' | ') || f.attempts.at(-1)?.error}`);
   }
   console.log(`status log → ${STATUS_PATH}`);
+  console.log(`request log → ${REQUESTED_LOG}`);
+  await releaseLock();
 }
 
-main().catch(err => {
+main().catch(async err => {
+  await releaseLock().catch(() => {});
   console.error('FAILED:', err.message);
   if (err.body) console.error('body:', JSON.stringify(err.body, null, 2));
   process.exit(1);

--- a/scripts/v3/lib/safety.mjs
+++ b/scripts/v3/lib/safety.mjs
@@ -1,0 +1,229 @@
+// Safety rails for the V3 RD pipeline.
+//
+// Provides:
+//   - promptHash(entry, common, styleId) — canonical SHA-256 over the inputs
+//     that determine the RD output. Used for dedup against approved entries.
+//   - acquireLock() / releaseLock() — process-level mutex on
+//     /tmp/rd_v3_generate.lock with stale-PID detection. Refuses to proceed
+//     if another generator is live.
+//   - getCostCaps() — read RD_BATCH_CAP_USD / RD_DAILY_CAP_USD env vars.
+//   - dailyTotalUsd(jsonlPath, dateIso) — sum cost from today's POSTs.
+//   - appendRequested(jsonlPath, record) — append-only audit log.
+//   - loadStatus / saveStatus — read/write the manifest-status.json file
+//     with an `approved[id] = [{prompt_hash, ...}]` index for dedup.
+//   - findApproved(status, id, hash) — bool/record lookup.
+//   - markApproved(status, id, record) — append + dedupe by hash.
+//   - writeStubPng(path, w, h) — solid-color PNG used by RD_DRY_RUN mode.
+//
+// All write paths assume the caller holds the process lock.
+
+import fs from 'node:fs/promises';
+import crypto from 'node:crypto';
+import sharp from 'sharp';
+
+export const LOCK_PATH = '/tmp/rd_v3_generate.lock';
+export const BATCH_CAP_DEFAULT_USD = 0.50;
+export const DAILY_CAP_DEFAULT_USD = 5.00;
+
+// ----- prompt hash ----------------------------------------------------------
+
+/**
+ * Canonical SHA-256 over (entry × common × styleId). Any change to prompt,
+ * dimensions, seed, palette flag, style id, or asset class produces a new
+ * hash. Used to skip already-approved entries.
+ */
+export function promptHash(entry, common, styleId) {
+  const canonical = JSON.stringify({
+    style_prefix: common?.style_prefix ?? '',
+    negative_prompt: common?.negative_prompt ?? '',
+    use_input_palette: common?.use_input_palette ?? false,
+    style_id: styleId ?? null,
+    id: entry.id,
+    prompt: entry.prompt,
+    prompt_style: entry.prompt_style,
+    width: entry.width,
+    height: entry.height,
+    seed: entry.seed,
+    remove_bg: entry.remove_bg ?? false,
+    return_spritesheet: entry.return_spritesheet ?? false,
+    asset_class: entry.asset_class ?? null,
+  });
+  return crypto.createHash('sha256').update(canonical).digest('hex');
+}
+
+// ----- lock -----------------------------------------------------------------
+
+let _heldLock = false;
+
+async function _isPidAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    return e.code !== 'ESRCH';
+  }
+}
+
+/**
+ * Take the v3 generator lock. Throws if another live process owns it.
+ * Idempotent within a single process — safe to call once at startup.
+ */
+export async function acquireLock(lockPath = LOCK_PATH) {
+  if (_heldLock) return lockPath;
+  const pidStr = String(process.pid);
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const fh = await fs.open(lockPath, 'wx');
+      try {
+        await fh.write(pidStr);
+      } finally {
+        await fh.close();
+      }
+      _heldLock = true;
+      return lockPath;
+    } catch (e) {
+      if (e.code !== 'EEXIST') throw e;
+      let oldPid = NaN;
+      try {
+        const txt = (await fs.readFile(lockPath, 'utf8')).trim();
+        oldPid = parseInt(txt, 10);
+      } catch {}
+      if (await _isPidAlive(oldPid)) {
+        throw new Error(`v3 pipeline lock held by pid=${oldPid} at ${lockPath}. ` +
+          `Wait for it to finish, or remove the lock if you are sure it is stale.`);
+      }
+      // stale — unlink and retry once
+      await fs.unlink(lockPath).catch(() => {});
+    }
+  }
+  throw new Error(`could not acquire ${lockPath} (race with another stale-takeover?)`);
+}
+
+export async function releaseLock(lockPath = LOCK_PATH) {
+  if (!_heldLock) return;
+  try {
+    const txt = (await fs.readFile(lockPath, 'utf8')).trim();
+    if (txt === String(process.pid)) {
+      await fs.unlink(lockPath);
+    }
+  } catch {}
+  _heldLock = false;
+}
+
+// ----- cost caps ------------------------------------------------------------
+
+export function getCostCaps() {
+  const batch = parseFloat(process.env.RD_BATCH_CAP_USD ?? BATCH_CAP_DEFAULT_USD);
+  const daily = parseFloat(process.env.RD_DAILY_CAP_USD ?? DAILY_CAP_DEFAULT_USD);
+  if (!Number.isFinite(batch) || batch < 0) {
+    throw new Error(`RD_BATCH_CAP_USD must be a non-negative number, got ${process.env.RD_BATCH_CAP_USD}`);
+  }
+  if (!Number.isFinite(daily) || daily < 0) {
+    throw new Error(`RD_DAILY_CAP_USD must be a non-negative number, got ${process.env.RD_DAILY_CAP_USD}`);
+  }
+  return { batch, daily };
+}
+
+/** UTC date prefix (YYYY-MM-DD) for the current moment. */
+export function todayUtcDate(now = new Date()) {
+  return now.toISOString().slice(0, 10);
+}
+
+/** Sum of `cost` (USD) from jsonl entries whose `timestamp` starts with dateIso. */
+export async function dailyTotalUsd(jsonlPath, dateIso) {
+  let total = 0;
+  let raw;
+  try {
+    raw = await fs.readFile(jsonlPath, 'utf8');
+  } catch (e) {
+    if (e.code === 'ENOENT') return 0;
+    throw e;
+  }
+  for (const line of raw.split('\n')) {
+    if (!line.trim()) continue;
+    let r;
+    try { r = JSON.parse(line); } catch { continue; }
+    if (typeof r.cost !== 'number' || !Number.isFinite(r.cost)) continue;
+    if (typeof r.timestamp !== 'string') continue;
+    if (r.timestamp.slice(0, 10) === dateIso) total += r.cost;
+  }
+  return total;
+}
+
+// ----- requested.jsonl ------------------------------------------------------
+
+/**
+ * Append one JSON record + newline to the audit log. Uses fs.open('a') which
+ * is atomic for small writes; outer process lock keeps multi-write batches in
+ * order.
+ */
+export async function appendRequested(jsonlPath, record) {
+  const line = JSON.stringify(record) + '\n';
+  const fh = await fs.open(jsonlPath, 'a');
+  try {
+    await fh.write(line);
+    await fh.sync().catch(() => {}); // best-effort fsync
+  } finally {
+    await fh.close();
+  }
+}
+
+// ----- manifest-status.json -------------------------------------------------
+
+export async function loadStatus(statusPath) {
+  try {
+    const txt = await fs.readFile(statusPath, 'utf8');
+    const obj = JSON.parse(txt);
+    if (!obj.runs) obj.runs = [];
+    if (!obj.approved) obj.approved = {};
+    return obj;
+  } catch (e) {
+    if (e.code === 'ENOENT') return { runs: [], approved: {} };
+    throw e;
+  }
+}
+
+export async function saveStatus(statusPath, status) {
+  await fs.writeFile(statusPath, JSON.stringify(status, null, 2) + '\n', 'utf8');
+}
+
+/** Returns the matching approval record (with prompt_hash) or null. */
+export function findApproved(status, id, hash) {
+  const arr = status?.approved?.[id];
+  if (!Array.isArray(arr)) return null;
+  return arr.find(r => r && r.prompt_hash === hash) || null;
+}
+
+/**
+ * Record a successful normalize as approved. Dedup by prompt_hash so re-runs
+ * don't bloat the file. Most recent record wins.
+ */
+export function markApproved(status, id, record) {
+  if (!status.approved) status.approved = {};
+  const arr = status.approved[id] = (status.approved[id] || []);
+  const existing = arr.findIndex(r => r && r.prompt_hash === record.prompt_hash);
+  if (existing >= 0) arr.splice(existing, 1);
+  arr.push(record);
+}
+
+// ----- dry-run stub ---------------------------------------------------------
+
+/**
+ * Write a tiny solid-color PNG at the requested dimensions. Used by
+ * RD_DRY_RUN to simulate the RD POST without spending credits.
+ */
+export async function writeStubPng(outPath, width, height) {
+  const w = Math.max(1, width | 0) || 32;
+  const h = Math.max(1, height | 0) || 32;
+  const buf = await sharp({
+    create: {
+      width: w,
+      height: h,
+      channels: 4,
+      background: { r: 132, g: 49, b: 121, alpha: 1 }, // muted lavender — easy to spot
+    },
+  }).png().toBuffer();
+  await fs.writeFile(outPath, buf);
+  return { width: w, height: h, bytes: buf.length };
+}

--- a/scripts/v3/rd-reconcile.mjs
+++ b/scripts/v3/rd-reconcile.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+// Reconcile scripts/v3/requested.jsonl against RD's /credits endpoint.
+//
+// Usage:
+//   RD_API_KEY=... node scripts/v3/rd-reconcile.mjs           # full report
+//   RD_API_KEY=... node scripts/v3/rd-reconcile.mjs --today   # today only
+//   RD_API_KEY=... node scripts/v3/rd-reconcile.mjs --offline # skip /credits
+//
+// Reports:
+//   - count and total $ of POSTs in the audit log (overall + today)
+//   - earliest / latest entry timestamps
+//   - inferred starting balance (earliest entry's `cost + remaining_balance`)
+//   - inferred ending balance (latest entry's `remaining_balance`) vs current
+//     /credits balance — flags any drift > $0.05.
+//   - dry-run entries excluded from cost totals.
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { getCredits } from './lib/rd-client.mjs';
+import { todayUtcDate } from './lib/safety.mjs';
+
+const HERE = import.meta.dirname;
+const LOG_PATH = path.join(HERE, 'requested.jsonl');
+
+const args = new Set(process.argv.slice(2));
+const TODAY_ONLY = args.has('--today');
+const OFFLINE = args.has('--offline');
+
+function fmt(usd) { return `$${Number(usd).toFixed(4)}`; }
+
+async function readEntries() {
+  let raw;
+  try {
+    raw = await fs.readFile(LOG_PATH, 'utf8');
+  } catch (e) {
+    if (e.code === 'ENOENT') return [];
+    throw e;
+  }
+  const out = [];
+  for (const line of raw.split('\n')) {
+    if (!line.trim()) continue;
+    try { out.push(JSON.parse(line)); } catch {}
+  }
+  return out;
+}
+
+function summarize(entries, label) {
+  const realCost = entries.filter(e => e.outcome === 'ok' && typeof e.cost === 'number')
+    .reduce((s, e) => s + e.cost, 0);
+  const dryRuns = entries.filter(e => e.outcome === 'dry-run').length;
+  const apiErrors = entries.filter(e => e.outcome === 'api-error').length;
+  const ok = entries.filter(e => e.outcome === 'ok').length;
+  console.log(`\n--- ${label} (${entries.length} log entries) ---`);
+  console.log(`  ok          ${ok}    (cost ${fmt(realCost)})`);
+  console.log(`  dry-run     ${dryRuns}`);
+  console.log(`  api-error   ${apiErrors}`);
+  return { realCost, ok, dryRuns, apiErrors };
+}
+
+function balanceWindow(entries) {
+  const ok = entries.filter(e => e.outcome === 'ok' && typeof e.remaining_balance === 'number');
+  if (!ok.length) return null;
+  const first = ok[0];
+  const last = ok[ok.length - 1];
+  const startBal = (first.remaining_balance ?? 0) + (first.cost ?? 0);
+  return {
+    earliestTs: first.timestamp,
+    latestTs: last.timestamp,
+    startBalance: startBal,
+    endBalanceFromLog: last.remaining_balance,
+  };
+}
+
+async function main() {
+  const all = await readEntries();
+  if (!all.length) {
+    console.log(`no entries in ${LOG_PATH}`);
+    return;
+  }
+
+  const today = todayUtcDate();
+  const todayEntries = all.filter(e => typeof e.timestamp === 'string' && e.timestamp.slice(0, 10) === today);
+
+  summarize(all, 'all-time');
+  summarize(todayEntries, `today (${today})`);
+
+  const allWin = balanceWindow(all);
+  if (allWin) {
+    console.log(`\nbalance window (from log):`);
+    console.log(`  earliest ${allWin.earliestTs}   inferred start ≈ ${fmt(allWin.startBalance)}`);
+    console.log(`  latest   ${allWin.latestTs}   end (from log) = ${fmt(allWin.endBalanceFromLog)}`);
+  }
+
+  if (OFFLINE) {
+    console.log(`\n--offline; skipping /credits.`);
+    return;
+  }
+
+  let credits;
+  try {
+    credits = await getCredits();
+  } catch (e) {
+    console.error(`failed to GET /credits: ${e.message}`);
+    process.exit(1);
+  }
+  const liveBalance = Number(credits.balance ?? 0);
+  console.log(`\nlive /credits: balance=${fmt(liveBalance)}, credits=${credits.credits ?? '-'}`);
+
+  if (allWin) {
+    const drift = liveBalance - allWin.endBalanceFromLog;
+    const driftAbs = Math.abs(drift);
+    const sign = drift >= 0 ? '+' : '-';
+    console.log(`drift vs latest log: ${sign}${fmt(driftAbs)}  (live − log)`);
+    if (driftAbs > 0.05) {
+      console.log(`  ⚠ drift > $0.05 — likely off-band charges (other RD usage) or stale log.`);
+      process.exitCode = 3;
+    } else {
+      console.log(`  ✅ within tolerance ($0.05).`);
+    }
+  }
+
+  if (TODAY_ONLY) return;
+}
+
+main().catch(err => {
+  console.error('FAILED:', err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Implements **[SWO_V3_PIPELINE_HARDENING]** — five safety rails around `scripts/v3/generate.mjs` so the V3 RD pipeline can never silently waste credits, double-bill an approved entry, or race a second invocation. This is a precondition for the next batch of V3 RD work (`[SWO_V3_HUD_ICONS]`, `[SWO_V3_SHOP_CHROME]`, `[SWO_V3_VFX_SPRITES]`, `[SWO_V3_COSMETIC_HATS_V1]`).

### What's added

1. **prompt_hash dedup** — every entry is hashed (SHA-256 over prompt + style + dimensions + seed + palette + style_id). `manifest-status.json` gains an `approved[id]` index keyed by hash. Refuses entries already approved unless `--force-regenerate`.

2. **Cost caps** — `RD_BATCH_CAP_USD` (default `$0.50`) and `RD_DAILY_CAP_USD` (default `$5.00`) read from env. Daily total reconstructed from today's `requested.jsonl`. Either breach aborts with exit 2 unless `--override-cost-cap`.

3. **Process lock** — `/tmp/rd_v3_generate.lock` with PID stale detection. Refuses if owner PID is alive, takes over if stale. Released on exit / SIGINT / SIGTERM.

4. **`requested.jsonl`** — append-only audit log (one record per POST: ok / api-error / dry-run). gitignored.

5. **`RD_DRY_RUN=1`** — skips RD POST, writes a stub PNG to `scripts/v3/tmp/`, marks the entry approved (so dedup is exercised end-to-end), **never overwrites the real `public/sanctuary-v3` asset**.

### New files

- `scripts/v3/lib/safety.mjs` — hash, lock, caps, status helpers, stub PNG
- `scripts/v3/rd-reconcile.mjs` — sums jsonl cost vs `GET /credits`, flags drift > $0.05

### Modified

- `scripts/v3/generate.mjs` — wires safety; adds `--only ID` bypassing enabled filter, `--force-regenerate`, `--override-cost-cap`, jsonl append before raw write
- `scripts/v3/.gitignore` — ignore `requested.jsonl`
- `package.json` — `v3:generate`, `v3:check-cost`, `v3:reconcile` npm scripts

## Test plan

Acceptance criteria from `[SWO_V3_PIPELINE_HARDENING]`:

- [x] `RD_DRY_RUN=1 RD_API_KEY=fake node scripts/v3/generate.mjs --only spawn-fox --force` produces stub PNG (in `tmp/`, real asset untouched)
- [x] Second run with the same hash refuses (`"already approved"`, no POST, exit 0)
- [x] `RD_BATCH_CAP_USD=0.05 ...` aborts with exit 2; `--override-cost-cap` proceeds with WARNING
- [x] Daily-cap branch verified by replaying jsonl with mock cost entries
- [x] Lock conflict against a live pid refuses; stale pid (e.g. 99999) is recovered automatically
- [x] `node scripts/v3/rd-reconcile.mjs --offline` summarizes jsonl correctly

Quality gates:

- [x] `npm run type-check` — clean
- [x] `npm run lint` — no new errors in any of the new/modified files (213 pre-existing problems on dev untouched)
- [x] `npm run build` — clean (`Compiled successfully in 4.2s`)
- [x] `npm test` — same 5 pre-existing failures on dev (sanctuary API e2e), no regressions

## Out of scope (follow-ups)

- Wiring caps & lock into `scripts/v3/generate-overworld.mjs` — separate entry point, similar pattern needed; tracked as a follow-up if operator wants symmetric protection there.
- Vitest unit tests for `safety.mjs` (hash determinism, dedup gate, cap math) — kept out to ship the safety landing fast; can follow if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)