### PR TITLE
feat(sanctuary): share InteractAction→VfxKind mapping for V2/V3 radial menus

### DIFF
--- a/components/sanctuary/overlays/CompanionMenu.tsx
+++ b/components/sanctuary/overlays/CompanionMenu.tsx
@@ -5,17 +5,11 @@ import EventBus from '@/components/sanctuary/EventBus';
 import { getWalletAuthHeader } from '@/lib/clientWalletAuth';
 import {
   emitCompanionVfx,
-  type CompanionVfxKind,
+  vfxKindForInteractAction,
+  type CompanionInteractAction,
 } from '@/lib/sanctuary/vfxEvents';
 
-type InteractAction = 'pet' | 'feed' | 'talk';
-
-// Map interact action → shared VFX kind. `talk` opens the chat overlay
-// instead of rendering a reaction, so it has no VFX entry.
-const ACTION_VFX: Partial<Record<InteractAction, CompanionVfxKind>> = {
-  pet: 'sparkle',
-  feed: 'food',
-};
+type InteractAction = CompanionInteractAction;
 
 interface MenuPosition {
   x: number;
@@ -130,7 +124,7 @@ export default function CompanionMenu({
     // Publish through the shared VFX contract so V3 (and any future
     // listener — analytics, replay capture, etc.) can render its own
     // sprite-sheet effect. V2 keeps its inline emoji rendering above.
-    const kind = ACTION_VFX[action];
+    const kind = vfxKindForInteractAction(action);
     if (kind) {
       emitCompanionVfx(EventBus, { kind, x, y, durationMs: 800, source: action });
     }

--- a/lib/sanctuary/__tests__/vfxEvents.test.ts
+++ b/lib/sanctuary/__tests__/vfxEvents.test.ts
@@ -2,10 +2,13 @@
 import { describe, it, expect, vi } from 'vitest';
 
 import {
+  COMPANION_INTERACT_VFX,
   COMPANION_VFX_EVENT,
   COMPANION_VFX_KINDS,
   emitCompanionVfx,
   onCompanionVfx,
+  vfxKindForInteractAction,
+  type CompanionInteractAction,
   type CompanionVfxPayload,
   type VfxEventBus,
 } from '../vfxEvents';
@@ -124,5 +127,49 @@ describe('companion VFX event contract', () => {
     }
 
     expect(seen).toEqual([...COMPANION_VFX_KINDS]);
+  });
+});
+
+describe('companion interact-action → VFX-kind mapping', () => {
+  it('maps pet → sparkle and feed → food', () => {
+    expect(vfxKindForInteractAction('pet')).toBe('sparkle');
+    expect(vfxKindForInteractAction('feed')).toBe('food');
+  });
+
+  it('returns undefined for talk (no VFX — opens chat overlay)', () => {
+    expect(vfxKindForInteractAction('talk')).toBeUndefined();
+  });
+
+  it('exposes a frozen mapping with the same kinds the helper resolves', () => {
+    expect(Object.isFrozen(COMPANION_INTERACT_VFX)).toBe(true);
+    expect(COMPANION_INTERACT_VFX.pet).toBe('sparkle');
+    expect(COMPANION_INTERACT_VFX.feed).toBe('food');
+    expect(COMPANION_INTERACT_VFX.talk).toBeUndefined();
+  });
+
+  it('every mapped kind is a recognised CompanionVfxKind', () => {
+    for (const kind of Object.values(COMPANION_INTERACT_VFX)) {
+      if (kind === undefined) continue;
+      expect(COMPANION_VFX_KINDS).toContain(kind);
+    }
+  });
+
+  it('round-trips through emitCompanionVfx for every action that has a VFX', () => {
+    const bus = makeBus();
+    const seen: CompanionVfxPayload[] = [];
+    onCompanionVfx(bus, (p) => seen.push(p));
+
+    const actions: CompanionInteractAction[] = ['pet', 'feed', 'talk'];
+    for (const action of actions) {
+      const kind = vfxKindForInteractAction(action);
+      if (kind) {
+        emitCompanionVfx(bus, { kind, x: 1, y: 2, source: action });
+      }
+    }
+
+    expect(seen).toEqual([
+      { kind: 'sparkle', x: 1, y: 2, source: 'pet' },
+      { kind: 'food', x: 1, y: 2, source: 'feed' },
+    ]);
   });
 });

--- a/lib/sanctuary/vfxEvents.ts
+++ b/lib/sanctuary/vfxEvents.ts
@@ -111,3 +111,37 @@ export function onCompanionVfx(
     bus.off(COMPANION_VFX_EVENT, listener, ctx);
   };
 }
+
+/**
+ * Companion radial-menu actions. Source of truth lives in
+ * `lib/sanctuary/validation.ts` (the API contract); this is the matching
+ * client-facing literal type so V2 + V3 radial menus share one mapping.
+ */
+export type CompanionInteractAction = 'pet' | 'feed' | 'talk';
+
+/**
+ * Canonical mapping: which VFX kind a given radial-menu action should
+ * trigger. `talk` opens the chat overlay through a separate event and has
+ * no VFX, so it is intentionally absent from the map.
+ *
+ * Both V2 (`CompanionMenu.tsx`) and the future V3 RadialMenu must consume
+ * this mapping rather than redeclaring it locally — keeps `pet → sparkle`
+ * and `feed → food` consistent across visual tracks.
+ */
+export const COMPANION_INTERACT_VFX: Readonly<
+  Partial<Record<CompanionInteractAction, CompanionVfxKind>>
+> = Object.freeze({
+  pet: 'sparkle',
+  feed: 'food',
+});
+
+/**
+ * Lookup helper: returns the VFX kind for an action, or `undefined` if the
+ * action has no associated VFX (e.g. `talk`). Use this in radial-menu code
+ * to decide whether to call {@link emitCompanionVfx}.
+ */
+export function vfxKindForInteractAction(
+  action: CompanionInteractAction,
+): CompanionVfxKind | undefined {
+  return COMPANION_INTERACT_VFX[action];
+}


### PR DESCRIPTION
## Summary

Promotes the `InteractAction → CompanionVfxKind` mapping from V2's `CompanionMenu` into the shared trigger contract at `lib/sanctuary/vfxEvents.ts`, so the upcoming V3 RadialMenu can publish `pet → sparkle` / `feed → food` without redeclaring the mapping (drift risk) or importing a private constant from a V2 component.

This is a follow-up to **#251 [SWO_SHARED_VFX_TRIGGER_API]**, which shipped the `companion:vfx` event + `emitCompanionVfx`/`onCompanionVfx` helpers. The trigger contract was deliberately scoped to *trigger only* — and the V2 menu's local action-mapping was the last piece that wasn't actually shared. This PR closes that gap.

## Changes

**`lib/sanctuary/vfxEvents.ts`**
- `CompanionInteractAction` literal type (`'pet' | 'feed' | 'talk'`) — mirrors the Zod API contract in `lib/sanctuary/validation.ts`
- `COMPANION_INTERACT_VFX` — frozen `Readonly<Partial<Record<…>>>` with `pet → sparkle`, `feed → food`. `talk` has no VFX (opens chat overlay) and is intentionally absent.
- `vfxKindForInteractAction(action)` — lookup helper returning `CompanionVfxKind | undefined`

**`components/sanctuary/overlays/CompanionMenu.tsx`**
- Removed local `ACTION_VFX` constant and inline `InteractAction` string-union
- Imports the shared type and helper. Behaviour unchanged.

**`lib/sanctuary/__tests__/vfxEvents.test.ts`**
- Five new tests under a new `companion interact-action → VFX-kind mapping` describe block: `pet → sparkle`, `feed → food`, `talk → undefined`, mapping is frozen, every mapped kind is in `COMPANION_VFX_KINDS`, and round-trip through `emitCompanionVfx` for every action that has a VFX.

## Test plan

- [x] `npx vitest run lib/sanctuary/__tests__/vfxEvents.test.ts` — 12/12 pass (7 prior + 5 new)
- [x] `npx vitest run` — 473 pass, 5 pre-existing failures unrelated (api-e2e nft-traits x2, chat history limit, interact action message, roomScene v3 — all noted in prior PR #251 baseline)
- [x] `npm run type-check` — clean
- [x] `npx eslint` on the three touched files — clean
- [x] Manual review: V2 emit path unchanged; V3 RadialMenu (future) can now `import { vfxKindForInteractAction } from '@/lib/sanctuary/vfxEvents'`

## Mirror Validation (PROD)

Ran baseline-diff against `/opt/star_world_order/PROD` (mirror is currently at PR #244, predates PR #251 — `vfxEvents.ts` does not exist in baseline so the file was overlaid in full):

- **tsc --noEmit**: PASS — 412 baseline error lines before overlay, 412 after; `diff` is empty (no new tsc errors). 412 baseline errors all pre-existing in PROD (V3 sprites missing Phaser deps, colyseus.js module not installed, etc.) and excluded from the diff.
- **vitest run**: PASS — 428 passed, 5 failed before AND after overlay (same 5 pre-existing failures); the new `vfxEvents.test.ts` adds 12 passing tests on top with no new failures.

Overall: **PASS**

Mirror restored to byte-identical state.

## Task linkage

- Original task: `[SWO_SHARED_VFX_TRIGGER_API]` (PROJECT:SWO, P2)
- PR class: **A** (full completion of the residual scope after #251 — the *trigger contract* now genuinely covers both the event and the action-mapping)
- Follow-ups (separate tasks): `[SWO_V3_COMPANION_SPRITE]`, `[SWO_V3_RADIAL_MENU]`, `[SWO_V3_VFX_SPRITES]` will consume this mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)