### PR TITLE
feat(sanctuary v3): swap Press Start 2P → Pixelify Sans [SWO_V3_FONT_SWAP]

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ When a governance proposal is created, a discussion thread is automatically crea
 - **Contracts**: Solidity 0.8.20, OpenZeppelin 5.x
 - **Database**: SQLite (better-sqlite3)
 - **Floor Prices**: Local ME Scraper API (auto-updates every 30 min)
-- **Font**: Press Start 2P (Retro Pixel)
+- **Font**: Pixelify Sans (SNES-mood bitmap, 4 weights)
 
 ## 📄 License
 

--- a/app/casino/CasinoContent.tsx
+++ b/app/casino/CasinoContent.tsx
@@ -107,7 +107,7 @@ function NeonSign({ text, color }: { text: string; color: string }) {
             0 0 40px ${color},
             0 0 80px ${color}
           `,
-          fontFamily: "'Press Start 2P', cursive",
+          fontFamily: "'Pixelify Sans', cursive",
         }}
       >
         {text}

--- a/app/globals.css
+++ b/app/globals.css
@@ -26,7 +26,7 @@
   --sunset-warm: #ff9d4d;
   
   --crt-glow: rgba(0, 255, 255, 0.1);
-  --font-pixel: 'Press Start 2P', 'Courier New', monospace;
+  --font-pixel: 'Pixelify Sans', 'Courier New', monospace;
   
   /* Loading screen zoom animation values */
   /* Desktop: zoom 4.5x and shift down 10% to center the screen content */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,13 +15,13 @@ export default function RootLayout({
   return (
     <html lang="en">
       <head>
-        {/* 
-          Note: Using external font link as fallback. For production optimization,
-          consider using next/font/google when build environment supports it.
-          The CSS provides Courier New as fallback for the pixel font.
+        {/*
+          SNES-mood bitmap font for the Forgotten Memories palette (SWO_V3_FONT_SWAP).
+          Pixelify Sans is a true bitmap pixel font with 4 weights for hierarchy.
+          The CSS provides Courier New as fallback.
         */}
-        <link 
-          href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" 
+        <link
+          href="https://fonts.googleapis.com/css2?family=Pixelify+Sans:wght@400;500;600;700&display=swap"
           rel="stylesheet"
         />
       </head>

--- a/docs/SANCTUARY_STYLE_DOCTRINE.md
+++ b/docs/SANCTUARY_STYLE_DOCTRINE.md
@@ -163,7 +163,7 @@ The existing Skrumpey sprites define the visual floor. All Sanctuary assets must
 
 ## 5. Typography in Sanctuary
 
-Inherits SWO global: **Press Start 2P** for all text.
+Inherits SWO global: **Pixelify Sans** for all text (SNES-mood bitmap font, swapped from Press Start 2P 2026-04-26 per `[SWO_V3_FONT_SWAP]`).
 
 | Element | Size | Color | Notes |
 |---------|------|-------|-------|

--- a/docs/SANCTUARY_V3.md
+++ b/docs/SANCTUARY_V3.md
@@ -340,7 +340,7 @@ scripts/v3/
 | NPC sprites | Mixed sources, style mismatch | RD `walking_and_idle`, palette-locked |
 | Player | V2 character sheet | RD-regenerated to FM palette |
 | Companion | Existing constellation PNGs (kept — on-spec) | Same — no change |
-| Font | Press Start 2P | TBD bitmap font matching FM mood |
+| Font | Pixelify Sans (was Press Start 2P) | Pixelify Sans — SNES-mood bitmap, FM-aligned |
 | Phaser scenes | `WorldScene`, `RoomScene`, minigame scenes | `WorldSceneV3`, `RoomSceneV3` (same minigames) |
 | Game logic — minigames | Existing | **Identical, reused as-is** |
 | Game logic — quest board, shop, training, companion chat | Existing | **Identical, reused as-is** |
@@ -359,7 +359,7 @@ scripts/v3/
 | Phase | Scope | Effort | Stop point | RD spend |
 |-------|-------|--------|-------------|----------|
 | **0** | Approve this canonical doc | 0 | (you confirm) | $0 |
-| **1** | Add LICENSE.txt to FM folder; replace `Press Start 2P` font globally with a SNES-mood bitmap font | ~1h | Font visible on V2 + V3 placeholder | $0 |
+| **1** | ✅ DONE — Replaced `Press Start 2P` globally with **Pixelify Sans** (Google Fonts, 4 weights, true bitmap pixel font, SNES-JRPG mood). LICENSE.txt for FM folder still pending. | ~1h | Font visible on V2 + V3 + DOM chrome | $0 |
 | **2** | Build RD pipeline: `scripts/v3/{generate,normalize,extract-palette}.mjs`, create custom RD user style, save style ID | ~2h | Pipeline runs; one test prop generates + normalizes successfully | ~$0.05 |
 | **3** | Generate ONE NPC (Spawn Fox) end-to-end through the pipeline. Render it on top of the FM tileset in a quick test scene. **You eyeball it.** | ~30min | **You sign off on the style.** If it looks slop, we re-prompt before any bulk spend. | ~$0.10 |
 | **4** | Bulk-generate the rest: 9 more NPCs + ~15 themed props + 8 building exteriors. Each goes through normalize. | ~30min wall | All assets in `public/sanctuary-v3/` passing checklist | ~$3 |

--- a/game/scenes/CookingRhythmScene.ts
+++ b/game/scenes/CookingRhythmScene.ts
@@ -69,7 +69,7 @@ export class CookingRhythmScene extends MinigameScene {
 
     this.add
       .text(600, 220, 'COOK THE RECIPE', {
-        fontFamily: '"Press Start 2P", monospace',
+        fontFamily: '"Pixelify Sans", monospace',
         fontSize: '14px',
         color: '#ffaa44',
         stroke: '#000000',
@@ -80,7 +80,7 @@ export class CookingRhythmScene extends MinigameScene {
 
     this.add
       .text(600, 700, 'PRESS ARROW KEYS WHEN NOTES REACH THE PAN', {
-        fontFamily: '"Press Start 2P", monospace',
+        fontFamily: '"Pixelify Sans", monospace',
         fontSize: '10px',
         color: '#ff66aa',
         stroke: '#000000',
@@ -91,7 +91,7 @@ export class CookingRhythmScene extends MinigameScene {
 
     this.feedbackText = this.add
       .text(TARGET_X, TARGET_Y - 110, '', {
-        fontFamily: '"Press Start 2P", monospace',
+        fontFamily: '"Pixelify Sans", monospace',
         fontSize: '14px',
         color: '#ffd700',
         stroke: '#000000',

--- a/game/scenes/DreamCatcherScene.ts
+++ b/game/scenes/DreamCatcherScene.ts
@@ -61,7 +61,7 @@ export class DreamCatcherScene extends MinigameScene {
 
     this.add
       .text(600, 90, 'CATCH DREAMS · AVOID NIGHTMARES', {
-        fontFamily: '"Press Start 2P", monospace',
+        fontFamily: '"Pixelify Sans", monospace',
         fontSize: '12px',
         color: '#cc66ff',
         stroke: '#000000',
@@ -72,7 +72,7 @@ export class DreamCatcherScene extends MinigameScene {
 
     this.statusText = this.add
       .text(600, 840, 'ARROW KEYS / A · D TO MOVE', {
-        fontFamily: '"Press Start 2P", monospace',
+        fontFamily: '"Pixelify Sans", monospace',
         fontSize: '10px',
         color: '#9966ff',
         stroke: '#000000',

--- a/game/scenes/ForgeHammerScene.ts
+++ b/game/scenes/ForgeHammerScene.ts
@@ -52,7 +52,7 @@ export class ForgeHammerScene extends MinigameScene {
 
     this.feedbackText = this.add
       .text(METER_X, METER_Y - 110, '', {
-        fontFamily: '"Press Start 2P", monospace',
+        fontFamily: '"Pixelify Sans", monospace',
         fontSize: '14px',
         color: '#ffd700',
         stroke: '#000000',
@@ -63,7 +63,7 @@ export class ForgeHammerScene extends MinigameScene {
 
     this.add
       .text(METER_X, METER_Y + 250, 'PRESS SPACE TO STRIKE', {
-        fontFamily: '"Press Start 2P", monospace',
+        fontFamily: '"Pixelify Sans", monospace',
         fontSize: '10px',
         color: '#ff66aa',
         stroke: '#000000',

--- a/game/scenes/LoreTriviaScene.ts
+++ b/game/scenes/LoreTriviaScene.ts
@@ -130,7 +130,7 @@ export class LoreTriviaScene extends MinigameScene {
   protected setup(): void {
     this.add
       .text(PROMPT_X, 110, 'COSMIC LORE TRIVIA', {
-        fontFamily: '"Press Start 2P", monospace',
+        fontFamily: '"Pixelify Sans", monospace',
         fontSize: '14px',
         color: '#8866ff',
         stroke: '#000000',
@@ -141,7 +141,7 @@ export class LoreTriviaScene extends MinigameScene {
 
     this.add
       .text(PROMPT_X, 160, 'CLICK ANSWER · OR PRESS 1-4', {
-        fontFamily: '"Press Start 2P", monospace',
+        fontFamily: '"Pixelify Sans", monospace',
         fontSize: '10px',
         color: '#9966ff',
         stroke: '#000000',
@@ -152,7 +152,7 @@ export class LoreTriviaScene extends MinigameScene {
 
     this.promptText = this.add
       .text(PROMPT_X, PROMPT_Y, '', {
-        fontFamily: '"Press Start 2P", monospace',
+        fontFamily: '"Pixelify Sans", monospace',
         fontSize: '18px',
         color: '#ffd700',
         stroke: '#000000',
@@ -166,7 +166,7 @@ export class LoreTriviaScene extends MinigameScene {
     // Per-question timer: text + a thin progress bar under the prompt.
     this.questionTimerText = this.add
       .text(PROMPT_X, PROMPT_Y + 50, '', {
-        fontFamily: '"Press Start 2P", monospace',
+        fontFamily: '"Pixelify Sans", monospace',
         fontSize: '12px',
         color: '#00f7ff',
         stroke: '#000000',
@@ -178,7 +178,7 @@ export class LoreTriviaScene extends MinigameScene {
 
     this.feedbackText = this.add
       .text(PROMPT_X, 800, '', {
-        fontFamily: '"Press Start 2P", monospace',
+        fontFamily: '"Pixelify Sans", monospace',
         fontSize: '14px',
         color: '#ffffff',
         stroke: '#000000',
@@ -321,7 +321,7 @@ export class LoreTriviaScene extends MinigameScene {
     container.add(bg);
     const label = this.add
       .text(0, 0, '', {
-        fontFamily: '"Press Start 2P", monospace',
+        fontFamily: '"Pixelify Sans", monospace',
         fontSize: '14px',
         color: '#ffffff',
         stroke: '#000000',

--- a/game/scenes/MemoryMatchScene.ts
+++ b/game/scenes/MemoryMatchScene.ts
@@ -62,7 +62,7 @@ export class MemoryMatchScene extends MinigameScene {
 
     this.statusText = this.add
       .text(600, 110, '', {
-        fontFamily: '"Press Start 2P", monospace',
+        fontFamily: '"Pixelify Sans", monospace',
         fontSize: '10px',
         color: '#ffd700',
         stroke: '#000000',

--- a/game/scenes/MinigameScene.ts
+++ b/game/scenes/MinigameScene.ts
@@ -255,7 +255,7 @@ export abstract class MinigameScene extends Phaser.Scene {
   private setupHUD() {
     this.titleText = this.add
       .text(SCREEN_W / 2, 24, this.gameTitle, {
-        fontFamily: '"Press Start 2P", monospace',
+        fontFamily: '"Pixelify Sans", monospace',
         fontSize: '16px',
         color: '#ffd700',
         stroke: '#000000',
@@ -269,7 +269,7 @@ export abstract class MinigameScene extends Phaser.Scene {
 
     this.scoreText = this.add
       .text(20, 56, '', {
-        fontFamily: '"Press Start 2P", monospace',
+        fontFamily: '"Pixelify Sans", monospace',
         fontSize: '18px',
         color: '#00f7ff',
         stroke: '#000000',
@@ -282,7 +282,7 @@ export abstract class MinigameScene extends Phaser.Scene {
 
     this.timerText = this.add
       .text(SCREEN_W - 20, 56, '', {
-        fontFamily: '"Press Start 2P", monospace',
+        fontFamily: '"Pixelify Sans", monospace',
         fontSize: '20px',
         color: '#ff66aa',
         stroke: '#000000',
@@ -344,7 +344,7 @@ export abstract class MinigameScene extends Phaser.Scene {
 
     const titleObj = this.add
       .text(0, -h / 2 + 28, opts.title, {
-        fontFamily: '"Press Start 2P", monospace',
+        fontFamily: '"Pixelify Sans", monospace',
         fontSize: '18px',
         color: '#ffd700',
         stroke: '#000000',
@@ -356,7 +356,7 @@ export abstract class MinigameScene extends Phaser.Scene {
     opts.lines.forEach((line, i) => {
       const lineObj = this.add
         .text(0, -h / 2 + 80 + i * 26, line, {
-          fontFamily: '"Press Start 2P", monospace',
+          fontFamily: '"Pixelify Sans", monospace',
           fontSize: '10px',
           color: '#00f7ff',
           stroke: '#000000',
@@ -381,7 +381,7 @@ export abstract class MinigameScene extends Phaser.Scene {
       btnG.strokeRect(-90, -16, 180, 32);
       const label = this.add
         .text(0, 0, btn.label, {
-          fontFamily: '"Press Start 2P", monospace',
+          fontFamily: '"Pixelify Sans", monospace',
           fontSize: '10px',
           color: '#ffffff',
           stroke: '#000000',
@@ -417,7 +417,7 @@ export abstract class MinigameScene extends Phaser.Scene {
         // Replace the placeholder lines with named refs we can update later.
         const status = this.add
           .text(0, -20, 'STAR  +calculating...', {
-            fontFamily: '"Press Start 2P", monospace',
+            fontFamily: '"Pixelify Sans", monospace',
             fontSize: '12px',
             color: '#ffd700',
             stroke: '#000000',
@@ -426,7 +426,7 @@ export abstract class MinigameScene extends Phaser.Scene {
           .setOrigin(0.5);
         const detail = this.add
           .text(0, 14, 'Personal Best: ...', {
-            fontFamily: '"Press Start 2P", monospace',
+            fontFamily: '"Pixelify Sans", monospace',
             fontSize: '9px',
             color: '#9966ff',
             stroke: '#000000',

--- a/game/scenes/RoomScene.ts
+++ b/game/scenes/RoomScene.ts
@@ -229,7 +229,7 @@ export class RoomScene extends Phaser.Scene {
 
     const hint = this.add
       .text(zoneCenterX, zoneCenterY - 28, '[E] EXIT', {
-        fontFamily: '"Press Start 2P", monospace',
+        fontFamily: '"Pixelify Sans", monospace',
         fontSize: '10px',
         color: '#ff00ff',
         stroke: '#000000',
@@ -252,7 +252,7 @@ export class RoomScene extends Phaser.Scene {
     const screenW = this.scale.width;
     this.add
       .text(screenW / 2, 16, this.room.toUpperCase(), {
-        fontFamily: '"Press Start 2P", monospace',
+        fontFamily: '"Pixelify Sans", monospace',
         fontSize: '14px',
         color: '#ffd700',
         stroke: '#000000',

--- a/game/scenes/StarConnectScene.ts
+++ b/game/scenes/StarConnectScene.ts
@@ -46,7 +46,7 @@ export class StarConnectScene extends MinigameScene {
 
     this.hudText = this.add
       .text(600, 105, '', {
-        fontFamily: '"Press Start 2P", monospace',
+        fontFamily: '"Pixelify Sans", monospace',
         fontSize: '10px',
         color: '#ffd700',
         stroke: '#000000',

--- a/game/scenes/WorldScene.ts
+++ b/game/scenes/WorldScene.ts
@@ -248,7 +248,7 @@ export class WorldScene extends Phaser.Scene {
   private setupDoorPrompt() {
     this.doorPrompt = this.add
       .text(0, 0, '', {
-        fontFamily: '"Press Start 2P", monospace',
+        fontFamily: '"Pixelify Sans", monospace',
         fontSize: '6px',
         color: '#ffd700',
         stroke: '#000000',
@@ -260,7 +260,7 @@ export class WorldScene extends Phaser.Scene {
     this.doorHighlightGfx = this.add.graphics().setDepth(29);
     this.doorHighlightArrow = this.add
       .text(0, 0, '▼', {
-        fontFamily: '"Press Start 2P", monospace',
+        fontFamily: '"Pixelify Sans", monospace',
         fontSize: '10px',
         color: '#00f7ff',
         stroke: '#000000',

--- a/game/sprites/CompanionSprite.ts
+++ b/game/sprites/CompanionSprite.ts
@@ -100,7 +100,7 @@ export class CompanionSprite extends Phaser.GameObjects.Container {
       if (!this.zzzText && this.scene) {
         this.zzzText = this.scene.add
           .text(this.x, this.y - 12, 'Zzz', {
-            fontFamily: '"Press Start 2P", monospace',
+            fontFamily: '"Pixelify Sans", monospace',
             fontSize: '6px',
             color: '#9966ff',
             stroke: '#000000',

--- a/game/sprites/NPCSprite.ts
+++ b/game/sprites/NPCSprite.ts
@@ -65,7 +65,7 @@ export class NPCSprite extends Phaser.GameObjects.Container {
     this.shadow.setDepth(7);
 
     this.nameTag = scene.add.text(0, nameTagY, def.name, {
-      fontFamily: '"Press Start 2P", monospace',
+      fontFamily: '"Pixelify Sans", monospace',
       fontSize: '5px',
       color: '#ffffff',
       stroke: '#000000',
@@ -76,7 +76,7 @@ export class NPCSprite extends Phaser.GameObjects.Container {
     this.add(this.nameTag);
 
     this.indicator = scene.add.text(0, this.indicatorBaseY, '!', {
-      fontFamily: '"Press Start 2P", monospace',
+      fontFamily: '"Pixelify Sans", monospace',
       fontSize: '8px',
       color: '#ffd700',
       stroke: '#000000',

--- a/game/sprites/OtherPlayerSprite.ts
+++ b/game/sprites/OtherPlayerSprite.ts
@@ -29,7 +29,7 @@ export class OtherPlayerSprite {
     this.sprite.setVisible(false);
 
     this.nameTag = scene.add.text(0, 0, '', {
-      fontFamily: '"Press Start 2P", monospace',
+      fontFamily: '"Pixelify Sans", monospace',
       fontSize: '3px',
       color: '#00f7ff',
       stroke: '#000000',

--- a/game/v3/scenes/RoomSceneV3.ts
+++ b/game/v3/scenes/RoomSceneV3.ts
@@ -170,7 +170,7 @@ export class RoomSceneV3 extends Phaser.Scene {
     // Visible "[E] EXIT" hint.
     this.add
       .text(ROOM_W / 2, ROOM_H - TILE - 18, '[E] EXIT', {
-        fontFamily: '"Press Start 2P", monospace',
+        fontFamily: '"Pixelify Sans", monospace',
         fontSize: '8px',
         color: '#ff66aa',
         stroke: '#000000',
@@ -189,7 +189,7 @@ export class RoomSceneV3 extends Phaser.Scene {
     const screenW = this.scale.width;
     this.add
       .text(screenW / 2, 16, this.roomId.toUpperCase().replace(/-/g, ' '), {
-        fontFamily: '"Press Start 2P", monospace',
+        fontFamily: '"Pixelify Sans", monospace',
         fontSize: '14px',
         color: '#ffd700',
         stroke: '#000000',

--- a/game/v3/scenes/WorldSceneV3.ts
+++ b/game/v3/scenes/WorldSceneV3.ts
@@ -160,7 +160,7 @@ export class WorldSceneV3 extends Phaser.Scene {
     }
     this.doorPrompt = this.add
       .text(0, 0, '', {
-        fontFamily: '"Press Start 2P", monospace',
+        fontFamily: '"Pixelify Sans", monospace',
         fontSize: '8px',
         color: '#ffd700',
         stroke: '#000000',

--- a/game/v3/sprites/NPCSpriteV3.ts
+++ b/game/v3/sprites/NPCSpriteV3.ts
@@ -36,7 +36,7 @@ export class NPCSpriteV3 extends Phaser.GameObjects.Container {
     this.shadow.setDepth(7);
 
     this.nameTag = scene.add.text(0, -28, def.name, {
-      fontFamily: '"Press Start 2P", monospace',
+      fontFamily: '"Pixelify Sans", monospace',
       fontSize: '8px',
       color: '#ffd700',
       stroke: '#000000',

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -33,7 +33,7 @@ const config: Config = {
         },
       },
       fontFamily: {
-        pixel: ['"Press Start 2P"', 'monospace'],
+        pixel: ['"Pixelify Sans"', 'monospace'],
       },
       animation: {
         'pixel-float': 'pixelFloat 3s ease-in-out infinite',


### PR DESCRIPTION
## Summary

Phase 1 of `docs/SANCTUARY_V3.md` §14 — replace `Press Start 2P` (8-bit arcade) with **Pixelify Sans** (SNES-mood bitmap, 4 weights) to match the Forgotten Memories palette mood.

- ~1h scope as documented
- Affects V2 + V3 chrome (DOM overlays are shared between tracks; choice driven by V3 doctrine)
- Single CSS variable + Tailwind token + 35 hardcoded Phaser `fontFamily` strings all swapped consistently
- Loads via Google Fonts `<link>` (same loading mechanism as before — drop-in font name change)

## Why Pixelify Sans

- **True bitmap pixel font** — renders crisp at 8/10/12px sizes already used in scenes
- **4 weights (400/500/600/700)** — supports hierarchy (Press Start 2P had only one weight)
- **SNES JRPG aesthetic** — matches the FM palette mood the V3 doctrine targets
- **Available on Google Fonts** — no `.ttf` hand-loading needed, fits existing infra

## Files Changed

| Group | Files | Notes |
|-------|-------|-------|
| Loader | `app/layout.tsx` | Google Fonts URL + comment update |
| Tokens | `app/globals.css`, `tailwind.config.ts` | `--font-pixel`, `fontFamily.pixel` |
| V2 game | 11 files in `game/scenes/` and `game/sprites/` | 27 hardcoded `fontFamily` strings |
| V3 game | 3 files in `game/v3/` | 4 hardcoded `fontFamily` strings (WorldSceneV3, RoomSceneV3, NPCSpriteV3) |
| Casino | `app/casino/CasinoContent.tsx` | Neon casino label (kept cursive fallback) |
| Docs | `SANCTUARY_V3.md`, `SANCTUARY_STYLE_DOCTRINE.md`, `README.md` | Phase 1 marked DONE; system map + typography section updated |

## Test plan

- [x] `npm run type-check` ✓ passes
- [x] `npm run build` ✓ 77/77 static pages, 4.2s compile
- [x] `npm run lint` — only pre-existing warnings (none related to this PR; layout.tsx custom-font warning was already present with the previous Google Fonts link)
- [ ] Operator visual sign-off at `localhost:3000/sanctuary?v=3` (V3 chrome) and `?v=2` (V2 chrome) and `/casino`
- [ ] Verify fallback works (`Courier New` → `monospace`) if Google Fonts CDN unreachable

## Doctrine touchpoints

- `docs/SANCTUARY_V3.md` §14 phase 1 — was: "TBD bitmap font matching FM mood"; now: marked ✅ DONE with Pixelify Sans
- `docs/SANCTUARY_STYLE_DOCTRINE.md` §5 — typography updated
- `[SWO_V3_FONT_SWAP]` queue item closes with this PR

## Follow-ups

- LICENSE.txt for the FM tileset folder (still pending from §14 phase 1)
- Optional refactor: extract `PIXEL_FONT_FAMILY` constant to `game/constants/fonts.ts` if future swaps prove frequent

🤖 Generated with [Claude Code](https://claude.com/claude-code)