### PR TITLE
feat(sanctuary): companion chat memory consolidation (weekly batch)

### DIFF
--- a/app/api/admin/route.ts
+++ b/app/api/admin/route.ts
@@ -33,6 +33,7 @@ import {
   getRaffleWinnerDetails,
 } from '@/lib/db';
 import { logger } from '@/lib/logger';
+import { consolidateAllCompanionMemories } from '@/lib/sanctuary/memoryConsolidation';
 
 /**
  * GET /api/admin
@@ -391,6 +392,29 @@ export async function POST(request: NextRequest) {
         success: true,
         message: `Deleted ${deleted} direct messages older than ${olderThanDays} days`,
         deleted,
+      });
+    }
+
+    // Consolidate companion chat memories (weekly batch job)
+    if (action === 'consolidateChatMemories') {
+      const {
+        duplicateSimilarityThreshold,
+        topicClusterThreshold,
+        feelingDecayAfterDays,
+      } = body;
+      const stats = consolidateAllCompanionMemories({
+        duplicateSimilarityThreshold:
+          typeof duplicateSimilarityThreshold === 'number' ? duplicateSimilarityThreshold : undefined,
+        topicClusterThreshold:
+          typeof topicClusterThreshold === 'number' ? topicClusterThreshold : undefined,
+        feelingDecayAfterDays:
+          typeof feelingDecayAfterDays === 'number' ? feelingDecayAfterDays : undefined,
+      });
+      logger.info('Admin: Consolidated companion chat memories', { ...stats });
+      return NextResponse.json({
+        success: true,
+        message: `Scanned ${stats.companionsScanned} companions / ${stats.memoriesScanned} memories — merged ${stats.merged}, decayed ${stats.decayed}`,
+        stats,
       });
     }
 

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -7243,6 +7243,87 @@ export function getTopChatMemories(
   return getChatMemories(walletAddress, tokenId, { limit });
 }
 
+// ─── V2.1: Memory Consolidation (weekly batch job) ──────────────────
+
+export interface CompanionMemoryOwner {
+  wallet_address: string;
+  token_id: number;
+}
+
+export function listCompanionMemoryOwners(): CompanionMemoryOwner[] {
+  const db = getDatabase();
+  return db.prepare(`
+    SELECT DISTINCT wallet_address, token_id
+    FROM sanctuary_chat_memories
+    ORDER BY wallet_address ASC, token_id ASC
+  `).all() as CompanionMemoryOwner[];
+}
+
+export function getAllChatMemoriesForCompanion(
+  walletAddress: string,
+  tokenId: number,
+): SanctuaryChatMemory[] {
+  const db = getDatabase();
+  return db.prepare(`
+    SELECT * FROM sanctuary_chat_memories
+    WHERE wallet_address = ? AND token_id = ?
+    ORDER BY id ASC
+  `).all(walletAddress.toLowerCase(), tokenId) as SanctuaryChatMemory[];
+}
+
+export interface ApplyConsolidationPlan {
+  merges: Array<{
+    keepId: number;
+    removeIds: number[];
+    newImportance: number;
+    newMentionCount: number;
+  }>;
+  decays: Array<{ id: number; newImportance: number }>;
+}
+
+export interface ApplyConsolidationResult {
+  merged: number;
+  decayed: number;
+}
+
+export function applyMemoryConsolidationPlan(
+  plan: ApplyConsolidationPlan,
+): ApplyConsolidationResult {
+  const db = getDatabase();
+  const updateKeeper = db.prepare(`
+    UPDATE sanctuary_chat_memories
+    SET importance = ?, mention_count = ?, updated_at = CURRENT_TIMESTAMP
+    WHERE id = ?
+  `);
+  const deleteOne = db.prepare(`DELETE FROM sanctuary_chat_memories WHERE id = ?`);
+  const decayOne = db.prepare(`
+    UPDATE sanctuary_chat_memories
+    SET importance = ?, updated_at = CURRENT_TIMESTAMP
+    WHERE id = ?
+  `);
+
+  let merged = 0;
+  let decayed = 0;
+
+  const txn = db.transaction(() => {
+    for (const m of plan.merges) {
+      if (m.removeIds.length === 0) continue;
+      updateKeeper.run(m.newImportance, m.newMentionCount, m.keepId);
+      for (const rid of m.removeIds) {
+        deleteOne.run(rid);
+        merged += 1;
+      }
+    }
+    for (const d of plan.decays) {
+      decayOne.run(d.newImportance, d.id);
+      decayed += 1;
+    }
+  });
+  txn();
+
+  return { merged, decayed };
+}
+
 export function generateTemplateCompanionReply(
   companion: SanctuaryCompanionWithMeta,
   userMessage: string,

--- a/lib/sanctuary/__tests__/memoryConsolidation.test.ts
+++ b/lib/sanctuary/__tests__/memoryConsolidation.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect } from 'vitest';
+import type { SanctuaryChatMemory, SanctuaryChatMemoryCategory } from '@/lib/db';
+import {
+  jaccardSimilarity,
+  normalizeFactText,
+  planConsolidation,
+  summarizePlan,
+  tokenizeFact,
+  CONSOLIDATION_DEFAULTS,
+} from '../memoryConsolidation';
+
+let nextId = 1;
+
+function makeMemory(
+  category: SanctuaryChatMemoryCategory,
+  fact: string,
+  overrides: Partial<SanctuaryChatMemory> = {},
+): SanctuaryChatMemory {
+  const id = overrides.id ?? nextId++;
+  return {
+    id,
+    wallet_address: '0xtest',
+    token_id: 1,
+    category,
+    fact,
+    importance: 1,
+    mention_count: 1,
+    last_mentioned_at: '2026-04-26T00:00:00.000Z',
+    source_message_id: null,
+    created_at: '2026-04-26T00:00:00.000Z',
+    updated_at: '2026-04-26T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('normalizeFactText', () => {
+  it('lowercases, strips punctuation, collapses whitespace', () => {
+    expect(normalizeFactText('  Likes  Cosmic-Berries!! ')).toBe('likes cosmic berries');
+  });
+  it('returns empty for empty input', () => {
+    expect(normalizeFactText('')).toBe('');
+  });
+});
+
+describe('tokenizeFact', () => {
+  it('drops stop words and short tokens', () => {
+    expect(tokenizeFact('They are in the sanctuary today')).toEqual(['sanctuary', 'today']);
+  });
+});
+
+describe('jaccardSimilarity', () => {
+  it('returns 1 for identical normalized facts', () => {
+    expect(jaccardSimilarity('Holder likes tea', 'holder likes tea!')).toBe(1);
+  });
+  it('returns 0 for entirely disjoint facts', () => {
+    expect(jaccardSimilarity('Holder likes tea', 'sky burns red')).toBe(0);
+  });
+  it('returns a value in (0,1) for partial overlap', () => {
+    const sim = jaccardSimilarity('Holder enjoys cosmic berries', 'Holder loves cosmic berries');
+    expect(sim).toBeGreaterThan(0);
+    expect(sim).toBeLessThan(1);
+  });
+  it('returns 1 when both facts are empty after tokenization', () => {
+    expect(jaccardSimilarity('the a is', 'or to in')).toBe(1);
+  });
+});
+
+describe('planConsolidation — merges', () => {
+  it('returns no merges for distinct facts within a category', () => {
+    const memories = [
+      makeMemory('preferences', 'Loves cosmic berries'),
+      makeMemory('preferences', 'Dislikes loud noises'),
+    ];
+    const plan = planConsolidation(memories, { now: Date.parse('2026-04-26T00:00:00Z') });
+    expect(plan.merges).toEqual([]);
+  });
+
+  it('merges duplicate preferences (same category, near-identical fact)', () => {
+    const a = makeMemory('preferences', 'Loves cosmic berries', { id: 10, importance: 2, mention_count: 3 });
+    const b = makeMemory('preferences', 'loves cosmic berries!', { id: 11, importance: 4, mention_count: 1 });
+    const plan = planConsolidation([a, b], { now: Date.parse('2026-04-26T00:00:00Z') });
+    expect(plan.merges).toHaveLength(1);
+    const merge = plan.merges[0];
+    expect(merge.category).toBe('preferences');
+    expect(merge.keepId).toBe(11);
+    expect(merge.removeIds).toEqual([10]);
+    expect(merge.newImportance).toBe(4);
+    expect(merge.newMentionCount).toBe(4);
+  });
+
+  it('does not merge across categories even with identical text', () => {
+    const a = makeMemory('preferences', 'cosmic berries', { id: 1 });
+    const b = makeMemory('recurring_topics', 'cosmic berries', { id: 2 });
+    const plan = planConsolidation([a, b], { now: Date.parse('2026-04-26T00:00:00Z') });
+    expect(plan.merges).toEqual([]);
+  });
+
+  it('clusters recurring_topics with looser similarity (summarization)', () => {
+    const a = makeMemory('recurring_topics', 'asks about the constellations', { id: 1, importance: 3, mention_count: 2 });
+    const b = makeMemory('recurring_topics', 'asks about constellations again', { id: 2, importance: 1, mention_count: 1 });
+    const plan = planConsolidation([a, b], { now: Date.parse('2026-04-26T00:00:00Z') });
+    expect(plan.merges).toHaveLength(1);
+    expect(plan.merges[0].keepId).toBe(1);
+    expect(plan.merges[0].removeIds).toEqual([2]);
+    expect(plan.merges[0].newMentionCount).toBe(3);
+  });
+
+  it('does NOT cluster the same loose pair when category is preferences (stricter threshold)', () => {
+    const a = makeMemory('preferences', 'asks about the constellations', { id: 1, importance: 3 });
+    const b = makeMemory('preferences', 'asks about constellations again', { id: 2, importance: 1 });
+    const plan = planConsolidation([a, b], { now: Date.parse('2026-04-26T00:00:00Z') });
+    expect(plan.merges).toEqual([]);
+  });
+
+  it('keeps the highest-importance memory as the cluster representative', () => {
+    const a = makeMemory('preferences', 'enjoys quiet evenings', { id: 1, importance: 1 });
+    const b = makeMemory('preferences', 'enjoys quiet evenings', { id: 2, importance: 5 });
+    const c = makeMemory('preferences', 'enjoys quiet evenings', { id: 3, importance: 3 });
+    const plan = planConsolidation([a, b, c], { now: Date.parse('2026-04-26T00:00:00Z') });
+    expect(plan.merges).toHaveLength(1);
+    expect(plan.merges[0].keepId).toBe(2);
+    expect(plan.merges[0].removeIds.sort()).toEqual([1, 3]);
+    expect(plan.merges[0].newImportance).toBe(5);
+  });
+
+  it('clamps newImportance to [1,5]', () => {
+    const a = makeMemory('preferences', 'fact', { id: 1, importance: 5 });
+    const b = makeMemory('preferences', 'fact', { id: 2, importance: 5 });
+    const plan = planConsolidation([a, b], { now: Date.parse('2026-04-26T00:00:00Z') });
+    expect(plan.merges[0].newImportance).toBe(5);
+  });
+});
+
+describe('planConsolidation — decays', () => {
+  const now = Date.parse('2026-04-26T00:00:00Z');
+
+  it('decays old companion_feelings importance by 1', () => {
+    const old = makeMemory('companion_feelings', 'I feel safe near them', {
+      id: 1,
+      importance: 4,
+      last_mentioned_at: '2026-04-01T00:00:00Z', // ~25 days old
+    });
+    const plan = planConsolidation([old], { now, feelingDecayAfterDays: 14 });
+    expect(plan.decays).toHaveLength(1);
+    expect(plan.decays[0].id).toBe(1);
+    expect(plan.decays[0].oldImportance).toBe(4);
+    expect(plan.decays[0].newImportance).toBe(3);
+  });
+
+  it('does not decay recent companion_feelings', () => {
+    const recent = makeMemory('companion_feelings', 'I feel curious', {
+      id: 2,
+      importance: 4,
+      last_mentioned_at: '2026-04-25T00:00:00Z', // 1 day old
+    });
+    const plan = planConsolidation([recent], { now, feelingDecayAfterDays: 14 });
+    expect(plan.decays).toEqual([]);
+  });
+
+  it('does not decay below importance 1', () => {
+    const stuck = makeMemory('companion_feelings', 'fading feeling', {
+      id: 3,
+      importance: 1,
+      last_mentioned_at: '2026-01-01T00:00:00Z',
+    });
+    const plan = planConsolidation([stuck], { now, feelingDecayAfterDays: 14 });
+    expect(plan.decays).toEqual([]);
+  });
+
+  it('does not decay non-feeling categories', () => {
+    const old = makeMemory('preferences', 'old preference', {
+      id: 4,
+      importance: 4,
+      last_mentioned_at: '2026-01-01T00:00:00Z',
+    });
+    const plan = planConsolidation([old], { now, feelingDecayAfterDays: 14 });
+    expect(plan.decays).toEqual([]);
+  });
+
+  it('skips memories whose timestamps cannot be parsed', () => {
+    const broken = makeMemory('companion_feelings', 'feeling', {
+      id: 5,
+      importance: 4,
+      last_mentioned_at: 'not-a-date',
+    });
+    const plan = planConsolidation([broken], { now, feelingDecayAfterDays: 14 });
+    expect(plan.decays).toEqual([]);
+  });
+
+  it('does not decay memories that were merged away in the same plan', () => {
+    const old1 = makeMemory('companion_feelings', 'I feel calm', {
+      id: 6,
+      importance: 3,
+      last_mentioned_at: '2026-01-01T00:00:00Z',
+    });
+    const old2 = makeMemory('companion_feelings', 'i feel calm!', {
+      id: 7,
+      importance: 4,
+      last_mentioned_at: '2026-01-01T00:00:00Z',
+    });
+    const plan = planConsolidation([old1, old2], { now, feelingDecayAfterDays: 14 });
+    expect(plan.merges).toHaveLength(1);
+    // Survivor (keeper) may still be decayed.
+    const survivorId = plan.merges[0].keepId;
+    expect(plan.decays.map((d) => d.id)).toEqual([survivorId]);
+  });
+});
+
+describe('summarizePlan', () => {
+  it('counts merged removals and decays', () => {
+    const plan = planConsolidation([
+      makeMemory('preferences', 'cosmic berries', { id: 1 }),
+      makeMemory('preferences', 'cosmic berries', { id: 2 }),
+      makeMemory('preferences', 'cosmic berries', { id: 3 }),
+      makeMemory('companion_feelings', 'feeling', {
+        id: 4,
+        importance: 3,
+        last_mentioned_at: '2026-01-01T00:00:00Z',
+      }),
+    ], { now: Date.parse('2026-04-26T00:00:00Z') });
+    const sum = summarizePlan(plan);
+    expect(sum.merged).toBe(2);
+    expect(sum.decayed).toBe(1);
+  });
+});
+
+describe('CONSOLIDATION_DEFAULTS', () => {
+  it('exposes sensible defaults', () => {
+    expect(CONSOLIDATION_DEFAULTS.duplicateSimilarityThreshold).toBeGreaterThan(0.5);
+    expect(CONSOLIDATION_DEFAULTS.topicClusterThreshold).toBeGreaterThan(0);
+    expect(CONSOLIDATION_DEFAULTS.feelingDecayAfterDays).toBeGreaterThan(0);
+  });
+});

--- a/lib/sanctuary/memoryConsolidation.ts
+++ b/lib/sanctuary/memoryConsolidation.ts
@@ -1,0 +1,266 @@
+import type {
+  ApplyConsolidationPlan,
+  ApplyConsolidationResult,
+  CompanionMemoryOwner,
+  SanctuaryChatMemory,
+  SanctuaryChatMemoryCategory,
+} from '@/lib/db';
+import {
+  applyMemoryConsolidationPlan,
+  getAllChatMemoriesForCompanion,
+  listCompanionMemoryOwners,
+} from '@/lib/db';
+
+export interface MergeAction {
+  category: SanctuaryChatMemoryCategory;
+  keepId: number;
+  removeIds: number[];
+  newFact: string;
+  newImportance: number;
+  newMentionCount: number;
+}
+
+export interface DecayAction {
+  id: number;
+  oldImportance: number;
+  newImportance: number;
+}
+
+export interface ConsolidationPlan {
+  merges: MergeAction[];
+  decays: DecayAction[];
+}
+
+export interface ConsolidationOptions {
+  duplicateSimilarityThreshold?: number;
+  topicClusterThreshold?: number;
+  feelingDecayAfterDays?: number;
+  now?: number;
+}
+
+export interface ConsolidationDefaults {
+  duplicateSimilarityThreshold: number;
+  topicClusterThreshold: number;
+  feelingDecayAfterDays: number;
+}
+
+export const CONSOLIDATION_DEFAULTS: ConsolidationDefaults = {
+  duplicateSimilarityThreshold: 0.85,
+  topicClusterThreshold: 0.5,
+  feelingDecayAfterDays: 14,
+};
+
+const STOP_WORDS = new Set([
+  'a', 'an', 'and', 'are', 'as', 'at', 'be', 'by', 'for', 'from', 'has', 'have',
+  'i', 'in', 'is', 'it', 'its', 'of', 'on', 'or', 'that', 'the', 'their',
+  'they', 'them', 'this', 'to', 'was', 'were', 'with', 'we', 'us',
+]);
+
+export function normalizeFactText(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function tokenizeFact(s: string): string[] {
+  const norm = normalizeFactText(s);
+  if (!norm) return [];
+  return norm.split(' ').filter((tok) => tok.length > 1 && !STOP_WORDS.has(tok));
+}
+
+export function jaccardSimilarity(a: string, b: string): number {
+  const ta = new Set(tokenizeFact(a));
+  const tb = new Set(tokenizeFact(b));
+  if (ta.size === 0 && tb.size === 0) return 1;
+  if (ta.size === 0 || tb.size === 0) return 0;
+  let inter = 0;
+  for (const tok of ta) if (tb.has(tok)) inter++;
+  const union = ta.size + tb.size - inter;
+  return union === 0 ? 0 : inter / union;
+}
+
+function pickKeeper(cluster: SanctuaryChatMemory[]): SanctuaryChatMemory {
+  return cluster.reduce((best, m) => {
+    if (m.importance !== best.importance) {
+      return m.importance > best.importance ? m : best;
+    }
+    if (m.mention_count !== best.mention_count) {
+      return m.mention_count > best.mention_count ? m : best;
+    }
+    return new Date(m.last_mentioned_at) > new Date(best.last_mentioned_at) ? m : best;
+  }, cluster[0]);
+}
+
+function clusterByCategory(
+  memories: SanctuaryChatMemory[],
+  threshold: number,
+): SanctuaryChatMemory[][] {
+  const sorted = [...memories].sort((a, b) => {
+    if (b.importance !== a.importance) return b.importance - a.importance;
+    return b.mention_count - a.mention_count;
+  });
+  const used = new Set<number>();
+  const clusters: SanctuaryChatMemory[][] = [];
+  for (const seed of sorted) {
+    if (used.has(seed.id)) continue;
+    const cluster: SanctuaryChatMemory[] = [seed];
+    used.add(seed.id);
+    for (const candidate of sorted) {
+      if (used.has(candidate.id)) continue;
+      if (jaccardSimilarity(seed.fact, candidate.fact) >= threshold) {
+        cluster.push(candidate);
+        used.add(candidate.id);
+      }
+    }
+    clusters.push(cluster);
+  }
+  return clusters;
+}
+
+function mergeCluster(
+  cluster: SanctuaryChatMemory[],
+  category: SanctuaryChatMemoryCategory,
+): MergeAction | null {
+  if (cluster.length < 2) return null;
+  const keeper = pickKeeper(cluster);
+  const removeIds = cluster.filter((m) => m.id !== keeper.id).map((m) => m.id);
+  const newImportance = cluster.reduce((max, m) => Math.max(max, m.importance), 1);
+  const newMentionCount = cluster.reduce((sum, m) => sum + m.mention_count, 0);
+  return {
+    category,
+    keepId: keeper.id,
+    removeIds,
+    newFact: keeper.fact,
+    newImportance: Math.max(1, Math.min(5, newImportance)),
+    newMentionCount,
+  };
+}
+
+function planMerges(
+  memories: SanctuaryChatMemory[],
+  options: Required<Pick<ConsolidationOptions, 'duplicateSimilarityThreshold' | 'topicClusterThreshold'>>,
+): MergeAction[] {
+  const byCategory = new Map<SanctuaryChatMemoryCategory, SanctuaryChatMemory[]>();
+  for (const m of memories) {
+    const arr = byCategory.get(m.category) ?? [];
+    arr.push(m);
+    byCategory.set(m.category, arr);
+  }
+  const merges: MergeAction[] = [];
+  for (const [category, items] of byCategory.entries()) {
+    const threshold =
+      category === 'recurring_topics'
+        ? options.topicClusterThreshold
+        : options.duplicateSimilarityThreshold;
+    const clusters = clusterByCategory(items, threshold);
+    for (const cluster of clusters) {
+      const merge = mergeCluster(cluster, category);
+      if (merge) merges.push(merge);
+    }
+  }
+  return merges;
+}
+
+function planDecays(
+  memories: SanctuaryChatMemory[],
+  feelingDecayAfterDays: number,
+  nowMs: number,
+): DecayAction[] {
+  const cutoff = nowMs - feelingDecayAfterDays * 24 * 60 * 60 * 1000;
+  const decays: DecayAction[] = [];
+  for (const m of memories) {
+    if (m.category !== 'companion_feelings') continue;
+    if (m.importance <= 1) continue;
+    const lastMs = Date.parse(m.last_mentioned_at);
+    if (!Number.isFinite(lastMs)) continue;
+    if (lastMs > cutoff) continue;
+    decays.push({
+      id: m.id,
+      oldImportance: m.importance,
+      newImportance: Math.max(1, m.importance - 1),
+    });
+  }
+  return decays;
+}
+
+export function planConsolidation(
+  memories: SanctuaryChatMemory[],
+  options: ConsolidationOptions = {},
+): ConsolidationPlan {
+  const opts = {
+    duplicateSimilarityThreshold:
+      options.duplicateSimilarityThreshold ?? CONSOLIDATION_DEFAULTS.duplicateSimilarityThreshold,
+    topicClusterThreshold:
+      options.topicClusterThreshold ?? CONSOLIDATION_DEFAULTS.topicClusterThreshold,
+    feelingDecayAfterDays:
+      options.feelingDecayAfterDays ?? CONSOLIDATION_DEFAULTS.feelingDecayAfterDays,
+    now: options.now ?? Date.now(),
+  };
+  const merges = planMerges(memories, opts);
+  const mergedAwayIds = new Set(merges.flatMap((m) => m.removeIds));
+  const survivors = memories.filter((m) => !mergedAwayIds.has(m.id));
+  const decays = planDecays(survivors, opts.feelingDecayAfterDays, opts.now);
+  return { merges, decays };
+}
+
+export interface ConsolidationStats {
+  companionsScanned: number;
+  memoriesScanned: number;
+  merged: number;
+  decayed: number;
+}
+
+export function summarizePlan(plan: ConsolidationPlan): { merged: number; decayed: number } {
+  const merged = plan.merges.reduce((sum, m) => sum + m.removeIds.length, 0);
+  const decayed = plan.decays.length;
+  return { merged, decayed };
+}
+
+export function toApplyPlan(plan: ConsolidationPlan): ApplyConsolidationPlan {
+  return {
+    merges: plan.merges.map((m) => ({
+      keepId: m.keepId,
+      removeIds: m.removeIds,
+      newImportance: m.newImportance,
+      newMentionCount: m.newMentionCount,
+    })),
+    decays: plan.decays.map((d) => ({ id: d.id, newImportance: d.newImportance })),
+  };
+}
+
+export function consolidateCompanionMemories(
+  owner: CompanionMemoryOwner,
+  options: ConsolidationOptions = {},
+): ApplyConsolidationResult & { companionsScanned: number; memoriesScanned: number } {
+  const memories = getAllChatMemoriesForCompanion(owner.wallet_address, owner.token_id);
+  const plan = planConsolidation(memories, options);
+  const result = applyMemoryConsolidationPlan(toApplyPlan(plan));
+  return {
+    companionsScanned: 1,
+    memoriesScanned: memories.length,
+    merged: result.merged,
+    decayed: result.decayed,
+  };
+}
+
+export function consolidateAllCompanionMemories(
+  options: ConsolidationOptions = {},
+): ConsolidationStats {
+  const owners = listCompanionMemoryOwners();
+  const stats: ConsolidationStats = {
+    companionsScanned: 0,
+    memoriesScanned: 0,
+    merged: 0,
+    decayed: 0,
+  };
+  for (const owner of owners) {
+    const r = consolidateCompanionMemories(owner, options);
+    stats.companionsScanned += 1;
+    stats.memoriesScanned += r.memoriesScanned;
+    stats.merged += r.merged;
+    stats.decayed += r.decayed;
+  }
+  return stats;
+}


### PR DESCRIPTION
## Summary

Implements [SWO_SHARED_CHAT_MEMORY_CONSOLIDATION] — a weekly backend
batch job that keeps companion long-term memories tidy:

- **Merge duplicates** within the same category (Jaccard token similarity ≥ 0.85). Highest-importance memory wins; mention counts are summed.
- **Decay old emotions**: `companion_feelings` whose `last_mentioned_at` is older than N days (default 14) get importance reduced by 1 (floored at 1).
- **Summarize recurring topics**: looser threshold (default 0.5 Jaccard) clusters near-duplicate `recurring_topics` into a single representative.

The task identified this as a backend job depending on chat persistence shipped in `1d44697`.

## Surface area

- `lib/sanctuary/memoryConsolidation.ts` — pure planner (`planConsolidation`) + orchestrator (`consolidateAllCompanionMemories`).
- `lib/db.ts` — `listCompanionMemoryOwners`, `getAllChatMemoriesForCompanion`, `applyMemoryConsolidationPlan` (transactional).
- `app/api/admin/route.ts` — new POST action `consolidateChatMemories` (admin-auth, accepts optional threshold/decay-days overrides). Suitable for external cron / weekly trigger.
- `lib/sanctuary/__tests__/memoryConsolidation.test.ts` — 22 unit tests on the pure planner.

The pure planner takes a list of `SanctuaryChatMemory` rows and returns a `{merges, decays}` plan with no DB side effects, so it is fully unit-testable. The DB applier replays the plan inside a single transaction.

## Test plan
- [x] `npm run type-check` — 0 errors
- [x] `npx eslint` on changed files — 0 new errors / warnings
- [x] `npx vitest run` — 502 passed (22 new), 5 pre-existing failures unrelated (api-e2e nft-traits ×2, chat history limit, interact action message, roomScene v3)
- [x] `npm run build` — clean
- [ ] Manual: trigger via `POST /api/admin {action: 'consolidateChatMemories'}` against staging once admin wallet signature is available

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS — 447 errors before, 447 errors after (0 new; all pre-existing: PlayerSpriteV3.setFrame, missing colyseus.js, missing howler)
- **vitest run**: PASS — baseline 480 passed / 5 failed → after 502 passed / 5 failed (gained exactly the 22 new tests; pre-existing failures unchanged)
- Overall: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)