### PR TITLE
feat(sanctuary v3): mount radial CompanionMenu overlay [SWO_V3_RADIAL_MENU]

### DIFF
--- a/app/sanctuary/SanctuaryV3.tsx
+++ b/app/sanctuary/SanctuaryV3.tsx
@@ -15,6 +15,10 @@ const CompanionHUD = dynamic(
   () => import('@/components/sanctuary/overlays/CompanionHUD'),
   { ssr: false },
 );
+const CompanionMenu = dynamic(
+  () => import('@/components/sanctuary/overlays/CompanionMenu'),
+  { ssr: false },
+);
 const QuestDialog = dynamic(
   () => import('@/components/sanctuary/overlays/QuestDialog'),
   { ssr: false },
@@ -68,7 +72,9 @@ export default function SanctuaryV3() {
   const gameRef = useRef<PhaserGameV3Ref | null>(null);
   const { address, isConnected } = useAccount();
   const [activeTokenId, setActiveTokenId] = useState<number | null>(null);
+  const [refreshKey, setRefreshKey] = useState(0);
   const handleSceneReady = useCallback(() => {}, []);
+  const handleInteracted = useCallback(() => setRefreshKey((k) => k + 1), []);
 
   useEffect(() => {
     if (!address) return;
@@ -86,7 +92,7 @@ export default function SanctuaryV3() {
       }
     })();
     return () => { cancelled = true; };
-  }, [address]);
+  }, [address, refreshKey]);
 
   return (
     <div className="space-y-4">
@@ -116,6 +122,7 @@ export default function SanctuaryV3() {
       <div className="relative bg-black/80 border border-[#9966ff]/30 rounded-lg overflow-hidden shadow-[0_0_15px_rgba(153,102,255,0.15)]">
         <PhaserGameV3 ref={gameRef} onSceneReady={handleSceneReady} />
         <CompanionHUD walletAddress={address} />
+        <CompanionMenu walletAddress={address} tokenId={activeTokenId} onInteracted={handleInteracted} />
         <QuestDialog walletAddress={address} tokenId={activeTokenId} />
         <MinigameDialog walletAddress={address} tokenId={activeTokenId} />
         <QuestBoard walletAddress={address} tokenId={activeTokenId} />
@@ -131,7 +138,7 @@ export default function SanctuaryV3() {
       </div>
 
       <div className="text-xs text-gray-500 px-2">
-        Move with WASD or arrow keys. Click an NPC to interact. Press <kbd>C</kbd> to chat with your companion, <kbd>J</kbd> for journal, <kbd>T</kbd> for traits. V3 is in active development.
+        Move with WASD or arrow keys. Click your companion to pet, feed, or talk. Click an NPC to interact. Press <kbd>C</kbd> to chat with your companion, <kbd>J</kbd> for journal, <kbd>T</kbd> for traits. V3 is in active development.
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Mounts the V2 `CompanionMenu` (Pet / Feed / Talk radial menu) inside `SanctuaryV3.tsx` so clicking the companion sprite in V3 finally produces the radial menu instead of a dead click.
- WorldSceneV3 was already emitting `companion-clicked` (shipped in #255) — only the React-side listener was missing.
- Adds the V2-pattern `refreshKey` + `onInteracted` so the companion fetch refreshes after pet/feed, and updates the help text to mention the click.
- Reuses the existing shared event chain: `companion-clicked` → `companion-interacted` → `companion-mood` plus the `[SWO_SHARED_VFX_TRIGGER_API]` contract (#257). No new events.

## Test plan
- [x] `npm run type-check` passes
- [x] `npx eslint app/sanctuary/SanctuaryV3.tsx` clean
- [ ] Smoke at `localhost:3000/sanctuary?v=3`: click companion → radial menu opens; Pet → sparkle reaction + "+Bond/+XP" floating text; Feed → bounce reaction; Talk → opens chat overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)