### PR TITLE
feat(sanctuary): shared companion VFX event contract [SWO_SHARED_VFX_TRIGGER_API]

### DIFF
--- a/components/sanctuary/overlays/CompanionMenu.tsx
+++ b/components/sanctuary/overlays/CompanionMenu.tsx
@@ -3,8 +3,19 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import EventBus from '@/components/sanctuary/EventBus';
 import { getWalletAuthHeader } from '@/lib/clientWalletAuth';
+import {
+  emitCompanionVfx,
+  type CompanionVfxKind,
+} from '@/lib/sanctuary/vfxEvents';
 
 type InteractAction = 'pet' | 'feed' | 'talk';
+
+// Map interact action → shared VFX kind. `talk` opens the chat overlay
+// instead of rendering a reaction, so it has no VFX entry.
+const ACTION_VFX: Partial<Record<InteractAction, CompanionVfxKind>> = {
+  pet: 'sparkle',
+  feed: 'food',
+};
 
 interface MenuPosition {
   x: number;
@@ -115,6 +126,14 @@ export default function CompanionMenu({
   const triggerReaction = useCallback((action: InteractAction, x: number, y: number) => {
     setReaction({ type: action, x, y });
     setTimeout(() => setReaction(null), 800);
+
+    // Publish through the shared VFX contract so V3 (and any future
+    // listener — analytics, replay capture, etc.) can render its own
+    // sprite-sheet effect. V2 keeps its inline emoji rendering above.
+    const kind = ACTION_VFX[action];
+    if (kind) {
+      emitCompanionVfx(EventBus, { kind, x, y, durationMs: 800, source: action });
+    }
   }, []);
 
   const handleAction = useCallback(async (action: InteractAction) => {

--- a/lib/sanctuary/__tests__/vfxEvents.test.ts
+++ b/lib/sanctuary/__tests__/vfxEvents.test.ts
@@ -1,0 +1,128 @@
+// @vitest-environment node
+import { describe, it, expect, vi } from 'vitest';
+
+import {
+  COMPANION_VFX_EVENT,
+  COMPANION_VFX_KINDS,
+  emitCompanionVfx,
+  onCompanionVfx,
+  type CompanionVfxPayload,
+  type VfxEventBus,
+} from '../vfxEvents';
+
+interface TestBus extends VfxEventBus {
+  emitted: Array<{ event: string; payload: CompanionVfxPayload }>;
+}
+
+function makeBus(): TestBus {
+  const listeners = new Map<string, Array<(p: CompanionVfxPayload) => void>>();
+  const emitted: Array<{ event: string; payload: CompanionVfxPayload }> = [];
+  const bus: TestBus = {
+    emitted,
+    emit(event, payload) {
+      emitted.push({ event, payload });
+      (listeners.get(event) ?? []).forEach((fn) => fn(payload));
+      return true;
+    },
+    on(event, listener) {
+      const arr = listeners.get(event) ?? [];
+      arr.push(listener);
+      listeners.set(event, arr);
+      return bus;
+    },
+    off(event, listener) {
+      const arr = listeners.get(event) ?? [];
+      listeners.set(event, arr.filter((l) => l !== listener));
+      return bus;
+    },
+  };
+  return bus;
+}
+
+describe('companion VFX event contract', () => {
+  it('exposes the canonical event name', () => {
+    expect(COMPANION_VFX_EVENT).toBe('companion:vfx');
+  });
+
+  it('lists all known kinds in a stable order', () => {
+    expect(COMPANION_VFX_KINDS).toEqual([
+      'sparkle',
+      'heart',
+      'food',
+      'level-up',
+      'glow',
+      'dust',
+    ]);
+  });
+
+  it('emits the payload through to subscribers unchanged for known kinds', () => {
+    const bus = makeBus();
+    const spy = vi.fn();
+    onCompanionVfx(bus, spy);
+
+    const payload: CompanionVfxPayload = {
+      kind: 'heart',
+      x: 100,
+      y: 200,
+      durationMs: 600,
+      color: '#ff66aa',
+      source: 'pet',
+    };
+    emitCompanionVfx(bus, payload);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(payload);
+    expect(bus.emitted).toEqual([{ event: COMPANION_VFX_EVENT, payload }]);
+  });
+
+  it('coerces unknown kinds to sparkle rather than throwing', () => {
+    const bus = makeBus();
+    const spy = vi.fn();
+    onCompanionVfx(bus, spy);
+
+    emitCompanionVfx(bus, {
+      // @ts-expect-error - intentional unknown kind for runtime guard test
+      kind: 'wat',
+      x: 0,
+      y: 0,
+    });
+
+    expect(spy).toHaveBeenCalledWith({ kind: 'sparkle', x: 0, y: 0 });
+  });
+
+  it('returns an unsubscribe function that detaches the listener', () => {
+    const bus = makeBus();
+    const spy = vi.fn();
+    const unsubscribe = onCompanionVfx(bus, spy);
+    unsubscribe();
+
+    emitCompanionVfx(bus, { kind: 'sparkle', x: 0, y: 0 });
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('supports multiple independent subscribers', () => {
+    const bus = makeBus();
+    const a = vi.fn();
+    const b = vi.fn();
+    onCompanionVfx(bus, a);
+    onCompanionVfx(bus, b);
+
+    emitCompanionVfx(bus, { kind: 'glow', x: 5, y: 5 });
+
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+
+  it('every kind round-trips end-to-end', () => {
+    const bus = makeBus();
+    const seen: string[] = [];
+    onCompanionVfx(bus, (p) => seen.push(p.kind));
+
+    for (const kind of COMPANION_VFX_KINDS) {
+      emitCompanionVfx(bus, { kind, x: 0, y: 0 });
+    }
+
+    expect(seen).toEqual([...COMPANION_VFX_KINDS]);
+  });
+});

--- a/lib/sanctuary/vfxEvents.ts
+++ b/lib/sanctuary/vfxEvents.ts
@@ -1,0 +1,113 @@
+/**
+ * Shared companion-VFX event contract for Sanctuary V2 + V3.
+ *
+ * Gameplay code (radial menu, quest claim, level-up, equip flash, etc.)
+ * emits a single `companion:vfx` event via {@link emitCompanionVfx}. The
+ * active visual track listens via {@link onCompanionVfx} and renders
+ * whatever is appropriate to its style:
+ *
+ *   - V2 (cosmic placeholder palette): emoji/CSS overlay (current behaviour)
+ *   - V3 (Forgotten-Memories palette): FM-palette sprite sheets via
+ *     `[SWO_V3_VFX_SPRITES]` — sheets differ per track, but trigger contract
+ *     is shared.
+ *
+ * This file is the *trigger contract only* — kinds, payload shape, publisher,
+ * subscriber. Renderers (and per-track sprite assets) live elsewhere.
+ */
+
+/**
+ * Visual-effect kinds. Add new kinds here as new triggers arise. Keep the
+ * list disjoint and self-describing — never overload one kind for two
+ * different feelings.
+ */
+export type CompanionVfxKind =
+  | 'sparkle'   // generic positive feedback (pet success, small bond gain)
+  | 'heart'     // affection burst (large bond gain, milestone reached)
+  | 'food'      // feed action / item received
+  | 'level-up'  // level milestone celebration (largest VFX)
+  | 'glow'      // ambient aura / equip flash
+  | 'dust';     // movement / scene-transition footstep
+
+export const COMPANION_VFX_KINDS: readonly CompanionVfxKind[] = [
+  'sparkle',
+  'heart',
+  'food',
+  'level-up',
+  'glow',
+  'dust',
+];
+
+/**
+ * Standard event name. One event keeps the EventBus surface small and lets
+ * a renderer subscribe once and dispatch internally on `payload.kind`.
+ */
+export const COMPANION_VFX_EVENT = 'companion:vfx';
+
+export interface CompanionVfxPayload {
+  /** What kind of VFX to render. See {@link CompanionVfxKind}. */
+  kind: CompanionVfxKind;
+  /** Screen-space X in pixels (from canvas/overlay top-left). */
+  x: number;
+  /** Screen-space Y in pixels. */
+  y: number;
+  /** How long the effect should run, ms. Renderers may clamp. */
+  durationMs?: number;
+  /**
+   * Optional accent color override (CSS color string). Renderers may ignore
+   * this if their palette doesn't compose with the override (V3 FM-palette
+   * sheets typically will).
+   */
+  color?: string;
+  /**
+   * Free-form provenance string ("pet", "feed", "quest-claim", etc.) used
+   * for logging/analytics, not for rendering. Optional.
+   */
+  source?: string;
+}
+
+/**
+ * EventEmitter-shaped object. `Phaser.Events.EventEmitter` satisfies this,
+ * as does any node-style EventEmitter or duck-typed test mock — kept minimal
+ * so this contract has no Phaser dependency.
+ */
+export interface VfxEventBus {
+  emit(event: string, payload: CompanionVfxPayload): unknown;
+  on(event: string, listener: (p: CompanionVfxPayload) => void, ctx?: unknown): unknown;
+  off(event: string, listener: (p: CompanionVfxPayload) => void, ctx?: unknown): unknown;
+}
+
+function isKnownKind(kind: unknown): kind is CompanionVfxKind {
+  return typeof kind === 'string' && (COMPANION_VFX_KINDS as readonly string[]).includes(kind);
+}
+
+/**
+ * Canonical publisher. Always use this instead of `bus.emit(COMPANION_VFX_EVENT, …)`
+ * directly so future contract changes (extra fields, normalization,
+ * throttling, dev-mode tracing) only need to change in one place.
+ *
+ * Unknown kinds are coerced to `sparkle` rather than thrown — gameplay paths
+ * must never explode on a bad VFX call.
+ */
+export function emitCompanionVfx(bus: VfxEventBus, payload: CompanionVfxPayload): void {
+  const safe: CompanionVfxPayload = isKnownKind(payload.kind)
+    ? payload
+    : { ...payload, kind: 'sparkle' };
+  bus.emit(COMPANION_VFX_EVENT, safe);
+}
+
+/**
+ * Canonical subscriber. Returns an unsubscribe function for symmetry with
+ * React effect cleanup patterns:
+ *
+ *   useEffect(() => onCompanionVfx(EventBus, render), []);
+ */
+export function onCompanionVfx(
+  bus: VfxEventBus,
+  listener: (payload: CompanionVfxPayload) => void,
+  ctx?: unknown,
+): () => void {
+  bus.on(COMPANION_VFX_EVENT, listener, ctx);
+  return () => {
+    bus.off(COMPANION_VFX_EVENT, listener, ctx);
+  };
+}


### PR DESCRIPTION
## Summary

Trigger-only EventBus contract for companion visual effects so V2 and V3 publish through one canonical event and each track renders in its own style.

- New: `lib/sanctuary/vfxEvents.ts` — `CompanionVfxKind` union (sparkle/heart/food/level-up/glow/dust), `COMPANION_VFX_EVENT` constant, `emitCompanionVfx()` / `onCompanionVfx()` helpers, duck-typed `VfxEventBus` interface (no Phaser dep so node tests/mocks work)
- New: `lib/sanctuary/__tests__/vfxEvents.test.ts` — 7 contract tests covering name, kinds, payload pass-through, unknown-kind coercion, unsubscribe, fan-out, every-kind round-trip
- `CompanionMenu.tsx` now emits `companion:vfx` alongside its existing inline emoji rendering. V2 UX is unchanged; the new event flows for any V3 listener (sprite-sheet renderer arrives in `[SWO_V3_VFX_SPRITES]`).

Per the queue task: this PR is the trigger contract only. V3 sprite sheets are a separate task.

## Test plan

- [ ] `npx vitest run lib/sanctuary/__tests__/vfxEvents.test.ts` → 7/7 pass
- [ ] `npm run type-check` clean
- [ ] V2 radial menu (pet / feed) still renders the same inline reaction emoji as before
- [ ] Optional manual: subscribe a console listener (`EventBus.on('companion:vfx', console.log)`) and confirm pet/feed actions log a payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)