### PR TITLE
feat(sanctuary v3): EasyStar click-to-move pathfinding [SWO_V3_PLAYER_PATHFINDING]

### DIFF
--- a/game/v3/__tests__/pathfindingNavGrid.test.ts
+++ b/game/v3/__tests__/pathfindingNavGrid.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+
+// Mirror of WorldSceneV3's nav-grid construction so we can test it without
+// booting Phaser. Keep these constants in sync with WorldSceneV3.ts.
+const NAV_CELL = 16;
+
+interface Rect { x: number; y: number; w: number; h: number }
+
+function buildNavGrid(worldW: number, worldH: number, rects: Rect[]): number[][] {
+  const gridW = Math.ceil(worldW / NAV_CELL);
+  const gridH = Math.ceil(worldH / NAV_CELL);
+  const grid = Array.from({ length: gridH }, () =>
+    Array.from({ length: gridW }, () => 0),
+  );
+  for (const rect of rects) {
+    const x0 = Math.max(0, Math.floor(rect.x / NAV_CELL));
+    const y0 = Math.max(0, Math.floor(rect.y / NAV_CELL));
+    const x1 = Math.min(gridW - 1, Math.floor((rect.x + rect.w - 1) / NAV_CELL));
+    const y1 = Math.min(gridH - 1, Math.floor((rect.y + rect.h - 1) / NAV_CELL));
+    for (let y = y0; y <= y1; y++) {
+      for (let x = x0; x <= x1; x++) grid[y][x] = 1;
+    }
+  }
+  return grid;
+}
+
+describe('V3 nav grid construction', () => {
+  it('produces a grid sized to worldW/worldH at NAV_CELL granularity', () => {
+    const grid = buildNavGrid(1920, 1280, []);
+    expect(grid.length).toBe(80);
+    expect(grid[0].length).toBe(120);
+    for (const row of grid) for (const cell of row) expect(cell).toBe(0);
+  });
+
+  it('blocks every cell touched by a collision rect', () => {
+    const grid = buildNavGrid(128, 128, [{ x: 32, y: 32, w: 32, h: 32 }]);
+    expect(grid[2][2]).toBe(1);
+    expect(grid[2][3]).toBe(1);
+    expect(grid[3][2]).toBe(1);
+    expect(grid[3][3]).toBe(1);
+    expect(grid[1][1]).toBe(0);
+    expect(grid[4][4]).toBe(0);
+  });
+
+  it('clamps rects that overflow the world bounds', () => {
+    const grid = buildNavGrid(64, 64, [{ x: -16, y: -16, w: 32, h: 32 }]);
+    expect(grid[0][0]).toBe(1);
+    expect(grid.length).toBe(4);
+    expect(grid[0].length).toBe(4);
+  });
+
+  it('half-tile resolution exposes corner walkability inside a 32x32 tile', () => {
+    // A single 16×16 collision in the top-left of a 32×32 tile should leave
+    // the other three half-tiles walkable. This is V2's pathing-detail win
+    // that V3 inherits.
+    const grid = buildNavGrid(32, 32, [{ x: 0, y: 0, w: 16, h: 16 }]);
+    expect(grid[0][0]).toBe(1);
+    expect(grid[0][1]).toBe(0);
+    expect(grid[1][0]).toBe(0);
+    expect(grid[1][1]).toBe(0);
+  });
+});

--- a/game/v3/scenes/WorldSceneV3.ts
+++ b/game/v3/scenes/WorldSceneV3.ts
@@ -1,4 +1,5 @@
 import Phaser from 'phaser';
+import * as EasyStar from 'easystarjs';
 import EventBus from '@/components/sanctuary/EventBus';
 import { PlayerSpriteV3 } from '../sprites/PlayerSpriteV3';
 import { NPCSpriteV3 } from '../sprites/NPCSpriteV3';
@@ -24,6 +25,7 @@ import {
 const CAMERA_ZOOM = 1.5;
 const WATER_FPS = 6;
 const TILE = 32;
+const NAV_CELL = 16; // half-tile pathfinding grid, matches V2's WorldScene
 
 interface DoorMarker {
   roomId: BuildingId;
@@ -45,6 +47,11 @@ export class WorldSceneV3 extends Phaser.Scene {
   private currentDoor: DoorMarker | null = null;
   private doorPrompt: Phaser.GameObjects.Text | null = null;
   private interactKey!: Phaser.Input.Keyboard.Key;
+  private finder!: EasyStar.js;
+  private navGrid: number[][] = [];
+  private gridW = 0;
+  private gridH = 0;
+  private clickMarker: Phaser.GameObjects.Graphics | null = null;
 
   constructor() { super({ key: 'WorldSceneV3' }); }
 
@@ -125,13 +132,42 @@ export class WorldSceneV3 extends Phaser.Scene {
     // -------- Collision --------
     this.collisionGroup = this.physics.add.staticGroup();
     const collide = map.getObjectLayer('collision')?.objects ?? [];
+    const collisionRects: { x: number; y: number; w: number; h: number }[] = [];
     for (const o of collide) {
-      const cx = (o.x ?? 0) + (o.width ?? 0) / 2;
-      const cy = (o.y ?? 0) + (o.height ?? 0) / 2;
-      const zone = this.add.zone(cx, cy, o.width ?? 32, o.height ?? 32);
+      const w = o.width ?? 32;
+      const h = o.height ?? 32;
+      const ox = o.x ?? 0;
+      const oy = o.y ?? 0;
+      const cx = ox + w / 2;
+      const cy = oy + h / 2;
+      const zone = this.add.zone(cx, cy, w, h);
       this.physics.add.existing(zone, true);
       this.collisionGroup.add(zone);
+      collisionRects.push({ x: ox, y: oy, w, h });
     }
+
+    // -------- Pathfinding nav grid + finder --------
+    // Mirrors V2 WorldScene's setup so click-to-move feels the same. The
+    // grid blocks every cell touched by a collision rect.
+    this.gridW = Math.ceil(worldW / NAV_CELL);
+    this.gridH = Math.ceil(worldH / NAV_CELL);
+    this.navGrid = Array.from({ length: this.gridH }, () =>
+      Array.from({ length: this.gridW }, () => 0),
+    );
+    for (const rect of collisionRects) {
+      const x0 = Math.max(0, Math.floor(rect.x / NAV_CELL));
+      const y0 = Math.max(0, Math.floor(rect.y / NAV_CELL));
+      const x1 = Math.min(this.gridW - 1, Math.floor((rect.x + rect.w - 1) / NAV_CELL));
+      const y1 = Math.min(this.gridH - 1, Math.floor((rect.y + rect.h - 1) / NAV_CELL));
+      for (let y = y0; y <= y1; y++) {
+        for (let x = x0; x <= x1; x++) this.navGrid[y][x] = 1;
+      }
+    }
+    this.finder = new EasyStar.js();
+    this.finder.setGrid(this.navGrid);
+    this.finder.setAcceptableTiles([0]);
+    this.finder.enableDiagonals();
+    this.finder.setIterationsPerCalculation(200);
 
     // -------- Spawn the player --------
     // Pick spawn from the NPCs object layer's 'spawn-fox' position; if missing
@@ -141,8 +177,10 @@ export class WorldSceneV3 extends Phaser.Scene {
     const spawnX = fox ? (fox.x ?? 0) - 64 : worldW / 2;
     const spawnY = fox ? (fox.y ?? 0) + 32 : worldH / 2;
     this.player = new PlayerSpriteV3(this, spawnX, spawnY);
+    this.player.setNavCell(NAV_CELL);
     this.physics.add.collider(this.player, this.collisionGroup);
     this.cameras.main.startFollow(this.player, true, 0.1, 0.1);
+    this.setupClickToMove();
 
     // -------- Companion --------
     // Reuses V2's CompanionSprite + AnimationSystem (cosmic-palette assets).
@@ -201,6 +239,44 @@ export class WorldSceneV3 extends Phaser.Scene {
     EventBus.on('roomv3-exit', this.handleRoomExit, this);
 
     EventBus.emit('scene-ready', this);
+  }
+
+  private setupClickToMove() {
+    this.clickMarker = this.add.graphics().setDepth(5);
+    this.input.on('pointerdown', (pointer: Phaser.Input.Pointer) => {
+      if (pointer.rightButtonDown()) return;
+      const worldX = pointer.worldX;
+      const worldY = pointer.worldY;
+      const gx = Math.floor(worldX / NAV_CELL);
+      const gy = Math.floor(worldY / NAV_CELL);
+      if (gx < 0 || gy < 0 || gx >= this.gridW || gy >= this.gridH) return;
+      if (this.navGrid[gy][gx] === 1) return;
+
+      this.showClickMarker(worldX, worldY);
+
+      const playerGx = Math.floor(this.player.x / NAV_CELL);
+      const playerGy = Math.floor(this.player.y / NAV_CELL);
+      this.finder.findPath(playerGx, playerGy, gx, gy, (path) => {
+        if (path && path.length > 1) this.player.setPath(path);
+      });
+      this.finder.calculate();
+    });
+  }
+
+  private showClickMarker(x: number, y: number) {
+    if (!this.clickMarker) return;
+    this.clickMarker.clear();
+    this.clickMarker.lineStyle(1, 0xffd700, 0.9);
+    this.clickMarker.strokeCircle(x, y, 5);
+    this.clickMarker.setAlpha(1);
+    this.tweens.add({
+      targets: this.clickMarker,
+      alpha: 0,
+      duration: 600,
+      onComplete: () => {
+        this.clickMarker?.clear();
+      },
+    });
   }
 
   private setupCompanionInteraction() {
@@ -322,7 +398,8 @@ export class WorldSceneV3 extends Phaser.Scene {
 
   update(time: number) {
     if (!this.player) return;
-    this.player.handleInput();
+    const keyboardActive = this.player.handleInput();
+    if (!keyboardActive) this.player.updatePathMovement();
     if (this.companion) {
       this.companion.followPlayer(this.player.x, this.player.y, this.player.getDirection());
     }

--- a/game/v3/sprites/PlayerSpriteV3.ts
+++ b/game/v3/sprites/PlayerSpriteV3.ts
@@ -16,11 +16,17 @@ const DIRECTION_ROW: Record<Direction, number> = {
   down: 0, left: 1, right: 2, up: 3,
 };
 
+interface PathPoint { x: number; y: number }
+
 export class PlayerSpriteV3 extends Phaser.Physics.Arcade.Sprite {
   private direction: Direction = 'down';
   private cursors: Phaser.Types.Input.Keyboard.CursorKeys | null = null;
   private wasd: Record<string, Phaser.Input.Keyboard.Key> | null = null;
   private shadow: Phaser.GameObjects.Ellipse | null = null;
+  private pathQueue: PathPoint[] = [];
+  private pathTarget: PathPoint | null = null;
+  private isPathMoving = false;
+  private navCell = 16;
 
   static preload(scene: Phaser.Scene, sheetUrl: string) {
     if (scene.textures.exists(SHEET_KEY)) return;
@@ -83,8 +89,82 @@ export class PlayerSpriteV3 extends Phaser.Physics.Arcade.Sprite {
     return this.direction;
   }
 
-  handleInput() {
-    if (!this.cursors || !this.wasd) return;
+  setNavCell(cell: number) {
+    this.navCell = Math.max(1, Math.floor(cell));
+  }
+
+  isPathActive(): boolean {
+    return this.isPathMoving;
+  }
+
+  setPath(path: PathPoint[]) {
+    // EasyStar emits the start tile as path[0]; skip it so we don't re-walk
+    // a fractional cell and stutter at the first step.
+    this.pathQueue = path.slice(1);
+    this.isPathMoving = true;
+    this.moveToNextPoint();
+  }
+
+  clearPath() {
+    this.pathQueue = [];
+    this.pathTarget = null;
+    this.isPathMoving = false;
+  }
+
+  updatePathMovement() {
+    if (!this.isPathMoving || !this.pathTarget) return;
+    const body = this.body as Phaser.Physics.Arcade.Body;
+    const dx = this.pathTarget.x - this.x;
+    const dy = this.pathTarget.y - this.y;
+    const dist = Math.sqrt(dx * dx + dy * dy);
+
+    if (dist < 2) {
+      this.setPosition(this.pathTarget.x, this.pathTarget.y);
+      body.setVelocity(0);
+      this.moveToNextPoint();
+      return;
+    }
+
+    const vx = (dx / dist) * PLAYER_SPEED;
+    const vy = (dy / dist) * PLAYER_SPEED;
+    body.setVelocity(vx, vy);
+  }
+
+  private moveToNextPoint() {
+    if (this.pathQueue.length === 0) {
+      this.isPathMoving = false;
+      this.pathTarget = null;
+      const body = this.body as Phaser.Physics.Arcade.Body;
+      body.setVelocity(0);
+      this.stop();
+      this.setFrame(DIRECTION_ROW[this.direction] * 4);
+      return;
+    }
+
+    const next = this.pathQueue.shift()!;
+    this.pathTarget = {
+      x: next.x * this.navCell + this.navCell / 2,
+      y: next.y * this.navCell + this.navCell / 2,
+    };
+
+    const dx = this.pathTarget.x - this.x;
+    const dy = this.pathTarget.y - this.y;
+    if (Math.abs(dx) > Math.abs(dy)) {
+      this.direction = dx > 0 ? 'right' : 'left';
+    } else if (dy !== 0) {
+      this.direction = dy > 0 ? 'down' : 'up';
+    }
+
+    this.play(`player-v3-walk-${this.direction}`, true);
+  }
+
+  /**
+   * @returns true if the keyboard produced movement this frame. Caller
+   * should skip `updatePathMovement()` in that case so click-to-move
+   * yields cleanly to keyboard control.
+   */
+  handleInput(): boolean {
+    if (!this.cursors || !this.wasd) return false;
     const body = this.body as Phaser.Physics.Arcade.Body;
 
     const left  = this.cursors.left.isDown  || this.wasd.A.isDown;
@@ -92,9 +172,10 @@ export class PlayerSpriteV3 extends Phaser.Physics.Arcade.Sprite {
     const up    = this.cursors.up.isDown    || this.wasd.W.isDown;
     const down  = this.cursors.down.isDown  || this.wasd.S.isDown;
 
-    body.setVelocity(0);
-
     if (left || right || up || down) {
+      this.clearPath();
+      body.setVelocity(0);
+
       if (left)  { body.setVelocityX(-PLAYER_SPEED); this.direction = 'left'; }
       else if (right) { body.setVelocityX(PLAYER_SPEED); this.direction = 'right'; }
       if (up)    { body.setVelocityY(-PLAYER_SPEED); this.direction = 'up'; }
@@ -105,10 +186,15 @@ export class PlayerSpriteV3 extends Phaser.Physics.Arcade.Sprite {
       }
 
       this.play(`player-v3-walk-${this.direction}`, true);
-    } else {
+      return true;
+    }
+
+    if (!this.isPathMoving) {
+      body.setVelocity(0);
       this.stop();
       this.setFrame(DIRECTION_ROW[this.direction] * 4);
     }
+    return false;
   }
 
   destroy(fromScene?: boolean) {


### PR DESCRIPTION
## Summary
- Ports V2 WorldScene's EasyStar.js click-to-move to V3 so players are no longer arrow-key-only.
- `PlayerSpriteV3` gains a path state machine (setPath / clearPath / updatePathMovement / isPathActive) mirroring V2's `PlayerSprite`. `handleInput()` now returns a boolean and clears any active path on keyboard input.
- `WorldSceneV3` builds a half-tile (NAV_CELL=16) nav grid from the Tiled `collision` object layer, configures EasyStar with diagonals + 200 iters/calc, adds a pointerdown click-to-move handler with a yellow ring marker, and only runs path movement when the keyboard is idle.
- Companion + NPC sprites already `stopPropagation` on pointerdown, so clicking them still fires their handlers (radial menu, dialogue) without queuing a path.

## Test plan
- [x] `npm run type-check` passes
- [x] `npx vitest run game/v3/__tests__/pathfindingNavGrid.test.ts` — 4 passed (size, blocking, clamping, half-tile resolution)
- [ ] Smoke at `localhost:3000/sanctuary?v=3`: click an empty grass tile far from the player → player walks there. Click on a building wall → no path. Press arrow keys mid-walk → path clears, manual control resumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)