### PR TITLE
feat(sanctuary v3): wire 7 minigames into V3 [SWO_V3_MINIGAMES]

### DIFF
--- a/components/sanctuary/overlays/MinigameDialog.tsx
+++ b/components/sanctuary/overlays/MinigameDialog.tsx
@@ -42,8 +42,12 @@ interface PersonalBest {
   total_star_earned: number;
 }
 
-// NPC IDs that launch minigames + their game_id mapping
+// NPC IDs that launch minigames + their game_id mapping. The owning
+// RoomScene overrides `defaultRoom` with its own room identifier on
+// launch — V2 uses Title-Case `RoomKey`, V3 uses kebab-case `BuildingId`
+// — so the value here only matters when launched from outside a room.
 const MINIGAME_NPCS: Record<string, { gameId: string; sceneKey: string; defaultRoom: string }> = {
+  // V2 (Title-Case rooms, dedicated minigame NPCs).
   'npc-observatory-arcade': {
     gameId: 'star-catch',
     sceneKey: 'StarCatchScene',
@@ -78,6 +82,40 @@ const MINIGAME_NPCS: Record<string, { gameId: string; sceneKey: string; defaultR
     gameId: 'lore-trivia',
     sceneKey: 'LoreTriviaScene',
     defaultRoom: 'Cosmic Library',
+  },
+
+  // V3 (kebab-case BuildingIds, one zone-keeper per zone). Each V3 NPC
+  // offers their zone's signature minigame. Zones with no minigame in
+  // V2 (training-grounds, star-garden) intentionally have no entry.
+  'observatory-owl': {
+    gameId: 'star-catch',
+    sceneKey: 'StarCatchScene',
+    defaultRoom: 'observatory',
+  },
+  'springs-duck': {
+    gameId: 'memory-match',
+    sceneKey: 'MemoryMatchScene',
+    defaultRoom: 'hot-springs',
+  },
+  'forge-golem': {
+    gameId: 'forge-hammer',
+    sceneKey: 'ForgeHammerScene',
+    defaultRoom: 'aura-forge',
+  },
+  'kitchen-bunny': {
+    gameId: 'cooking-rhythm',
+    sceneKey: 'CookingRhythmScene',
+    defaultRoom: 'nebula-kitchen',
+  },
+  'dream-sheep': {
+    gameId: 'dream-catcher',
+    sceneKey: 'DreamCatcherScene',
+    defaultRoom: 'dream-hollow',
+  },
+  'library-moth': {
+    gameId: 'lore-trivia',
+    sceneKey: 'LoreTriviaScene',
+    defaultRoom: 'cosmic-library',
   },
 };
 

--- a/game/scenes/MinigameScene.ts
+++ b/game/scenes/MinigameScene.ts
@@ -1,11 +1,13 @@
 import Phaser from 'phaser';
 import EventBus from '@/components/sanctuary/EventBus';
-import type { RoomKey } from '../config/worldLayout';
 
+// returnRoom is opaque to the minigame scene — it just echoes it back on
+// exit. V2 passes a Title-Case `RoomKey`; V3 passes a kebab-case
+// `BuildingId`. The owning room scene matches on whichever format it uses.
 export interface MinigameLaunchData {
   gameId: string;
   tokenId: number | null;
-  returnRoom: RoomKey;
+  returnRoom: string;
   returnTo: { x: number; y: number };
   durationSeconds?: number;
   title?: string;
@@ -36,7 +38,7 @@ export abstract class MinigameScene extends Phaser.Scene {
   protected gameId: string = '';
   protected gameTitle: string = 'MINIGAME';
   protected tokenId: number | null = null;
-  protected returnRoom: RoomKey | null = null;
+  protected returnRoom: string | null = null;
   protected returnTo: { x: number; y: number } = { x: 600, y: 800 };
   protected durationSeconds: number = 60;
   protected score: number = 0;

--- a/game/v3/config/GameConfigV3.ts
+++ b/game/v3/config/GameConfigV3.ts
@@ -2,6 +2,14 @@ import Phaser from 'phaser';
 import { BootSceneV3 } from '../scenes/BootSceneV3';
 import { WorldSceneV3 } from '../scenes/WorldSceneV3';
 import { RoomSceneV3 } from '../scenes/RoomSceneV3';
+// Minigame scenes are shared logic — V3 reuses the V2 implementations.
+import { StarCatchScene } from '../../scenes/StarCatchScene';
+import { MemoryMatchScene } from '../../scenes/MemoryMatchScene';
+import { StarConnectScene } from '../../scenes/StarConnectScene';
+import { ForgeHammerScene } from '../../scenes/ForgeHammerScene';
+import { CookingRhythmScene } from '../../scenes/CookingRhythmScene';
+import { DreamCatcherScene } from '../../scenes/DreamCatcherScene';
+import { LoreTriviaScene } from '../../scenes/LoreTriviaScene';
 
 export const GAME_CONFIG_V3: Phaser.Types.Core.GameConfig = {
   type: Phaser.AUTO,
@@ -17,7 +25,18 @@ export const GAME_CONFIG_V3: Phaser.Types.Core.GameConfig = {
     default: 'arcade',
     arcade: { gravity: { x: 0, y: 0 }, debug: false },
   },
-  scene: [BootSceneV3, WorldSceneV3, RoomSceneV3],
+  scene: [
+    BootSceneV3,
+    WorldSceneV3,
+    RoomSceneV3,
+    StarCatchScene,
+    MemoryMatchScene,
+    StarConnectScene,
+    ForgeHammerScene,
+    CookingRhythmScene,
+    DreamCatcherScene,
+    LoreTriviaScene,
+  ],
   pixelArt: true,
   antialias: false,
   roundPixels: true,

--- a/game/v3/scenes/RoomSceneV3.ts
+++ b/game/v3/scenes/RoomSceneV3.ts
@@ -79,7 +79,69 @@ export class RoomSceneV3 extends Phaser.Scene {
     this.setupExit();
     this.setupHUD();
 
+    EventBus.on('minigame-launch', this.handleMinigameLaunch, this);
+    EventBus.on('minigame-exit', this.handleMinigameExit, this);
+
     EventBus.emit('scene-ready', this);
+  }
+
+  private handleMinigameLaunch(payload: {
+    gameId: string;
+    sceneKey: string;
+    tokenId: number | null;
+    durationSeconds?: number;
+    title?: string;
+  }) {
+    if (this.exiting) return;
+    if (!this.scene.manager.keys[payload.sceneKey]) return;
+    this.cameras.main.fadeOut(250, 0, 0, 0);
+    this.time.delayedCall(260, () => {
+      const returnTo = { x: this.player.x, y: this.player.y };
+      this.scene.sleep();
+      // Override returnRoom to this scene's kebab-case BuildingId so the
+      // minigame echoes a value the V3 exit listener will recognise. V2's
+      // RoomScene does the same with its Title-Case RoomKey.
+      this.scene.launch(payload.sceneKey, {
+        gameId: payload.gameId,
+        tokenId: payload.tokenId,
+        returnRoom: this.roomId,
+        returnTo,
+        durationSeconds: payload.durationSeconds,
+        title: payload.title,
+      });
+    });
+  }
+
+  private handleMinigameExit(payload: {
+    sceneKey?: string;
+    returnRoom?: string;
+    returnTo?: { x: number; y: number };
+  }) {
+    if (!payload?.returnRoom || payload.returnRoom !== this.roomId) return;
+    if (!this.scene.isSleeping()) return;
+    if (payload.sceneKey && this.scene.manager.getScene(payload.sceneKey)) {
+      this.scene.stop(payload.sceneKey);
+    } else {
+      const keys = [
+        'StarCatchScene',
+        'MemoryMatchScene',
+        'StarConnectScene',
+        'ForgeHammerScene',
+        'LoreTriviaScene',
+        'CookingRhythmScene',
+        'DreamCatcherScene',
+      ];
+      for (const k of keys) {
+        if (this.scene.manager.getScene(k)?.scene.isActive()) {
+          this.scene.stop(k);
+        }
+      }
+    }
+    this.scene.wake();
+    this.cameras.main.fadeIn(250, 0, 0, 0);
+    if (payload.returnTo && this.player) {
+      this.player.setPosition(payload.returnTo.x, payload.returnTo.y);
+    }
   }
 
   private renderInterior() {
@@ -216,5 +278,10 @@ export class RoomSceneV3 extends Phaser.Scene {
     if (!this.player || this.exiting) return;
     this.player.handleInput();
     this.npc?.update(time);
+  }
+
+  shutdown() {
+    EventBus.off('minigame-launch', this.handleMinigameLaunch, this);
+    EventBus.off('minigame-exit', this.handleMinigameExit, this);
   }
 }


### PR DESCRIPTION
## Summary

Closes the V3 parity-audit row "Minigames (7 scenes)" (PR #254). V3 launched the same `MinigameDialog` overlay as V2, but the dialog's emitted `minigame-launch` event landed on no listener — `RoomSceneV3` didn't subscribe and the scenes weren't registered in `GameConfigV3` — so playing was silently broken at `?v=3`.

- **GameConfigV3** registers all 7 V2 minigame scenes (StarCatch, MemoryMatch, StarConnect, ForgeHammer, CookingRhythm, DreamCatcher, LoreTrivia) so `scene.launch(sceneKey, …)` resolves at runtime.
- **RoomSceneV3** subscribes to `minigame-launch` and `minigame-exit`, mirroring V2's `RoomScene`. On launch, sleep this room and start the requested scene; on exit (gated by `returnRoom === this.roomId`), wake the room and restore player position.
- The launch handler overrides `returnRoom` with this scene's kebab-case `BuildingId`. The minigame echoes that value back on exit, so the kebab-case ↔ Title-Case bridge stays inside the owning room scene — minigame logic remains format-agnostic.
- **MinigameScene** relaxes `MinigameLaunchData.returnRoom` from `RoomKey` to `string`. The value is opaque to the scene (just echoed on exit), and V3 needs to pass kebab-case BuildingIds without a circular V2 import.
- **MinigameDialog** extends `MINIGAME_NPCS` with 6 V3 entries — each V3 zone-keeper offers their zone's signature minigame. Zones with no V2 minigame counterpart (training-grounds, star-garden) are intentionally omitted; star-connect is dropped from V3 since each V3 zone has only one NPC slot.

## V3 NPC → minigame mapping

| V3 NPC | Zone (kebab) | Minigame |
|---|---|---|
| `observatory-owl` | `observatory` | star-catch |
| `springs-duck` | `hot-springs` | memory-match |
| `forge-golem` | `aura-forge` | forge-hammer |
| `kitchen-bunny` | `nebula-kitchen` | cooking-rhythm |
| `dream-sheep` | `dream-hollow` | dream-catcher |
| `library-moth` | `cosmic-library` | lore-trivia |

## Out of scope

- V3-native minigame visuals — scenes still use cosmic palette internally. Re-skinning to FM palette is a follow-up.
- StarConnect for V3 — would need a second NPC slot in observatory.

## Test plan

- [x] `npm run type-check` passes
- [x] `npm run lint` — no new errors in changed files
- [x] `npm run build` succeeds
- [x] `npm test -- game/__tests__/` — 43/44 pass (1 pre-existing roomScene source-text assertion unrelated)
- [ ] Operator: visit `localhost:3000/sanctuary?v=3`, walk into a zone, click the zone NPC, confirm the MinigameDialog opens, click "Begin", confirm the minigame scene launches, exit via ESC, confirm return to V3 room

🤖 Generated with [Claude Code](https://claude.com/claude-code)