### PR TITLE
feat(sanctuary): shared multi-step expedition data model [SWO_SHARED_EXPEDITIONS]

### DIFF
--- a/data/sanctuary/expeditions.json
+++ b/data/sanctuary/expeditions.json
@@ -1,0 +1,186 @@
+{
+  "$comment": "Sanctuary multi-step expedition seed data. Loaded by lib/sanctuary/expeditions.ts as ExpeditionDefinition[]. Each expedition is a small branching narrative an NPC unlocks for the player. The npcSource field maps to a quest source via game/config/questSourceMap.ts; both V2 (cosmic placeholder) and V3 (Forgotten Memories) overlays render the same data.",
+  "season": "spring-2026",
+  "expeditions": [
+    {
+      "id": "expedition-observatory-comet-watch",
+      "title": "The Comet's Tail",
+      "description": "Astris has spotted an unscheduled comet streaking the southern sky. She needs another set of eyes — and steady hands at the lens.",
+      "npcSource": "observatory",
+      "startStepId": "comet-arrive",
+      "rewards": {
+        "xp": 80,
+        "bond": 6.0,
+        "trait": "Stargazer"
+      },
+      "steps": [
+        {
+          "id": "comet-arrive",
+          "narrative": "The Observatory dome is open to a sliver of velvet sky. Astris is bent over the great refractor, hair pulled back, fingers tight on the focus knob. \"You came. Good. The tail is fading and I can't take both readings alone.\"",
+          "choices": [
+            {
+              "id": "offer-lens",
+              "label": "\"I'll take the lens. Tell me what to track.\"",
+              "nextStepId": "comet-track",
+              "tone": "earnest"
+            },
+            {
+              "id": "offer-log",
+              "label": "\"Hand me the logbook — I'll write what you call.\"",
+              "nextStepId": "comet-log",
+              "tone": "diligent"
+            }
+          ]
+        },
+        {
+          "id": "comet-track",
+          "narrative": "You bend to the eyepiece. The comet is a slow blue smear against pinholes of starlight. \"Hold steady,\" Astris murmurs. \"If we lose the tail's centerline we lose the whole night.\" The dome creaks; the field begins to drift.",
+          "choices": [
+            {
+              "id": "compensate-drift",
+              "label": "Counter-rotate the lens to follow the drift.",
+              "nextStepId": "comet-finale",
+              "tone": "skilled"
+            },
+            {
+              "id": "call-out",
+              "label": "Call out coordinates and let Astris correct.",
+              "nextStepId": "comet-finale",
+              "tone": "trusting"
+            }
+          ]
+        },
+        {
+          "id": "comet-log",
+          "narrative": "Astris recites in clipped bursts and you scratch them down: declination, magnitude, tail length. Halfway through, the ink in your pen runs thin. \"Don't stop,\" she says without looking up. \"Numbers first, neatness later.\"",
+          "choices": [
+            {
+              "id": "switch-pen",
+              "label": "Swap to charcoal and keep transcribing.",
+              "nextStepId": "comet-finale",
+              "tone": "resourceful"
+            },
+            {
+              "id": "abbreviate",
+              "label": "Shorten every entry to keep pace with her count.",
+              "nextStepId": "comet-finale",
+              "tone": "pragmatic"
+            }
+          ]
+        },
+        {
+          "id": "comet-finale",
+          "narrative": "The comet's tail thins to a thread, then a memory. Astris straightens, eyes shining. \"We caught it. The whole arc.\" She holds the logbook against her chest. The dome falls quiet around the two of you, and the southern sky settles.",
+          "isFinal": true,
+          "choices": [
+            {
+              "id": "share-credit",
+              "label": "\"You did the hard part. I just held the line.\"",
+              "outcome": "success",
+              "tone": "humble"
+            },
+            {
+              "id": "claim-credit",
+              "label": "\"Couldn't have done it without me.\"",
+              "outcome": "partial",
+              "tone": "boastful"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "expedition-forge-ember-trial",
+      "title": "Ember Trial",
+      "description": "Pyrix is testing a new alloy and won't trust the bellows to anyone but a steady hand. Help him pull a clean ingot from the Aura Forge.",
+      "npcSource": "forge",
+      "startStepId": "forge-arrive",
+      "rewards": {
+        "xp": 100,
+        "bond": 7.0,
+        "trait": "Ironheart"
+      },
+      "steps": [
+        {
+          "id": "forge-arrive",
+          "narrative": "Heat hits you like a wall. Pyrix is shoulder-deep in the forge's red mouth, sleeves rolled, sweat bright on his brow. \"On time,\" he grunts. \"The crucible's hot. Pick: bellows, or hammer.\"",
+          "choices": [
+            {
+              "id": "take-bellows",
+              "label": "\"Bellows. I can keep a rhythm.\"",
+              "nextStepId": "forge-bellows",
+              "tone": "rhythm"
+            },
+            {
+              "id": "take-hammer",
+              "label": "\"Hammer. I'll strike where you point.\"",
+              "nextStepId": "forge-hammer",
+              "tone": "brave"
+            }
+          ]
+        },
+        {
+          "id": "forge-bellows",
+          "narrative": "You haul on the leather grips — long, slow, deep. The flames lift to a clean white roar. Pyrix nods approval, then snaps: \"Now faster. Faster than feels safe.\" The crucible glows past orange, into something close to dawn.",
+          "choices": [
+            {
+              "id": "trust-pyrix",
+              "label": "Trust him and pump harder.",
+              "nextStepId": "forge-finale",
+              "tone": "trusting"
+            },
+            {
+              "id": "hold-steady",
+              "label": "Hold the rhythm — don't risk overheat.",
+              "nextStepId": "forge-finale",
+              "tone": "cautious"
+            }
+          ]
+        },
+        {
+          "id": "forge-hammer",
+          "narrative": "Pyrix pulls the ingot. It pulses like something alive. \"Three strikes,\" he says. \"First high, second flat, third — listen for the right note. Don't crack it.\" He sets it on the anvil and steps back.",
+          "choices": [
+            {
+              "id": "strike-confident",
+              "label": "Strike confidently — finish all three before doubt creeps in.",
+              "nextStepId": "forge-finale",
+              "tone": "decisive"
+            },
+            {
+              "id": "strike-careful",
+              "label": "Take the third strike slow and listen for the note.",
+              "nextStepId": "forge-finale",
+              "tone": "patient"
+            }
+          ]
+        },
+        {
+          "id": "forge-finale",
+          "narrative": "The ingot quenches with a hiss that sounds almost like a sigh. Pyrix lifts it: dark, even, the grain running true. \"Clean pour,\" he says, and that from him is almost a hymn. He sets the ingot in your hands. It is warm. It is yours, briefly, before it becomes the Sanctuary's.",
+          "isFinal": true,
+          "choices": [
+            {
+              "id": "return-ingot",
+              "label": "Return the ingot — \"Forge it into something we both need.\"",
+              "outcome": "success",
+              "tone": "selfless"
+            },
+            {
+              "id": "keep-shard",
+              "label": "Snap a shard off for yourself before handing it back.",
+              "outcome": "partial",
+              "tone": "selfish"
+            },
+            {
+              "id": "drop-ingot",
+              "label": "Fumble it — your hands are still shaking from the heat.",
+              "outcome": "failure",
+              "tone": "rattled"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/lib/sanctuary/__tests__/expeditions.test.ts
+++ b/lib/sanctuary/__tests__/expeditions.test.ts
@@ -1,0 +1,323 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import {
+  EXPEDITION_OUTCOMES,
+  EXPEDITION_OUTCOME_REWARD_SCALE,
+  abandonExpedition,
+  chooseExpeditionPath,
+  getCurrentStep,
+  getExpeditionRewards,
+  isExpeditionComplete,
+  startExpedition,
+  validateExpeditionDefinition,
+  type ExpeditionDefinition,
+} from '../expeditions';
+
+function buildSimpleExpedition(): ExpeditionDefinition {
+  return {
+    id: 'test-exp',
+    title: 'Test Expedition',
+    description: 'A small branching test.',
+    npcSource: 'observatory',
+    startStepId: 'start',
+    rewards: { xp: 100, bond: 5, trait: 'TestTrait' },
+    steps: [
+      {
+        id: 'start',
+        narrative: 'You begin.',
+        choices: [
+          { id: 'left', label: 'Go left', nextStepId: 'middle-a' },
+          { id: 'right', label: 'Go right', nextStepId: 'middle-b' },
+        ],
+      },
+      {
+        id: 'middle-a',
+        narrative: 'You went left.',
+        choices: [{ id: 'on', label: 'Onward', nextStepId: 'final' }],
+      },
+      {
+        id: 'middle-b',
+        narrative: 'You went right.',
+        choices: [{ id: 'on', label: 'Onward', nextStepId: 'final' }],
+      },
+      {
+        id: 'final',
+        narrative: 'The journey ends.',
+        isFinal: true,
+        choices: [
+          { id: 'win', label: 'Triumph', outcome: 'success' },
+          { id: 'partial', label: 'Mixed result', outcome: 'partial' },
+          { id: 'lose', label: 'Defeat', outcome: 'failure' },
+        ],
+      },
+    ],
+  };
+}
+
+describe('expedition definition validation', () => {
+  it('accepts a well-formed definition', () => {
+    const result = validateExpeditionDefinition(buildSimpleExpedition());
+    expect(result.ok).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('rejects a missing startStepId', () => {
+    const def = buildSimpleExpedition();
+    def.startStepId = 'nope';
+    const result = validateExpeditionDefinition(def);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.includes('startStepId'))).toBe(true);
+  });
+
+  it('rejects a non-terminal choice missing nextStepId', () => {
+    const def = buildSimpleExpedition();
+    def.steps[0].choices[0].nextStepId = null;
+    const result = validateExpeditionDefinition(def);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.includes('nextStepId'))).toBe(true);
+  });
+
+  it('rejects a terminal choice missing outcome', () => {
+    const def = buildSimpleExpedition();
+    def.steps[3].choices[0].outcome = undefined;
+    const result = validateExpeditionDefinition(def);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.includes('outcome'))).toBe(true);
+  });
+
+  it('rejects nextStepId that points to nothing', () => {
+    const def = buildSimpleExpedition();
+    def.steps[0].choices[0].nextStepId = 'ghost';
+    const result = validateExpeditionDefinition(def);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.includes('unknown step'))).toBe(true);
+  });
+
+  it('rejects duplicate step ids', () => {
+    const def = buildSimpleExpedition();
+    def.steps[1].id = 'start';
+    const result = validateExpeditionDefinition(def);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.includes('duplicate step id'))).toBe(true);
+  });
+
+  it('rejects a step with no choices', () => {
+    const def = buildSimpleExpedition();
+    def.steps[1].choices = [];
+    const result = validateExpeditionDefinition(def);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.includes('at least one choice'))).toBe(true);
+  });
+});
+
+describe('expedition reducer', () => {
+  it('starts at the declared start step', () => {
+    const def = buildSimpleExpedition();
+    const state = startExpedition(def);
+    expect(state.expeditionId).toBe('test-exp');
+    expect(state.currentStepId).toBe('start');
+    expect(state.status).toBe('active');
+    expect(state.history).toEqual([]);
+    expect(state.finalOutcome).toBeUndefined();
+  });
+
+  it('throws when starting an expedition with an unresolved start step', () => {
+    const def = buildSimpleExpedition();
+    def.startStepId = 'no-such-step';
+    expect(() => startExpedition(def)).toThrow(/startStepId/);
+  });
+
+  it('advances through non-terminal choices', () => {
+    const def = buildSimpleExpedition();
+    let state = startExpedition(def);
+    state = chooseExpeditionPath(state, def, 'left');
+    expect(state.currentStepId).toBe('middle-a');
+    expect(state.status).toBe('active');
+    expect(state.history).toEqual([
+      { stepId: 'start', choiceId: 'left', outcome: undefined },
+    ]);
+  });
+
+  it('does not mutate the input state when advancing', () => {
+    const def = buildSimpleExpedition();
+    const initial = startExpedition(def);
+    const next = chooseExpeditionPath(initial, def, 'left');
+    expect(initial.currentStepId).toBe('start');
+    expect(initial.history).toEqual([]);
+    expect(next).not.toBe(initial);
+  });
+
+  it('terminates the expedition when a final-step choice is taken', () => {
+    const def = buildSimpleExpedition();
+    let state = startExpedition(def);
+    state = chooseExpeditionPath(state, def, 'right');
+    state = chooseExpeditionPath(state, def, 'on');
+    state = chooseExpeditionPath(state, def, 'win');
+    expect(state.status).toBe('completed');
+    expect(state.currentStepId).toBeNull();
+    expect(state.finalOutcome).toBe('success');
+    expect(state.history.map((h) => h.choiceId)).toEqual(['right', 'on', 'win']);
+    expect(isExpeditionComplete(state)).toBe(true);
+  });
+
+  it('records the outcome attached to the terminal choice', () => {
+    const def = buildSimpleExpedition();
+    let state = startExpedition(def);
+    state = chooseExpeditionPath(state, def, 'left');
+    state = chooseExpeditionPath(state, def, 'on');
+    state = chooseExpeditionPath(state, def, 'partial');
+    expect(state.finalOutcome).toBe('partial');
+  });
+
+  it('throws when choosing a choice that does not exist on the current step', () => {
+    const def = buildSimpleExpedition();
+    const state = startExpedition(def);
+    expect(() => chooseExpeditionPath(state, def, 'phantom')).toThrow(/no choice/);
+  });
+
+  it('throws when given a state from a different expedition', () => {
+    const def = buildSimpleExpedition();
+    const state = { ...startExpedition(def), expeditionId: 'other' };
+    expect(() => chooseExpeditionPath(state, def, 'left')).toThrow(/mismatch/);
+  });
+
+  it('throws when advancing a completed expedition', () => {
+    const def = buildSimpleExpedition();
+    let state = startExpedition(def);
+    state = chooseExpeditionPath(state, def, 'left');
+    state = chooseExpeditionPath(state, def, 'on');
+    state = chooseExpeditionPath(state, def, 'win');
+    expect(() => chooseExpeditionPath(state, def, 'win')).toThrow(/not active/);
+  });
+});
+
+describe('abandon + reward payout', () => {
+  it('abandon marks active state as abandoned', () => {
+    const def = buildSimpleExpedition();
+    const state = startExpedition(def);
+    const abandoned = abandonExpedition(state);
+    expect(abandoned.status).toBe('abandoned');
+    expect(abandoned.currentStepId).toBeNull();
+  });
+
+  it('abandon is idempotent on already-completed states', () => {
+    const def = buildSimpleExpedition();
+    let state = startExpedition(def);
+    state = chooseExpeditionPath(state, def, 'left');
+    state = chooseExpeditionPath(state, def, 'on');
+    state = chooseExpeditionPath(state, def, 'win');
+    const after = abandonExpedition(state);
+    expect(after).toBe(state);
+    expect(after.status).toBe('completed');
+  });
+
+  it('returns zero rewards for an active expedition', () => {
+    const def = buildSimpleExpedition();
+    const state = startExpedition(def);
+    expect(getExpeditionRewards(state, def)).toEqual({ xp: 0, bond: 0, trait: null });
+  });
+
+  it('returns zero rewards for an abandoned expedition', () => {
+    const def = buildSimpleExpedition();
+    const state = abandonExpedition(startExpedition(def));
+    expect(getExpeditionRewards(state, def)).toEqual({ xp: 0, bond: 0, trait: null });
+  });
+
+  it('pays full rewards (incl. trait) on success', () => {
+    const def = buildSimpleExpedition();
+    let state = startExpedition(def);
+    state = chooseExpeditionPath(state, def, 'left');
+    state = chooseExpeditionPath(state, def, 'on');
+    state = chooseExpeditionPath(state, def, 'win');
+    expect(getExpeditionRewards(state, def)).toEqual({
+      xp: 100,
+      bond: 5,
+      trait: 'TestTrait',
+    });
+  });
+
+  it('pays scaled rewards and no trait on partial', () => {
+    const def = buildSimpleExpedition();
+    let state = startExpedition(def);
+    state = chooseExpeditionPath(state, def, 'left');
+    state = chooseExpeditionPath(state, def, 'on');
+    state = chooseExpeditionPath(state, def, 'partial');
+    expect(getExpeditionRewards(state, def)).toEqual({
+      xp: 50,
+      bond: 2.5,
+      trait: null,
+    });
+  });
+
+  it('pays minimum rewards on failure', () => {
+    const def = buildSimpleExpedition();
+    let state = startExpedition(def);
+    state = chooseExpeditionPath(state, def, 'left');
+    state = chooseExpeditionPath(state, def, 'on');
+    state = chooseExpeditionPath(state, def, 'lose');
+    expect(getExpeditionRewards(state, def)).toEqual({
+      xp: 25,
+      bond: 1.3,
+      trait: null,
+    });
+  });
+
+  it('exposes a stable outcome list and reward scale', () => {
+    expect(EXPEDITION_OUTCOMES).toEqual(['success', 'partial', 'failure']);
+    expect(EXPEDITION_OUTCOME_REWARD_SCALE).toEqual({
+      success: 1.0,
+      partial: 0.5,
+      failure: 0.25,
+    });
+    expect(Object.isFrozen(EXPEDITION_OUTCOME_REWARD_SCALE)).toBe(true);
+  });
+});
+
+describe('current-step lookup', () => {
+  it('returns the current step while active', () => {
+    const def = buildSimpleExpedition();
+    const state = startExpedition(def);
+    const step = getCurrentStep(state, def);
+    expect(step?.id).toBe('start');
+  });
+
+  it('returns null after completion', () => {
+    const def = buildSimpleExpedition();
+    let state = startExpedition(def);
+    state = chooseExpeditionPath(state, def, 'left');
+    state = chooseExpeditionPath(state, def, 'on');
+    state = chooseExpeditionPath(state, def, 'win');
+    expect(getCurrentStep(state, def)).toBeNull();
+  });
+});
+
+describe('seed expeditions in data/sanctuary/expeditions.json', () => {
+  it('every shipped expedition validates cleanly', () => {
+    const seedPath = resolve(__dirname, '..', '..', '..', 'data', 'sanctuary', 'expeditions.json');
+    const raw = readFileSync(seedPath, 'utf8');
+    const parsed = JSON.parse(raw) as { expeditions: ExpeditionDefinition[] };
+    expect(parsed.expeditions.length).toBeGreaterThan(0);
+    for (const def of parsed.expeditions) {
+      const result = validateExpeditionDefinition(def);
+      expect(result.errors, `expedition ${def.id}: ${result.errors.join('; ')}`).toEqual(
+        [],
+      );
+      expect(result.ok).toBe(true);
+    }
+  });
+
+  it('every shipped expedition has at least one reachable success outcome', () => {
+    const seedPath = resolve(__dirname, '..', '..', '..', 'data', 'sanctuary', 'expeditions.json');
+    const raw = readFileSync(seedPath, 'utf8');
+    const parsed = JSON.parse(raw) as { expeditions: ExpeditionDefinition[] };
+    for (const def of parsed.expeditions) {
+      const hasSuccess = def.steps
+        .filter((s) => s.isFinal)
+        .some((s) => s.choices.some((c) => c.outcome === 'success'));
+      expect(hasSuccess, `expedition ${def.id} has no success outcome`).toBe(true);
+    }
+  });
+});

--- a/lib/sanctuary/expeditions.ts
+++ b/lib/sanctuary/expeditions.ts
@@ -1,0 +1,366 @@
+/**
+ * Shared multi-step expedition adventures for Sanctuary V2 + V3.
+ *
+ * An "expedition" is a linked-step quest with narrative text and branching
+ * choices. Where a normal {@link SanctuaryQuest} has a single counter that
+ * ticks once per location visit, an expedition is a small interactive story
+ * the player walks through inside an overlay: each step shows a paragraph of
+ * narrative + 2–3 choices, each choice transitions to the next step (or
+ * terminates the expedition). The terminal step carries an outcome label
+ * (`success` | `partial` | `failure`) that scales the reward payout.
+ *
+ * This file is the *engine-agnostic contract*: pure data types + pure reducer
+ * functions. Both V2 (cosmic placeholder) and V3 (Forgotten Memories) overlays
+ * consume the same module — only rendering style differs. There is intentionally
+ * NO Phaser, NO React, and NO database access here.
+ *
+ * Followups (separate PRs):
+ *   - DB schema for `sanctuary_expeditions` + `sanctuary_expedition_progress`
+ *     (mirrors the quest-progress pattern in lib/db.ts).
+ *   - API route under `app/api/sanctuary/expeditions/`.
+ *   - Overlay component `components/sanctuary/overlays/ExpeditionDialog.tsx`.
+ */
+
+export type ExpeditionOutcome = 'success' | 'partial' | 'failure';
+
+export const EXPEDITION_OUTCOMES: readonly ExpeditionOutcome[] = [
+  'success',
+  'partial',
+  'failure',
+];
+
+export type ExpeditionStatus = 'active' | 'completed' | 'abandoned';
+
+export interface ExpeditionChoice {
+  /** Stable ID, unique within the parent step. */
+  id: string;
+  /** Player-facing label shown on the choice button. */
+  label: string;
+  /**
+   * ID of the step to transition to. If the parent step is terminal, the
+   * `nextStepId` is ignored and the expedition ends with this choice's
+   * `outcome`. For non-terminal steps, this MUST point to a real step id.
+   */
+  nextStepId?: string | null;
+  /**
+   * Optional flavor tag for analytics / personality (e.g. "diplomatic",
+   * "reckless"). Not used by the reducer.
+   */
+  tone?: string;
+  /**
+   * Outcome to record when this choice ends the expedition (terminal steps
+   * only). Ignored for non-terminal steps.
+   */
+  outcome?: ExpeditionOutcome;
+}
+
+export interface ExpeditionStep {
+  /** Stable ID, unique within the parent expedition. */
+  id: string;
+  /** Narrative paragraph shown to the player when this step is current. */
+  narrative: string;
+  /** 1+ choices. UI typically renders 2–3; we don't cap here. */
+  choices: ExpeditionChoice[];
+  /**
+   * If `true`, choosing any of `choices` ends the expedition with the
+   * choice's `outcome` (defaulting to `'success'`). Non-terminal choices on
+   * a terminal step are a definition error and rejected by
+   * {@link validateExpeditionDefinition}.
+   */
+  isFinal?: boolean;
+}
+
+export interface ExpeditionRewards {
+  xp: number;
+  bond: number;
+  /** Optional trait unlock awarded only on full success. */
+  trait?: string | null;
+}
+
+export interface ExpeditionDefinition {
+  /** Stable ID, unique across all expeditions. */
+  id: string;
+  title: string;
+  /** Short pitch shown in the quest board / NPC dialog before launching. */
+  description: string;
+  /**
+   * Quest source tag (matches `requirement_type` in `sanctuary_quests`, e.g.
+   * `"observatory"`, `"forge"`). Used by the QuestBoard to attribute the
+   * expedition to an NPC via `getQuestSource()`.
+   */
+  npcSource: string;
+  /** Step that the expedition begins on. Must reference a step in `steps`. */
+  startStepId: string;
+  /** All steps in the expedition. Order is presentation-only. */
+  steps: ExpeditionStep[];
+  /**
+   * Base rewards on full success. Partial outcomes scale by
+   * {@link EXPEDITION_OUTCOME_REWARD_SCALE}.
+   */
+  rewards: ExpeditionRewards;
+}
+
+export interface ExpeditionHistoryEntry {
+  stepId: string;
+  choiceId: string;
+  /** Outcome attached to the choice, if any (only meaningful for terminal). */
+  outcome?: ExpeditionOutcome;
+}
+
+export interface ExpeditionState {
+  expeditionId: string;
+  /** ID of the step the player is currently on, or `null` if expedition ended. */
+  currentStepId: string | null;
+  status: ExpeditionStatus;
+  history: ExpeditionHistoryEntry[];
+  /** Final outcome — only set when `status === 'completed'`. */
+  finalOutcome?: ExpeditionOutcome;
+}
+
+/**
+ * Reward multipliers for each outcome. Tuned conservatively: a partial result
+ * is worth half, a failure still pays out a token amount so playing through
+ * is not punished into uselessness, and only `success` unlocks the trait.
+ *
+ * Frozen so callers can't accidentally mutate the table.
+ */
+export const EXPEDITION_OUTCOME_REWARD_SCALE: Readonly<Record<ExpeditionOutcome, number>> =
+  Object.freeze({
+    success: 1.0,
+    partial: 0.5,
+    failure: 0.25,
+  });
+
+// ---------------------------------------------------------------------------
+// Definition validation
+// ---------------------------------------------------------------------------
+
+export interface ExpeditionValidationResult {
+  ok: boolean;
+  errors: string[];
+}
+
+/**
+ * Static validator for an expedition definition. Catches the structural bugs
+ * that would only surface as a confusing UI failure mid-expedition (dangling
+ * `nextStepId`, terminal step with no `outcome`, etc.). Call this from data
+ * loaders and from tests when authoring new expeditions.
+ */
+export function validateExpeditionDefinition(
+  def: ExpeditionDefinition,
+): ExpeditionValidationResult {
+  const errors: string[] = [];
+
+  if (!def.id) errors.push('expedition.id is required');
+  if (!def.title) errors.push('expedition.title is required');
+  if (!def.npcSource) errors.push('expedition.npcSource is required');
+  if (!Array.isArray(def.steps) || def.steps.length === 0) {
+    errors.push('expedition.steps must be a non-empty array');
+    return { ok: false, errors };
+  }
+
+  const stepIds = new Set<string>();
+  for (const step of def.steps) {
+    if (!step.id) {
+      errors.push('step is missing id');
+      continue;
+    }
+    if (stepIds.has(step.id)) {
+      errors.push(`duplicate step id: ${step.id}`);
+    }
+    stepIds.add(step.id);
+    if (!Array.isArray(step.choices) || step.choices.length === 0) {
+      errors.push(`step "${step.id}" must have at least one choice`);
+      continue;
+    }
+    const choiceIds = new Set<string>();
+    for (const choice of step.choices) {
+      if (!choice.id) {
+        errors.push(`step "${step.id}" has a choice missing id`);
+        continue;
+      }
+      if (choiceIds.has(choice.id)) {
+        errors.push(`step "${step.id}" has duplicate choice id: ${choice.id}`);
+      }
+      choiceIds.add(choice.id);
+      if (step.isFinal) {
+        if (!choice.outcome) {
+          errors.push(
+            `terminal step "${step.id}" choice "${choice.id}" must declare an outcome`,
+          );
+        }
+      } else if (!choice.nextStepId) {
+        errors.push(
+          `non-terminal step "${step.id}" choice "${choice.id}" must declare nextStepId`,
+        );
+      }
+    }
+  }
+
+  if (!stepIds.has(def.startStepId)) {
+    errors.push(`startStepId "${def.startStepId}" does not match any step`);
+  }
+
+  // Cross-check nextStepId references against the resolved step set.
+  for (const step of def.steps) {
+    if (step.isFinal) continue;
+    for (const choice of step.choices) {
+      if (choice.nextStepId && !stepIds.has(choice.nextStepId)) {
+        errors.push(
+          `step "${step.id}" choice "${choice.id}" points to unknown step "${choice.nextStepId}"`,
+        );
+      }
+    }
+  }
+
+  return { ok: errors.length === 0, errors };
+}
+
+// ---------------------------------------------------------------------------
+// Pure reducer
+// ---------------------------------------------------------------------------
+
+function getStep(def: ExpeditionDefinition, stepId: string): ExpeditionStep | null {
+  return def.steps.find((s) => s.id === stepId) ?? null;
+}
+
+/**
+ * Look up the step the player is currently on. Returns `null` when the
+ * expedition is no longer active (completed or abandoned).
+ */
+export function getCurrentStep(
+  state: ExpeditionState,
+  def: ExpeditionDefinition,
+): ExpeditionStep | null {
+  if (state.status !== 'active' || !state.currentStepId) return null;
+  return getStep(def, state.currentStepId);
+}
+
+/**
+ * Begin a new expedition session. Pure: returns the initial state, no I/O.
+ */
+export function startExpedition(def: ExpeditionDefinition): ExpeditionState {
+  if (!getStep(def, def.startStepId)) {
+    throw new Error(
+      `cannot start expedition "${def.id}": startStepId "${def.startStepId}" not found`,
+    );
+  }
+  return {
+    expeditionId: def.id,
+    currentStepId: def.startStepId,
+    status: 'active',
+    history: [],
+  };
+}
+
+/**
+ * Apply a choice to the current step. Pure: returns a new state object,
+ * never mutates the input.
+ *
+ * Throws when the call is structurally invalid (wrong expedition, wrong
+ * step, unknown choice id, expedition already ended). The caller is
+ * expected to be the overlay layer which has direct access to the same
+ * definition the state was produced from, so these are programmer errors,
+ * not user-facing failures.
+ */
+export function chooseExpeditionPath(
+  state: ExpeditionState,
+  def: ExpeditionDefinition,
+  choiceId: string,
+): ExpeditionState {
+  if (state.expeditionId !== def.id) {
+    throw new Error(
+      `expedition mismatch: state for "${state.expeditionId}" given def "${def.id}"`,
+    );
+  }
+  if (state.status !== 'active' || !state.currentStepId) {
+    throw new Error(`expedition "${state.expeditionId}" is not active`);
+  }
+  const step = getStep(def, state.currentStepId);
+  if (!step) {
+    throw new Error(
+      `expedition "${def.id}" current step "${state.currentStepId}" not found`,
+    );
+  }
+  const choice = step.choices.find((c) => c.id === choiceId);
+  if (!choice) {
+    throw new Error(
+      `expedition "${def.id}" step "${step.id}" has no choice "${choiceId}"`,
+    );
+  }
+
+  const historyEntry: ExpeditionHistoryEntry = {
+    stepId: step.id,
+    choiceId: choice.id,
+    outcome: choice.outcome,
+  };
+  const history = [...state.history, historyEntry];
+
+  if (step.isFinal) {
+    return {
+      ...state,
+      currentStepId: null,
+      status: 'completed',
+      history,
+      finalOutcome: choice.outcome ?? 'success',
+    };
+  }
+
+  if (!choice.nextStepId || !getStep(def, choice.nextStepId)) {
+    throw new Error(
+      `expedition "${def.id}" choice "${choice.id}" has invalid nextStepId`,
+    );
+  }
+
+  return {
+    ...state,
+    currentStepId: choice.nextStepId,
+    status: 'active',
+    history,
+  };
+}
+
+/**
+ * Abandon an in-progress expedition. Idempotent on already-ended states —
+ * abandoning a completed expedition leaves it completed (no silent reset).
+ */
+export function abandonExpedition(state: ExpeditionState): ExpeditionState {
+  if (state.status !== 'active') return state;
+  return {
+    ...state,
+    currentStepId: null,
+    status: 'abandoned',
+  };
+}
+
+export function isExpeditionComplete(state: ExpeditionState): boolean {
+  return state.status === 'completed';
+}
+
+/**
+ * Compute the reward payout for the player given a (typically completed)
+ * expedition state. Scales the definition's base rewards by
+ * {@link EXPEDITION_OUTCOME_REWARD_SCALE}; only `success` keeps the trait.
+ *
+ * Returns zeros for active or abandoned expeditions — the caller (claim API,
+ * overlay) is responsible for not awarding mid-flight.
+ */
+export function getExpeditionRewards(
+  state: ExpeditionState,
+  def: ExpeditionDefinition,
+): ExpeditionRewards {
+  if (state.expeditionId !== def.id) {
+    throw new Error(
+      `expedition mismatch: state for "${state.expeditionId}" given def "${def.id}"`,
+    );
+  }
+  if (state.status !== 'completed' || !state.finalOutcome) {
+    return { xp: 0, bond: 0, trait: null };
+  }
+  const scale = EXPEDITION_OUTCOME_REWARD_SCALE[state.finalOutcome];
+  return {
+    xp: Math.round(def.rewards.xp * scale),
+    bond: Math.round(def.rewards.bond * scale * 10) / 10,
+    trait: state.finalOutcome === 'success' ? def.rewards.trait ?? null : null,
+  };
+}


### PR DESCRIPTION
## Summary
Adds a shared, engine-agnostic data model for multi-step expedition adventures with narrative choices. Both V2 and V3 sanctuary overlays consume the same module — only rendering style differs.

## Files
- **`lib/sanctuary/expeditions.ts`** — pure types + reducer (`startExpedition`, `chooseExpeditionPath`, `abandonExpedition`, `getExpeditionRewards`) and a static `validateExpeditionDefinition()` for catching authoring errors at load time. No Phaser, no React, no DB access.
- **`data/sanctuary/expeditions.json`** — two seed expeditions: *The Comet's Tail* (Observatory, Astris) and *Ember Trial* (Aura Forge, Pyrix). Each has 4 steps with branching paths and `success`/`partial`/`failure` terminal outcomes. The `npcSource` field maps to the existing `questSourceMap.ts` so quest-board/NPC attribution is consistent with seasonal quests.
- **`lib/sanctuary/__tests__/expeditions.test.ts`** — 28 vitest tests covering: definition validation (start ref, dangling next, terminal-outcome requirement, duplicate ids, empty choices), reducer transitions through both branches, input-state immutability, abandon idempotency on already-completed expeditions, outcome-scaled reward payout (success = 100% + trait, partial = 50%, failure = 25%), `getCurrentStep` lifecycle, and seed-data conformance.

## Scope
This PR ships the shared *contract*. Out of scope (separate PRs):
- DB schema (`sanctuary_expeditions`, `sanctuary_expedition_progress`) mirroring the quest-progress pattern in `lib/db.ts`.
- API route `app/api/sanctuary/expeditions/`.
- Overlay component `components/sanctuary/overlays/ExpeditionDialog.tsx`.

The contract is deliberately small so the DB/API/UI work can be added incrementally without churn on the data model.

## Validation
- `npm run type-check`: PASS (0 errors)
- `npx eslint <changed files>`: PASS (0 errors)
- `npx vitest run`: 28 new tests pass; full suite 508 passed / 5 pre-existing failures unrelated (api-e2e nft-traits ×2, chat history limit, interact-action error message, roomScene v3 — same as prior runs).

## Mirror Validation (PROD)
Baseline (PROD `/opt/star_world_order/PROD` before overlay):
- **tsc --noEmit**: 435 pre-existing errors (missing modules: phaser, colyseus.js, howler — not yet deployed to mirror)
- **vitest run**: 468 passed / 5 failed (same pre-existing failures as workspace)

After overlaying the three new files into PROD:
- **tsc --noEmit**: PASS — 435 errors, **0 new** (baseline-diff = 0)
- **vitest run**: PASS — 496 passed / 5 failed → +28 new passing tests, no new failures
- Files removed and PROD restored to byte-identical baseline (435 tsc, 468 vitest).

Overall: **PASS**

## Test plan
- [x] All 28 new expedition tests pass locally and in PROD mirror
- [x] No new tsc errors introduced (verified baseline-diff)
- [x] No regressions in existing test suite (5 pre-existing failures unchanged)
- [x] Seed expedition JSON validates via `validateExpeditionDefinition`
- [ ] Follow-up PR: wire DB + API + overlay component

🤖 Generated with [Claude Code](https://claude.com/claude-code)