### PR TITLE
feat(sanctuary v3): emit location-entered/exited from V3 zones [SWO_V3_LOCATION_EVENTS]

### DIFF
--- a/game/v3/__tests__/buildingDisplayNames.test.ts
+++ b/game/v3/__tests__/buildingDisplayNames.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import {
+  BUILDING_IDS,
+  BUILDING_DISPLAY_NAMES,
+  type BuildingId,
+} from '../config/npcDefinitionsV3';
+
+const AUDIO_AMBIENT_KEYS = [
+  'Hot Springs',
+  'Training Grounds',
+  'Dream Hollow',
+  'Star Garden',
+  'Nebula Kitchen',
+  'Cosmic Library',
+  'Observatory',
+  'Aura Forge',
+];
+
+describe('BUILDING_DISPLAY_NAMES', () => {
+  it('covers every BuildingId', () => {
+    for (const id of BUILDING_IDS) {
+      expect(BUILDING_DISPLAY_NAMES[id]).toBeTruthy();
+    }
+  });
+
+  it('display names match shared audio AMBIENT_TRACKS keys', () => {
+    const displayNames = (BUILDING_IDS as readonly BuildingId[]).map(
+      id => BUILDING_DISPLAY_NAMES[id],
+    );
+    for (const expected of AUDIO_AMBIENT_KEYS) {
+      expect(displayNames).toContain(expected);
+    }
+  });
+
+  it('display names match V2 DOORS room values for parity', async () => {
+    const { DOORS } = await import('../../config/worldLayout');
+    const v2Rooms = new Set(DOORS.map(d => d.room as string));
+    const v3Names = new Set(
+      (BUILDING_IDS as readonly BuildingId[]).map(id => BUILDING_DISPLAY_NAMES[id]),
+    );
+    for (const name of v3Names) {
+      expect(v2Rooms.has(name)).toBe(true);
+    }
+  });
+});

--- a/game/v3/config/npcDefinitionsV3.ts
+++ b/game/v3/config/npcDefinitionsV3.ts
@@ -18,6 +18,20 @@ export const BUILDING_IDS: readonly BuildingId[] = [
   'training-grounds', 'dream-hollow', 'nebula-kitchen', 'aura-forge',
 ] as const;
 
+// Display names matching V2's `Door.room` values + audio.ts AMBIENT_TRACKS keys.
+// Used by WorldSceneV3 to emit `location-entered`/`location-exited` events that
+// the shared audio service + Colyseus multiplayer hook already consume.
+export const BUILDING_DISPLAY_NAMES: Readonly<Record<BuildingId, string>> = Object.freeze({
+  'hot-springs': 'Hot Springs',
+  observatory: 'Observatory',
+  'training-grounds': 'Training Grounds',
+  'star-garden': 'Star Garden',
+  'cosmic-library': 'Cosmic Library',
+  'nebula-kitchen': 'Nebula Kitchen',
+  'dream-hollow': 'Dream Hollow',
+  'aura-forge': 'Aura Forge',
+});
+
 export type NPCSheet =
   | 'spawn-fox'
   | 'springs-duck'

--- a/game/v3/scenes/WorldSceneV3.ts
+++ b/game/v3/scenes/WorldSceneV3.ts
@@ -4,6 +4,7 @@ import { PlayerSpriteV3 } from '../sprites/PlayerSpriteV3';
 import { NPCSpriteV3 } from '../sprites/NPCSpriteV3';
 import {
   NPCS_V3,
+  BUILDING_DISPLAY_NAMES,
   type BuildingId,
   type NPCDefV3,
   type NPCSheet,
@@ -290,7 +291,15 @@ export class WorldSceneV3 extends Phaser.Scene {
         break;
       }
     }
-    this.currentDoor = inside;
+    if (inside !== this.currentDoor) {
+      if (this.currentDoor) {
+        EventBus.emit('location-exited', { name: BUILDING_DISPLAY_NAMES[this.currentDoor.roomId] });
+      }
+      if (inside) {
+        EventBus.emit('location-entered', { name: BUILDING_DISPLAY_NAMES[inside.roomId] });
+      }
+      this.currentDoor = inside;
+    }
     if (inside && this.doorPrompt) {
       this.doorPrompt.setText(`[E] ENTER ${inside.roomId.toUpperCase().replace(/-/g, ' ')}`);
       this.doorPrompt.setPosition(inside.x, inside.y - 6);


### PR DESCRIPTION
## Summary
- WorldSceneV3 now emits `location-entered` / `location-exited` on door-zone transitions, matching V2's WorldScene contract.
- Adds `BUILDING_DISPLAY_NAMES` mapping to bridge V3's kebab-case `BuildingId` to the display names used by `lib/sanctuary/audio.ts` (AMBIENT_TRACKS keys) and `lib/colyseus/useMultiplayer.ts`.
- Unblocks per-zone ambient audio crossfade and zone-aware multiplayer filtering at `?v=3` without changing any V2 behavior.

## Test plan
- [x] `npm run type-check` passes
- [x] `npx vitest run game/v3/__tests__/buildingDisplayNames.test.ts` — 3 passed (covers BuildingId, AMBIENT_TRACKS keys, V2 parity)
- [ ] Smoke at `localhost:3000/sanctuary?v=3`: walk into Observatory door zone — audio service should switch to observatory ambient track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)