### PR TITLE
feat(sanctuary): mobile-friendly overlay sweep [SWO_SHARED_MOBILE_OVERLAYS]

### DIFF
--- a/components/sanctuary/overlays/ChatInput.tsx
+++ b/components/sanctuary/overlays/ChatInput.tsx
@@ -62,7 +62,10 @@ export default function ChatInput() {
   );
 
   return (
-    <div className="absolute bottom-2 left-2 right-2 z-20 flex gap-2">
+    <div
+      className="absolute bottom-2 left-2 right-2 z-20 flex gap-2 max-w-full"
+      style={{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}
+    >
       <input
         ref={inputRef}
         value={text}
@@ -72,9 +75,13 @@ export default function ChatInput() {
         onBlur={() => setFocused(false)}
         placeholder={focused ? 'Type a message...' : 'Press Enter to chat'}
         maxLength={MAX_LENGTH}
+        // 16 px font keeps iOS Safari from auto-zooming the viewport on focus,
+        // which is the dominant mobile UX bug for chat inputs.
+        style={{ fontSize: '16px' }}
         className={`
-          flex-1 px-3 py-1.5 rounded
-          bg-[#0a0a1a]/90 border text-xs text-white
+          flex-1 min-w-0 px-3 rounded
+          min-h-[44px]
+          bg-[#0a0a1a]/90 border text-white
           font-['Press_Start_2P'] placeholder:text-gray-500
           outline-none transition-all
           ${focused
@@ -86,9 +93,14 @@ export default function ChatInput() {
       {focused && text.trim() && (
         <button
           onClick={send}
-          className="px-3 py-1.5 rounded bg-[#00f7ff]/20 border border-[#00f7ff]/40
+          // onMouseDown.preventDefault avoids stealing focus from the input
+          // before the click registers — otherwise the input blurs and the
+          // button vanishes mid-tap on touch devices.
+          onMouseDown={(e) => e.preventDefault()}
+          className="px-4 min-h-[44px] min-w-[44px] rounded bg-[#00f7ff]/20 border border-[#00f7ff]/40
                      text-[#00f7ff] text-xs font-['Press_Start_2P']
-                     hover:bg-[#00f7ff]/30 transition-all"
+                     hover:bg-[#00f7ff]/30 active:bg-[#00f7ff]/40 transition-all
+                     touch-manipulation select-none shrink-0"
         >
           Send
         </button>

--- a/components/sanctuary/overlays/CompanionChatOverlay.tsx
+++ b/components/sanctuary/overlays/CompanionChatOverlay.tsx
@@ -138,15 +138,23 @@ export default function CompanionChatOverlay({
     }
   }, [lines, typing]);
 
-  // Position the panel above the companion sprite
+  // Position the panel above the companion sprite, clamped so the rendered
+  // panel never spills past the viewport on small screens. The wrapper uses
+  // -translate-x-1/2 + max-w-[calc(100vw-1rem)], so we clamp by the actual
+  // rendered width (minus the safe margin) rather than the design constant.
   useEffect(() => {
     if (!open) return;
     const tick = () => {
       const el = panelRef.current;
       if (el) {
         const screen = worldToScreen(cameraState.companionX, cameraState.companionY);
-        el.style.left = `${screen.x}px`;
-        el.style.top = `${screen.y + PANEL_OFFSET_Y}px`;
+        const vw = typeof window !== 'undefined' ? window.innerWidth : 1024;
+        const half = el.offsetWidth / 2;
+        const margin = 8;
+        const x = Math.min(Math.max(screen.x, half + margin), vw - half - margin);
+        const y = Math.max(margin, screen.y + PANEL_OFFSET_Y);
+        el.style.left = `${x}px`;
+        el.style.top = `${y}px`;
       }
       rafRef.current = requestAnimationFrame(tick);
     };
@@ -246,7 +254,9 @@ export default function CompanionChatOverlay({
     <div className="absolute inset-0 z-30 pointer-events-none">
       <div
         ref={panelRef}
-        className="absolute pointer-events-auto -translate-x-1/2"
+        // Fluid sizing: keep the design width on tablets+ but cap to the
+        // viewport (with 1 rem of breathing room on each side) below 768 px.
+        className="absolute pointer-events-auto -translate-x-1/2 max-w-[calc(100vw-1rem)]"
         style={{
           width: PANEL_WIDTH,
           willChange: 'left, top',
@@ -273,7 +283,9 @@ export default function CompanionChatOverlay({
               <button
                 onClick={close}
                 aria-label="Close chat"
-                className="text-[8px] text-gray-400 hover:text-white leading-none"
+                className="min-w-[44px] min-h-[44px] flex items-center justify-center
+                           text-base text-gray-400 hover:text-white leading-none
+                           touch-manipulation select-none -mr-2"
               >
                 ✕
               </button>
@@ -337,16 +349,21 @@ export default function CompanionChatOverlay({
               placeholder={typing ? 'Companion is typing…' : 'Press Enter to send'}
               maxLength={MAX_LENGTH}
               disabled={sending || typing}
-              className="flex-1 px-1.5 py-1 rounded bg-[#0a0a1a]/80 border border-[#9966ff]/30
-                         text-[7px] text-white font-['Press_Start_2P'] placeholder:text-gray-500
+              // 16 px font keeps iOS Safari from auto-zooming when the field gains focus.
+              style={{ fontSize: '16px' }}
+              className="flex-1 min-w-0 px-2 rounded bg-[#0a0a1a]/80 border border-[#9966ff]/30
+                         min-h-[44px] text-white font-['Press_Start_2P'] placeholder:text-gray-500
                          outline-none focus:border-[#9966ff]/70 disabled:opacity-50"
             />
             <button
               onClick={() => void send()}
+              onMouseDown={(e) => e.preventDefault()}
               disabled={!draft.trim() || sending || typing}
-              className="px-2 py-1 rounded bg-[#9966ff]/20 border border-[#9966ff]/40
+              className="px-3 min-h-[44px] min-w-[44px] rounded bg-[#9966ff]/20 border border-[#9966ff]/40
                          text-[#9966ff] text-[7px] font-['Press_Start_2P']
-                         hover:bg-[#9966ff]/30 transition-all disabled:opacity-40 disabled:cursor-not-allowed"
+                         hover:bg-[#9966ff]/30 active:bg-[#9966ff]/40 transition-all
+                         disabled:opacity-40 disabled:cursor-not-allowed
+                         touch-manipulation select-none shrink-0"
             >
               {sending ? '…' : 'Send'}
             </button>

--- a/components/sanctuary/overlays/CompanionMenu.tsx
+++ b/components/sanctuary/overlays/CompanionMenu.tsx
@@ -36,7 +36,9 @@ const ACTIONS: { action: InteractAction; icon: string; label: string; angle: num
   { action: 'talk', icon: '💬', label: 'Talk', angle: -330 },
 ];
 
-const RADIAL_DISTANCE = 56;
+// Mobile-friendly radial spacing — buttons are 56 px wide (≥44 px tap target),
+// so the orbit must keep ≥36 px gap between centers on small screens.
+const RADIAL_DISTANCE = 64;
 
 let floatingId = 0;
 
@@ -64,7 +66,15 @@ export default function CompanionMenu({
       setTimeout(() => setBusyNotice(null), 1600);
       return;
     }
-    setMenuPos({ x: payload.screenX, y: payload.screenY });
+    // Clamp menu inside the viewport so the radial cluster stays tappable on
+    // small phones. Each button is 56 px (radius 28) at distance RADIAL_DISTANCE
+    // from center, plus an 8 px safety margin so the button never clips the edge.
+    const margin = RADIAL_DISTANCE + 28 + 8;
+    const w = typeof window !== 'undefined' ? window.innerWidth : 1024;
+    const h = typeof window !== 'undefined' ? window.innerHeight : 768;
+    const x = Math.min(Math.max(payload.screenX, margin), Math.max(margin, w - margin));
+    const y = Math.min(Math.max(payload.screenY, margin), Math.max(margin, h - margin));
+    setMenuPos({ x, y });
     setVisible(true);
   }, [busyOnQuest]);
 
@@ -229,9 +239,10 @@ export default function CompanionMenu({
               onClick={() => handleAction(action)}
               disabled={interacting !== null}
               className={`
-                absolute w-12 h-12 -translate-x-1/2 -translate-y-1/2 rounded-full
+                absolute w-14 h-14 min-w-[44px] min-h-[44px] -translate-x-1/2 -translate-y-1/2 rounded-full
                 flex flex-col items-center justify-center
                 bg-black/90 border-2 transition-all duration-150
+                touch-manipulation select-none
                 ${isActive
                   ? 'border-[#ffd700] shadow-[0_0_12px_rgba(255,215,0,0.5)] scale-110'
                   : 'border-[#00f7ff]/50 hover:border-[#ffd700] hover:shadow-[0_0_8px_rgba(255,215,0,0.3)] hover:scale-110'

--- a/components/sanctuary/overlays/QuestTracker.tsx
+++ b/components/sanctuary/overlays/QuestTracker.tsx
@@ -100,13 +100,13 @@ export default function QuestTracker({ walletAddress, tokenId }: QuestTrackerPro
   return (
     <div className="absolute top-2 right-2 z-20 pointer-events-none select-none">
       <div
-        className="w-56 bg-black/85 border border-[#ffd700]/30 rounded-lg
+        className="w-56 max-w-[calc(100vw-1rem)] bg-black/85 border border-[#ffd700]/30 rounded-lg
           shadow-[0_0_15px_rgba(255,215,0,0.15)] pointer-events-auto overflow-hidden"
       >
         {/* Header */}
         <button
           onClick={() => setExpanded((v) => !v)}
-          className="w-full flex items-center justify-between px-2 py-1.5 bg-[#1a0033]/60 border-b border-[#ffd700]/20 hover:bg-[#1a0033]/80 transition-colors"
+          className="w-full min-h-[44px] flex items-center justify-between px-2 py-1.5 bg-[#1a0033]/60 border-b border-[#ffd700]/20 hover:bg-[#1a0033]/80 transition-colors touch-manipulation"
           aria-label={expanded ? 'Collapse quest tracker' : 'Expand quest tracker'}
         >
           <div className="flex items-center gap-1.5">
@@ -184,7 +184,7 @@ export default function QuestTracker({ walletAddress, tokenId }: QuestTrackerPro
 
             <button
               onClick={openBoard}
-              className="w-full mt-1 py-1 text-[7px] text-[#ffd700]/70 hover:text-[#ffd700] border border-[#ffd700]/20 hover:border-[#ffd700]/50 rounded transition-colors font-['Press_Start_2P']"
+              className="w-full mt-1 min-h-[44px] text-[7px] text-[#ffd700]/70 hover:text-[#ffd700] border border-[#ffd700]/20 hover:border-[#ffd700]/50 rounded transition-colors font-['Press_Start_2P'] touch-manipulation"
             >
               OPEN BOARD
             </button>

--- a/lib/sanctuary/__tests__/mobile_overlays.test.ts
+++ b/lib/sanctuary/__tests__/mobile_overlays.test.ts
@@ -1,0 +1,144 @@
+// @vitest-environment node
+//
+// [SWO_SHARED_MOBILE_OVERLAYS] Static contract tests for mobile-friendly
+// React overlays. These do not render React — vitest is configured for the
+// node environment — but they enforce the responsive properties demanded by
+// the task spec (≥44 px hit targets, fluid layout under 768 px,
+// touch-friendly chat input + radial menu).
+//
+// If the source no longer satisfies the contract, the offending overlay
+// will fail with a precise message naming the missing class.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const ROOT = resolve(__dirname, '../../../');
+const OVERLAY_DIR = resolve(ROOT, 'components/sanctuary/overlays');
+
+function read(name: string): string {
+  return readFileSync(resolve(OVERLAY_DIR, name), 'utf8');
+}
+
+/**
+ * Tailwind treats `min-h-[44px]` and `min-w-[44px]` as the canonical opt-in
+ * for the iOS/Android recommended 44 px touch target. We check for those
+ * (or the larger w-14/h-14 = 56 px) on every primary interactive element.
+ */
+const FORTY_FOUR = /min-h-\[44px\]|min-h-11|h-11|h-12|h-14|h-16/;
+
+describe('[SWO_SHARED_MOBILE_OVERLAYS] CompanionMenu radial buttons', () => {
+  const src = read('CompanionMenu.tsx');
+
+  it('uses ≥44 px radial buttons (w-14 h-14 with min-w/min-h fallback)', () => {
+    expect(src).toMatch(/w-14 h-14/);
+    expect(src).toMatch(/min-w-\[44px\]/);
+    expect(src).toMatch(/min-h-\[44px\]/);
+  });
+
+  it('opts into touch-manipulation for instant tap response', () => {
+    expect(src).toMatch(/touch-manipulation/);
+  });
+
+  it('clamps radial menu inside the viewport so no button clips offscreen', () => {
+    expect(src).toMatch(/window\.innerWidth/);
+    expect(src).toMatch(/window\.innerHeight/);
+    expect(src).toMatch(/Math\.(min|max)/);
+  });
+
+  it('keeps button centers far enough apart that 56 px buttons do not overlap', () => {
+    const match = src.match(/RADIAL_DISTANCE\s*=\s*(\d+)/);
+    expect(match, 'RADIAL_DISTANCE constant must be defined').not.toBeNull();
+    const distance = Number(match![1]);
+    // 56 px buttons sit on a circle of radius DISTANCE; chord between
+    // 120°-spaced buttons is DISTANCE * sqrt(3). Need ≥ 56 + 8 px of clearance.
+    const chord = distance * Math.sqrt(3);
+    expect(chord).toBeGreaterThanOrEqual(64);
+  });
+});
+
+describe('[SWO_SHARED_MOBILE_OVERLAYS] ChatInput', () => {
+  const src = read('ChatInput.tsx');
+
+  it('input field is ≥44 px tall', () => {
+    expect(src).toMatch(/min-h-\[44px\]/);
+  });
+
+  it('uses 16 px font on the input to suppress iOS Safari auto-zoom', () => {
+    expect(src).toMatch(/fontSize:\s*['"]16px['"]/);
+  });
+
+  it('Send button has a 44 px hit area and touch-manipulation', () => {
+    // The Send button is the second min-h occurrence; the regex global
+    // match should produce ≥2 hits when both input + button are sized.
+    const hits = src.match(/min-h-\[44px\]/g) ?? [];
+    expect(hits.length).toBeGreaterThanOrEqual(2);
+    expect(src).toMatch(/touch-manipulation/);
+  });
+
+  it('respects iOS safe-area-inset-bottom so the input is not hidden by the home indicator', () => {
+    expect(src).toMatch(/safe-area-inset-bottom/);
+  });
+
+  it('layout is fluid (no fixed widths that would overflow under 768 px)', () => {
+    // bottom-2 left-2 right-2 stretches edge-to-edge with 8 px gutters,
+    // and flex-1 + min-w-0 lets the input shrink without overflow.
+    expect(src).toMatch(/left-2 right-2/);
+    expect(src).toMatch(/flex-1[^"]*min-w-0|min-w-0[^"]*flex-1/);
+  });
+});
+
+describe('[SWO_SHARED_MOBILE_OVERLAYS] CompanionChatOverlay', () => {
+  const src = read('CompanionChatOverlay.tsx');
+
+  it('panel caps width to viewport on small screens', () => {
+    expect(src).toMatch(/max-w-\[calc\(100vw-1rem\)\]/);
+  });
+
+  it('clamps panel position so it never spills past the viewport', () => {
+    expect(src).toMatch(/window\.innerWidth/);
+    expect(src).toMatch(/offsetWidth/);
+  });
+
+  it('close button has a 44 px hit area', () => {
+    expect(src).toMatch(/min-w-\[44px\] min-h-\[44px\][^]*aria-label="Close chat"|aria-label="Close chat"[^]*min-w-\[44px\] min-h-\[44px\]/);
+  });
+
+  it('embedded chat input is ≥44 px tall and uses 16 px font', () => {
+    expect(src).toMatch(/min-h-\[44px\]/);
+    expect(src).toMatch(/fontSize:\s*['"]16px['"]/);
+  });
+
+  it('Send button has ≥44 px hit area and touch-manipulation', () => {
+    const hits = src.match(/min-h-\[44px\]/g) ?? [];
+    expect(hits.length).toBeGreaterThanOrEqual(3); // close + input + send
+    expect(src).toMatch(/touch-manipulation/);
+  });
+});
+
+describe('[SWO_SHARED_MOBILE_OVERLAYS] QuestTracker', () => {
+  const src = read('QuestTracker.tsx');
+
+  it('panel is fluid under 768 px (max-w viewport-relative)', () => {
+    expect(src).toMatch(/max-w-\[calc\(100vw-1rem\)\]/);
+  });
+
+  it('expand/collapse header and OPEN BOARD button are ≥44 px', () => {
+    const hits = src.match(/min-h-\[44px\]/g) ?? [];
+    expect(hits.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('marks tappable controls as touch-manipulation', () => {
+    expect(src).toMatch(/touch-manipulation/);
+  });
+});
+
+describe('[SWO_SHARED_MOBILE_OVERLAYS] regression — no shrunken touch targets in primary overlays', () => {
+  const PRIMARY = ['CompanionMenu.tsx', 'ChatInput.tsx', 'CompanionChatOverlay.tsx', 'QuestTracker.tsx'];
+  for (const name of PRIMARY) {
+    it(`${name} declares at least one ≥44 px control`, () => {
+      const src = read(name);
+      expect(src, `${name} should expose a 44+ px touch target`).toMatch(FORTY_FOUR);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Responsive React overlay sweep for the shared sanctuary HUD — minimum 44 px hit targets, fluid layout under 768 px, touch-friendly chat input + radial menu. Excludes the Phaser canvas joystick (handled per-track in \`[SWO_V3_MOBILE_CANVAS]\`).

- **CompanionMenu**: radial buttons grow to 56 px (\`w-14 h-14\` + \`min-w-[44px] min-h-[44px]\`), \`RADIAL_DISTANCE\` bumped to 64 px so the trio stays non-overlapping, menu position clamped inside the viewport so no orbit button clips offscreen, \`touch-manipulation\` enabled.
- **ChatInput**: 44 px tall input, 16 px font (suppresses iOS Safari auto-zoom on focus), \`env(safe-area-inset-bottom)\` padding, Send button now has a 44 × 44 hit area and \`onMouseDown.preventDefault\` so taps no longer race input blur.
- **CompanionChatOverlay**: panel caps at \`calc(100vw - 1rem)\` and is reposition-clamped per frame using actual \`offsetWidth\`; ✕ close button gets a 44 px hit zone; embedded input + Send adopt the same 44 px / 16 px / \`touch-manipulation\` contract.
- **QuestTracker**: header + OPEN BOARD button now 44 px tall, panel fluid under 768 px.
- **New test**: \`lib/sanctuary/__tests__/mobile_overlays.test.ts\` — 21 static contract checks (vitest node env) that read the source and assert hit targets, fluid widths, viewport clamping, iOS auto-zoom guards, safe-area insets, and \`touch-manipulation\` adoption.

## Test plan

- [x] \`npx tsc --noEmit\` → clean
- [x] \`npx vitest run lib/sanctuary/__tests__/mobile_overlays.test.ts\` → 21/21 pass
- [x] Full \`npx vitest run\` → 498 pass, 5 fail (pre-existing baseline, unrelated)
- [ ] Manual: open sanctuary on a 360 × 760 device emulator, confirm radial menu, chat input, companion chat, quest tracker all stay tappable and on-screen
- [ ] Manual: confirm iOS Safari does not auto-zoom when focusing chat inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)