### PR TITLE
feat(sanctuary v3): spawn companion sprite in WorldSceneV3 [SWO_V3_COMPANION_SPRITE]

### DIFF
--- a/game/v3/scenes/BootSceneV3.ts
+++ b/game/v3/scenes/BootSceneV3.ts
@@ -3,6 +3,8 @@ import EventBus from '@/components/sanctuary/EventBus';
 import { PlayerSpriteV3 } from '../sprites/PlayerSpriteV3';
 import { NPCSpriteV3 } from '../sprites/NPCSpriteV3';
 import { NPCS_V3, BUILDING_IDS } from '../config/npcDefinitionsV3';
+import { CompanionSprite } from '../../sprites/CompanionSprite';
+import { AnimationSystem } from '../../systems/AnimationSystem';
 
 export class BootSceneV3 extends Phaser.Scene {
   constructor() { super({ key: 'BootSceneV3' }); }
@@ -44,10 +46,17 @@ export class BootSceneV3 extends Phaser.Scene {
 
     // NPC sprites.
     for (const def of NPCS_V3) NPCSpriteV3.preload(this, def);
+
+    // Companion constellation textures (cosmic-palette assets reused at V3
+    // until FM-palette companion sheets are generated). Loading aether +
+    // spectra matches V2 BootScene; other constellations lazy-load via
+    // AnimationSystem.loadConstellationTextures on demand.
+    AnimationSystem.preloadConstellations(this, ['aether', 'spectra']);
   }
 
   create() {
     PlayerSpriteV3.registerAnims(this);
+    CompanionSprite.generatePlaceholderTexture(this);
     EventBus.emit('boot-progress', { phase: 'ready' });
     this.scene.start('WorldSceneV3');
   }

--- a/game/v3/scenes/WorldSceneV3.ts
+++ b/game/v3/scenes/WorldSceneV3.ts
@@ -8,6 +8,18 @@ import {
   type NPCDefV3,
   type NPCSheet,
 } from '../config/npcDefinitionsV3';
+import { CompanionSprite } from '../../sprites/CompanionSprite';
+import {
+  AnimationSystem,
+  CONSTELLATIONS,
+  type CompanionMood,
+  type Constellation,
+} from '../../systems/AnimationSystem';
+import {
+  COSMETIC_SLOTS,
+  type CosmeticSlot,
+  type EquippedCosmetics,
+} from '../../systems/CosmeticSystem';
 
 const CAMERA_ZOOM = 1.5;
 const WATER_FPS = 6;
@@ -24,6 +36,8 @@ interface DoorMarker {
 
 export class WorldSceneV3 extends Phaser.Scene {
   private player!: PlayerSpriteV3;
+  private companion!: CompanionSprite;
+  private animSystem!: AnimationSystem;
   private npcs: NPCSpriteV3[] = [];
   private collisionGroup!: Phaser.Physics.Arcade.StaticGroup;
   private waterSprites: Phaser.GameObjects.Sprite[] = [];
@@ -130,6 +144,16 @@ export class WorldSceneV3 extends Phaser.Scene {
     this.physics.add.collider(this.player, this.collisionGroup);
     this.cameras.main.startFollow(this.player, true, 0.1, 0.1);
 
+    // -------- Companion --------
+    // Reuses V2's CompanionSprite + AnimationSystem (cosmic-palette assets).
+    // FM-palette companion sheets are tracked under [SWO_V3_COMPANION_FM_PALETTE]
+    // and will swap textures here once generated.
+    this.animSystem = new AnimationSystem(this);
+    this.companion = new CompanionSprite(this, spawnX + 20, spawnY + 10);
+    this.companion.setAnimationSystem(this.animSystem);
+    this.setupCompanionInteraction();
+    this.setupCompanionEventBridge();
+
     // -------- NPCs --------
     // The map declares which NPC sheet to render at each spot; we look up the
     // matching definition (for name + dialogue). Unknown names get a fallback.
@@ -177,6 +201,63 @@ export class WorldSceneV3 extends Phaser.Scene {
     EventBus.on('roomv3-exit', this.handleRoomExit, this);
 
     EventBus.emit('scene-ready', this);
+  }
+
+  private setupCompanionInteraction() {
+    this.companion.setInteractive({ useHandCursor: true });
+    this.companion.on('pointerdown', (pointer: Phaser.Input.Pointer) => {
+      const camera = this.cameras.main;
+      const canvas = this.game.canvas;
+      const screenX = (this.companion.x - camera.worldView.x) * camera.zoom + canvas.offsetLeft;
+      const screenY = (this.companion.y - camera.worldView.y) * camera.zoom + canvas.offsetTop;
+      EventBus.emit('companion-clicked', { screenX, screenY });
+      pointer.event.stopPropagation();
+    });
+  }
+
+  private setupCompanionEventBridge() {
+    EventBus.on('companion-mood', this.onCompanionMood, this);
+    EventBus.on('companion-constellation', this.onCompanionConstellation, this);
+    EventBus.on('companion-away', this.onCompanionAway, this);
+    EventBus.on('companion-equip-cosmetic', this.onCompanionEquip, this);
+    EventBus.on('companion-unequip-cosmetic', this.onCompanionUnequip, this);
+    EventBus.on('companion-cosmetics', this.onCompanionCosmetics, this);
+  }
+
+  private onCompanionMood(mood: string) {
+    const valid: CompanionMood[] = ['happy', 'calm', 'sleepy', 'excited', 'curious', 'idle'];
+    if (valid.includes(mood as CompanionMood)) this.companion.setMood(mood as CompanionMood);
+  }
+
+  private onCompanionConstellation(constellation: string) {
+    const lower = constellation.toLowerCase() as Constellation;
+    if ((CONSTELLATIONS as readonly string[]).includes(lower)) {
+      void this.companion.setConstellation(lower);
+    }
+  }
+
+  private onCompanionAway(data: { away: boolean }) {
+    this.companion.setAway(!!data?.away);
+  }
+
+  private onCompanionEquip(data: { slot: string; cosmeticId: string }) {
+    if (!data) return;
+    if (!(COSMETIC_SLOTS as readonly string[]).includes(data.slot)) return;
+    this.companion.equipCosmetic(data.slot as CosmeticSlot, data.cosmeticId);
+  }
+
+  private onCompanionUnequip(data: { slot: string }) {
+    if (!data) return;
+    if (!(COSMETIC_SLOTS as readonly string[]).includes(data.slot)) return;
+    this.companion.unequipCosmetic(data.slot as CosmeticSlot);
+  }
+
+  private onCompanionCosmetics(data: EquippedCosmetics | string) {
+    if (typeof data === 'string') {
+      this.companion.applyEquippedCosmeticsJson(data);
+    } else if (data && typeof data === 'object') {
+      this.companion.applyEquippedCosmetics(data);
+    }
   }
 
   private handleRoomExit(payload: { returnTo?: { x: number; y: number } } = {}) {
@@ -231,11 +312,20 @@ export class WorldSceneV3 extends Phaser.Scene {
 
   shutdown() {
     EventBus.off('roomv3-exit', this.handleRoomExit, this);
+    EventBus.off('companion-mood', this.onCompanionMood, this);
+    EventBus.off('companion-constellation', this.onCompanionConstellation, this);
+    EventBus.off('companion-away', this.onCompanionAway, this);
+    EventBus.off('companion-equip-cosmetic', this.onCompanionEquip, this);
+    EventBus.off('companion-unequip-cosmetic', this.onCompanionUnequip, this);
+    EventBus.off('companion-cosmetics', this.onCompanionCosmetics, this);
   }
 
   update(time: number) {
     if (!this.player) return;
     this.player.handleInput();
+    if (this.companion) {
+      this.companion.followPlayer(this.player.x, this.player.y, this.player.getDirection());
+    }
     for (const npc of this.npcs) npc.update(time);
     this.updateDoorDetection();
     if (this.currentDoor && Phaser.Input.Keyboard.JustDown(this.interactKey)) {

--- a/game/v3/sprites/PlayerSpriteV3.ts
+++ b/game/v3/sprites/PlayerSpriteV3.ts
@@ -79,6 +79,10 @@ export class PlayerSpriteV3 extends Phaser.Physics.Arcade.Sprite {
     if (this.shadow) this.shadow.setPosition(this.x, this.y + 22);
   }
 
+  getDirection(): Direction {
+    return this.direction;
+  }
+
   handleInput() {
     if (!this.cursors || !this.wasd) return;
     const body = this.body as Phaser.Physics.Arcade.Body;


### PR DESCRIPTION
## Summary

Closes the largest gap from the V3 parity audit (PR #254): V3 had no in-world companion. The radial menu, cosmetic equip rendering, and VFX visual hooks all blocked on this.

- **BootSceneV3** preloads the aether + spectra constellation textures and generates the placeholder companion texture (mirrors V2 BootScene).
- **WorldSceneV3** instantiates `CompanionSprite` 20 px north-east of the player on spawn, attaches a fresh `AnimationSystem`, and calls `companion.followPlayer()` from the update loop. Pointer-down emits `companion-clicked` with screen coords for `CompanionMenu` to anchor (same contract as V2).
- **WorldSceneV3** subscribes to the V2 EventBus topics: `companion-mood`, `companion-constellation`, `companion-away`, `companion-equip-cosmetic`, `companion-unequip-cosmetic`, `companion-cosmetics`. Subscriptions are torn down in `shutdown()`.
- **PlayerSpriteV3** gains `getDirection()` so the companion can pick a follow offset / walk-direction frame.

## Asset note

This PR reuses V2's cosmic-palette companion PNGs at `/sanctuary/companions/{constellation}/{mood}.png`. FM-palette companion sheets are tracked separately and will swap textures here once generated (blocked on `RD_API_KEY` operator action, like the rest of the V3 RD pipeline tasks).

## Out of scope (per parity audit follow-up rows)

- **RoomSceneV3 companion spawn** — V2's RoomScene re-spawns the companion inside each room; V3's room scene is procedural and small, so the follow-up `[SWO_V3_ROOM_INTERIOR_MAPS]` will revisit room companion placement alongside hand-authored maps.
- `[SWO_V3_RADIAL_MENU]` — radial menu mounting is now unblocked.

## Test plan

- [x] `npm run type-check` passes
- [x] `npm run lint` — no new errors in changed files
- [x] `npm run build` succeeds
- [x] `npm test` — pre-existing failures unchanged (api-e2e + roomScene), no new failures
- [ ] Operator: visit `localhost:3000/sanctuary?v=3`, verify companion spawns beside player, follows on movement, accepts cosmetic-equip via shop dialog
- [ ] Operator: confirm companion-clicked fires when companion is clicked (companion menu should anchor near it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)