### PR TITLE
feat(sanctuary v2): deslop post-FX shader (palette quantize + Bayer dither)

### DIFF
--- a/game/__tests__/deslopShader.test.ts
+++ b/game/__tests__/deslopShader.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+
+import {
+  DESLOP_PALETTE_HEX,
+  PALETTE_SIZE,
+  DESLOP_DEFAULT_ON,
+  DESLOP_STORAGE_KEY,
+  hexToRgbNormalised,
+  paletteToFloat32,
+  nearestPaletteIndex,
+  isDeslopEnabled,
+} from '../shaders/deslopPalette';
+
+describe('deslop palette', () => {
+  it('exports a fixed-size palette of 6-digit hex strings', () => {
+    expect(PALETTE_SIZE).toBe(DESLOP_PALETTE_HEX.length);
+    expect(PALETTE_SIZE).toBeGreaterThanOrEqual(8);
+    for (const hex of DESLOP_PALETTE_HEX) {
+      expect(hex).toMatch(/^#[0-9a-f]{6}$/i);
+    }
+  });
+
+  it('hexToRgbNormalised maps hex to floats in [0,1]', () => {
+    expect(hexToRgbNormalised('#000000')).toEqual([0, 0, 0]);
+    expect(hexToRgbNormalised('#ffffff')).toEqual([1, 1, 1]);
+    const [r, g, b] = hexToRgbNormalised('#ffd700');
+    expect(r).toBeCloseTo(1, 5);
+    expect(g).toBeCloseTo(215 / 255, 5);
+    expect(b).toBeCloseTo(0, 5);
+  });
+
+  it('paletteToFloat32 packs PALETTE_SIZE * 3 floats', () => {
+    const flat = paletteToFloat32();
+    expect(flat).toBeInstanceOf(Float32Array);
+    expect(flat.length).toBe(PALETTE_SIZE * 3);
+    // First palette entry should match DESLOP_PALETTE_HEX[0] exactly.
+    const [r0, g0, b0] = hexToRgbNormalised(DESLOP_PALETTE_HEX[0]);
+    expect(flat[0]).toBeCloseTo(r0, 5);
+    expect(flat[1]).toBeCloseTo(g0, 5);
+    expect(flat[2]).toBeCloseTo(b0, 5);
+  });
+
+  it('nearestPaletteIndex returns a palette index for any input', () => {
+    const idx = nearestPaletteIndex(0.5, 0.5, 0.5);
+    expect(idx).toBeGreaterThanOrEqual(0);
+    expect(idx).toBeLessThan(PALETTE_SIZE);
+  });
+
+  it('nearestPaletteIndex maps an exact palette color to itself', () => {
+    const [r, g, b] = hexToRgbNormalised(DESLOP_PALETTE_HEX[7]); // cyan
+    expect(nearestPaletteIndex(r, g, b)).toBe(7);
+  });
+
+  it('throws on a malformed hex literal', () => {
+    expect(() => hexToRgbNormalised('#fff')).toThrow();
+  });
+});
+
+describe('isDeslopEnabled — toggle resolution', () => {
+  it('falls back to defaultOn when neither URL nor storage is set', () => {
+    expect(isDeslopEnabled({})).toBe(DESLOP_DEFAULT_ON);
+    expect(isDeslopEnabled({ defaultOn: true })).toBe(true);
+    expect(isDeslopEnabled({ defaultOn: false })).toBe(false);
+  });
+
+  it('honours ?deslop=1 URL flag', () => {
+    expect(isDeslopEnabled({ search: '?deslop=1', defaultOn: false })).toBe(true);
+    expect(isDeslopEnabled({ search: '?v=2&deslop=1', defaultOn: false })).toBe(true);
+    expect(isDeslopEnabled({ search: '?deslop=true' })).toBe(true);
+  });
+
+  it('honours ?deslop=0 URL flag (overrides defaultOn)', () => {
+    expect(isDeslopEnabled({ search: '?deslop=0', defaultOn: true })).toBe(false);
+    expect(isDeslopEnabled({ search: '?deslop=false', defaultOn: true })).toBe(false);
+  });
+
+  it('falls through to localStorage when URL flag is absent', () => {
+    const get = (key: string) => (key === DESLOP_STORAGE_KEY ? '1' : null);
+    expect(isDeslopEnabled({ localStorageGet: get, defaultOn: false })).toBe(true);
+  });
+
+  it('URL flag takes precedence over localStorage', () => {
+    const get = () => '1';
+    expect(
+      isDeslopEnabled({ search: '?deslop=0', localStorageGet: get, defaultOn: true }),
+    ).toBe(false);
+  });
+
+  it('ignores nonsense values and falls through to default', () => {
+    expect(isDeslopEnabled({ search: '?deslop=banana', defaultOn: true })).toBe(true);
+    expect(
+      isDeslopEnabled({ localStorageGet: () => 'banana', defaultOn: true }),
+    ).toBe(true);
+  });
+});
+
+describe('DeslopPostFXPipeline source — wiring guarantees', () => {
+  // Source-level smoke tests mirror the cosmeticSystem.test.ts pattern.
+  // We can't boot Phaser/WebGL in node, but we can guarantee that the
+  // critical glue (config registration, camera attach/detach, EventBus
+  // toggle) is present.
+  const pipelineSource = fs.readFileSync(
+    new URL('../shaders/DeslopPostFX.ts', import.meta.url),
+    'utf-8',
+  );
+  const configSource = fs.readFileSync(
+    new URL('../config/GameConfig.ts', import.meta.url),
+    'utf-8',
+  );
+  const worldSource = fs.readFileSync(
+    new URL('../scenes/WorldScene.ts', import.meta.url),
+    'utf-8',
+  );
+
+  it('pipeline class extends Phaser.Renderer.WebGL.Pipelines.PostFXPipeline', () => {
+    expect(pipelineSource).toMatch(/extends Phaser\.Renderer\.WebGL\.Pipelines[\s\S]{0,40}\.PostFXPipeline/);
+  });
+
+  it('pipeline declares a fragShader string', () => {
+    expect(pipelineSource).toContain('fragShader: FRAG_SHADER');
+  });
+
+  it('GameConfig registers the pipeline under the pipeline: key', () => {
+    expect(configSource).toContain('pipeline:');
+    expect(configSource).toContain('DESLOP_PIPELINE_KEY');
+    expect(configSource).toContain('DeslopPostFXPipeline');
+  });
+
+  it('WorldScene attaches the pipeline via setPostPipeline and detaches via removePostPipeline', () => {
+    expect(worldSource).toContain('cam.setPostPipeline(DeslopPostFXPipeline)');
+    expect(worldSource).toContain('cam.removePostPipeline(DESLOP_PIPELINE_KEY)');
+  });
+
+  it('WorldScene listens for runtime toggle on EventBus without scene restart', () => {
+    expect(worldSource).toContain("'deslop-toggle'");
+    // No scene.restart / scene.stop used by the toggle path.
+    const toggleBlock = worldSource.match(/setupDeslopShader[\s\S]+?(?=\n  private |\n  public |\n}\n)/);
+    expect(toggleBlock).not.toBeNull();
+    expect(toggleBlock?.[0] ?? '').not.toMatch(/scene\.restart/);
+  });
+
+  it('WorldScene resolves toggle via the shared isDeslopEnabledFromBrowser helper', () => {
+    expect(worldSource).toContain('isDeslopEnabledFromBrowser');
+  });
+});

--- a/game/config/GameConfig.ts
+++ b/game/config/GameConfig.ts
@@ -9,6 +9,7 @@ import { ForgeHammerScene } from '../scenes/ForgeHammerScene';
 import { CookingRhythmScene } from '../scenes/CookingRhythmScene';
 import { DreamCatcherScene } from '../scenes/DreamCatcherScene';
 import { LoreTriviaScene } from '../scenes/LoreTriviaScene';
+import { DeslopPostFXPipeline, DESLOP_PIPELINE_KEY } from '../shaders/DeslopPostFX';
 
 export const GAME_CONFIG: Phaser.Types.Core.GameConfig = {
   type: Phaser.AUTO,
@@ -42,4 +43,7 @@ export const GAME_CONFIG: Phaser.Types.Core.GameConfig = {
   pixelArt: true,
   antialias: false,
   roundPixels: true,
+  pipeline: {
+    [DESLOP_PIPELINE_KEY]: DeslopPostFXPipeline,
+  } as unknown as Phaser.Types.Core.PipelineConfig,
 };

--- a/game/scenes/WorldScene.ts
+++ b/game/scenes/WorldScene.ts
@@ -20,6 +20,11 @@ import {
 } from '../config/worldLayout';
 import { getOverworldNPCDefinitions } from '../config/npcDefinitions';
 import { cameraState } from '../systems/CameraState';
+import {
+  DeslopPostFXPipeline,
+  DESLOP_PIPELINE_KEY,
+} from '../shaders/DeslopPostFX';
+import { isDeslopEnabledFromBrowser } from '../shaders/deslopPalette';
 
 const CAMERA_ZOOM = 1.5;
 
@@ -98,7 +103,39 @@ export class WorldScene extends Phaser.Scene {
       if (params.get('edit') === '1') this.setEditorMode(true);
     }
 
+    this.setupDeslopShader();
+
     EventBus.emit('scene-ready', this);
+  }
+
+  private setupDeslopShader() {
+    const cam = this.cameras.main;
+    const apply = (on: boolean) => {
+      if (on) {
+        cam.setPostPipeline(DeslopPostFXPipeline);
+      } else {
+        cam.removePostPipeline(DESLOP_PIPELINE_KEY);
+      }
+    };
+    apply(isDeslopEnabledFromBrowser());
+
+    EventBus.on('deslop-toggle', (data: boolean | { on?: boolean }) => {
+      const on = typeof data === 'boolean' ? data : !!data?.on;
+      apply(on);
+    });
+
+    if (typeof window !== 'undefined') {
+      // dev hook so operators can A/B test without reloading
+      (window as unknown as { swoDeslop?: (on: boolean) => void }).swoDeslop =
+        (on: boolean) => {
+          try {
+            window.localStorage.setItem('swo_deslop', on ? '1' : '0');
+          } catch {
+            /* private mode — ignore */
+          }
+          apply(on);
+        };
+    }
   }
 
   private buildNavGrid() {

--- a/game/shaders/DeslopPostFX.ts
+++ b/game/shaders/DeslopPostFX.ts
@@ -1,0 +1,107 @@
+/**
+ * SWO_V2_DESLOP_SHADER
+ *
+ * Phaser PostFX pipeline that quantises the rendered canvas to a fixed
+ * 16-color SWO palette, optionally with 4x4 Bayer-matrix ordered dithering.
+ * Attach to a camera with `cam.setPostPipeline(DeslopPostFXPipeline)` and
+ * detach with `cam.removePostPipeline(DeslopPostFXPipeline)`. Toggling does
+ * not require restarting the scene.
+ *
+ * Registered in `game/config/GameConfig.ts` under the `pipeline:` key so
+ * Phaser auto-installs the class on `Phaser.Game` boot.
+ */
+
+import Phaser from 'phaser';
+
+import {
+  DESLOP_PALETTE_HEX,
+  PALETTE_SIZE,
+  paletteToFloat32,
+} from './deslopPalette';
+
+export const DESLOP_PIPELINE_KEY = 'DeslopPostFX';
+
+/**
+ * GLSL ES 1.00 fragment shader. Two passes:
+ *  1. Optional 4x4 Bayer offset added to the source RGB to scatter
+ *     quantisation error.
+ *  2. Nearest-color search across the 16-color palette uniform.
+ * The if/else cascade for the Bayer matrix is verbose but avoids dynamic
+ * matrix indexing, which has spotty support across mid-tier GPUs.
+ */
+const FRAG_SHADER = `
+precision mediump float;
+
+uniform sampler2D uMainSampler;
+uniform vec3 uPalette[${PALETTE_SIZE}];
+uniform float uDitherStrength;
+
+varying vec2 outTexCoord;
+
+float bayerOffset(vec2 fragPos) {
+  vec2 p = mod(fragPos, 4.0);
+  int x = int(p.x);
+  int y = int(p.y);
+  float v = 0.0;
+  if (y == 0) {
+    if (x == 0) v = 0.0; else if (x == 1) v = 8.0; else if (x == 2) v = 2.0; else v = 10.0;
+  } else if (y == 1) {
+    if (x == 0) v = 12.0; else if (x == 1) v = 4.0; else if (x == 2) v = 14.0; else v = 6.0;
+  } else if (y == 2) {
+    if (x == 0) v = 3.0; else if (x == 1) v = 11.0; else if (x == 2) v = 1.0; else v = 9.0;
+  } else {
+    if (x == 0) v = 15.0; else if (x == 1) v = 7.0; else if (x == 2) v = 13.0; else v = 5.0;
+  }
+  return (v / 16.0) - 0.5;
+}
+
+void main() {
+  vec4 src = texture2D(uMainSampler, outTexCoord);
+  float d = bayerOffset(gl_FragCoord.xy) * uDitherStrength;
+  vec3 dithered = clamp(src.rgb + vec3(d), 0.0, 1.0);
+
+  vec3 best = uPalette[0];
+  float bestDist = 1000.0;
+  for (int i = 0; i < ${PALETTE_SIZE}; i++) {
+    vec3 diff = dithered - uPalette[i];
+    float dist = dot(diff, diff);
+    if (dist < bestDist) {
+      bestDist = dist;
+      best = uPalette[i];
+    }
+  }
+
+  gl_FragColor = vec4(best, src.a);
+}
+`;
+
+/** A non-zero default produces visibly dithered banding without obvious noise. */
+const DEFAULT_DITHER_STRENGTH = 0.06;
+
+export class DeslopPostFXPipeline extends Phaser.Renderer.WebGL.Pipelines
+  .PostFXPipeline {
+  private ditherStrength = DEFAULT_DITHER_STRENGTH;
+  private readonly paletteFlat = paletteToFloat32();
+
+  constructor(game: Phaser.Game) {
+    super({
+      game,
+      name: DESLOP_PIPELINE_KEY,
+      fragShader: FRAG_SHADER,
+    });
+  }
+
+  /** Per-frame uniform refresh — palette is constant, dither strength may toggle. */
+  onPreRender(): void {
+    this.set3fv('uPalette', this.paletteFlat);
+    this.set1f('uDitherStrength', this.ditherStrength);
+  }
+
+  /** 0 disables Bayer dithering; ~0.06 is a good visible default. */
+  setDitherStrength(v: number): void {
+    this.ditherStrength = Math.max(0, Math.min(1, v));
+  }
+}
+
+// Re-export so consumers can do a single import for both the class and the palette.
+export { DESLOP_PALETTE_HEX, PALETTE_SIZE };

--- a/game/shaders/deslopPalette.ts
+++ b/game/shaders/deslopPalette.ts
@@ -1,0 +1,137 @@
+/**
+ * SWO_V2_DESLOP_SHADER — palette + toggle plumbing
+ *
+ * This module is intentionally Phaser-free so it can be unit tested in node
+ * without booting a renderer. The Phaser pipeline class lives in
+ * `DeslopPostFX.ts` and consumes the constants exported here.
+ */
+
+export type DeslopRGB = readonly [number, number, number];
+
+/**
+ * Fixed N-color SWO palette used by the deslop post-FX shader.
+ * Colors are normalised RGB in [0, 1]. Length must stay at PALETTE_SIZE
+ * because the GLSL fragment shader unrolls the loop against that constant.
+ */
+export const DESLOP_PALETTE_HEX: readonly string[] = [
+  '#0a0015', // 0  deep night (matches game bg)
+  '#1a0a2e', // 1  dark purple
+  '#2a1845', // 2  mid purple
+  '#4a2a7a', // 3  purple
+  '#7a4ab8', // 4  lavender
+  '#9966ff', // 5  light lavender (UI accent)
+  '#c9a6ff', // 6  pale purple
+  '#00f7ff', // 7  cyan (UI accent)
+  '#44ff88', // 8  green (UI accent)
+  '#ffd700', // 9  gold (UI accent)
+  '#ff6688', // 10 pink
+  '#ff3344', // 11 red
+  '#ffffff', // 12 white
+  '#aaaaaa', // 13 light gray
+  '#555566', // 14 mid gray
+  '#1a1a2a', // 15 dark gray-blue
+];
+
+export const PALETTE_SIZE = DESLOP_PALETTE_HEX.length;
+
+export function hexToRgbNormalised(hex: string): DeslopRGB {
+  const h = hex.replace(/^#/, '');
+  if (h.length !== 6) throw new Error(`Invalid palette hex: ${hex}`);
+  const r = parseInt(h.slice(0, 2), 16);
+  const g = parseInt(h.slice(2, 4), 16);
+  const b = parseInt(h.slice(4, 6), 16);
+  return [r / 255, g / 255, b / 255] as const;
+}
+
+export function paletteToFloat32(): Float32Array {
+  const out = new Float32Array(PALETTE_SIZE * 3);
+  for (let i = 0; i < PALETTE_SIZE; i++) {
+    const [r, g, b] = hexToRgbNormalised(DESLOP_PALETTE_HEX[i]);
+    out[i * 3] = r;
+    out[i * 3 + 1] = g;
+    out[i * 3 + 2] = b;
+  }
+  return out;
+}
+
+/** Picks the palette index whose RGB has the smallest squared distance to the input. */
+export function nearestPaletteIndex(r: number, g: number, b: number): number {
+  let bestIdx = 0;
+  let bestDist = Number.POSITIVE_INFINITY;
+  for (let i = 0; i < PALETTE_SIZE; i++) {
+    const [pr, pg, pb] = hexToRgbNormalised(DESLOP_PALETTE_HEX[i]);
+    const dr = r - pr;
+    const dg = g - pg;
+    const db = b - pb;
+    const d = dr * dr + dg * dg + db * db;
+    if (d < bestDist) {
+      bestDist = d;
+      bestIdx = i;
+    }
+  }
+  return bestIdx;
+}
+
+// ---- Toggle plumbing -------------------------------------------------------
+
+const URL_PARAM = 'deslop';
+export const DESLOP_STORAGE_KEY = 'swo_deslop';
+/**
+ * Default-on policy: per task spec, ship default-OFF (opt-in) until operator
+ * A/B inspection signs off. Flip to `true` once that happens.
+ */
+export const DESLOP_DEFAULT_ON = false;
+
+export interface DeslopToggleEnv {
+  /** URL search string, e.g. `window.location.search`. Optional. */
+  search?: string;
+  /** Localstorage getter, so node tests can stub it. Optional. */
+  localStorageGet?: (key: string) => string | null;
+  /** Falls back to this if neither URL nor storage has an opinion. */
+  defaultOn?: boolean;
+}
+
+function parseFlag(raw: string | null | undefined): boolean | null {
+  if (raw == null) return null;
+  const v = raw.trim().toLowerCase();
+  if (v === '1' || v === 'true' || v === 'on' || v === 'yes') return true;
+  if (v === '0' || v === 'false' || v === 'off' || v === 'no') return false;
+  return null;
+}
+
+/**
+ * Resolves the deslop toggle state. URL flag (?deslop=…) wins over
+ * localStorage; localStorage wins over the default. Used by both the runtime
+ * scene wiring and the unit tests.
+ */
+export function isDeslopEnabled(env: DeslopToggleEnv = {}): boolean {
+  const { search, localStorageGet, defaultOn = DESLOP_DEFAULT_ON } = env;
+
+  if (search) {
+    const params = new URLSearchParams(search);
+    const fromUrl = parseFlag(params.get(URL_PARAM));
+    if (fromUrl !== null) return fromUrl;
+  }
+
+  if (localStorageGet) {
+    const fromStorage = parseFlag(localStorageGet(DESLOP_STORAGE_KEY));
+    if (fromStorage !== null) return fromStorage;
+  }
+
+  return defaultOn;
+}
+
+/** Browser convenience that wires `window.location.search` and `localStorage`. */
+export function isDeslopEnabledFromBrowser(): boolean {
+  if (typeof window === 'undefined') return DESLOP_DEFAULT_ON;
+  return isDeslopEnabled({
+    search: window.location.search,
+    localStorageGet: (k) => {
+      try {
+        return window.localStorage.getItem(k);
+      } catch {
+        return null;
+      }
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- New Phaser `PostFXPipeline` (`game/shaders/DeslopPostFX.ts`) that quantises the rendered canvas to a fixed 16-color SWO palette with optional 4×4 Bayer ordered dithering.
- Registered in `game/config/GameConfig.ts` under the Phaser config `pipeline:` key, so Phaser auto-installs the class on `Phaser.Game` boot.
- Wired into `WorldScene.create` via `cam.setPostPipeline(DeslopPostFXPipeline)` / `cam.removePostPipeline(DESLOP_PIPELINE_KEY)` — toggling does **not** restart the scene.
- Toggle resolution: `?deslop=1` (URL) → `localStorage.swo_deslop` → `DESLOP_DEFAULT_ON`. Default is `false` (opt-in) per task spec; flip to `true` once operator A/B inspection signs off.
- Dev hook: `window.swoDeslop(true|false)` flips the camera pipeline live and persists the choice to `localStorage`.
- Also listens for `EventBus.emit('deslop-toggle', true|false)` for non-DOM control paths.

## Files
- `game/shaders/DeslopPostFX.ts` — Pipeline class + GLSL ES 1.0 fragment shader (palette quantize + Bayer offset). Palette uploaded as `vec3[16]` uniform per `onPreRender`; dither strength mutable.
- `game/shaders/deslopPalette.ts` — Phaser-free palette/toggle helpers: 16-color hex palette, `paletteToFloat32`, `nearestPaletteIndex`, `isDeslopEnabled`, `isDeslopEnabledFromBrowser`. Pure node-testable.
- `game/config/GameConfig.ts` — adds `pipeline: { [DESLOP_PIPELINE_KEY]: DeslopPostFXPipeline }` to the Game config.
- `game/scenes/WorldScene.ts` — `setupDeslopShader()` attaches/detaches the pipeline at runtime, with the URL flag, localStorage, EventBus, and `window.swoDeslop` paths.
- `game/__tests__/deslopShader.test.ts` — 18 new tests: palette packing, nearest-color search, toggle precedence, source-level wiring guarantees.

## Test plan
- [x] `npm run type-check` — 0 errors
- [x] `npm run lint` on changed files — 0 new errors/warnings (213 pre-existing project-wide are unchanged)
- [x] `npm run test` — 18 new deslop tests pass; 498 total pass; 5 pre-existing failures (`roomScene.test.ts:31` looking for stale `'ROOM_H - 60'` string + 4 in `lib/sanctuary/__tests__/api-e2e.test.ts`) are unrelated to this PR (verified via `git stash` baseline)
- [ ] Operator A/B screenshots before/after at `?v=2&deslop=1` — pending; once approved, flip `DESLOP_DEFAULT_ON` to `true` in `game/shaders/deslopPalette.ts`

## How to test in-app
- Default sanctuary v2 (`?v=2`): rendered as before (shader off).
- Toggle on via URL: `?v=2&deslop=1` → palette-quantized canvas with Bayer dither.
- Toggle off via URL: `?v=2&deslop=0` (overrides any persisted localStorage).
- Live toggle from devtools: `window.swoDeslop(true)` / `window.swoDeslop(false)` — persists to `localStorage.swo_deslop`.

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS — no NEW errors introduced. PROD baseline has 450 pre-existing errors (missing `phaser`/`colyseus.js`/`howler` modules in PROD `node_modules`); after overlay, errors count rises to 454, all due to the same pre-existing missing-module condition (now matched on shifted line numbers in `WorldScene.ts` plus 3 new lines in `game/shaders/DeslopPostFX.ts` that import `phaser`).
- **vitest run**: PASS — 18 new tests pass; identical 5 pre-existing failures as the workspace baseline; no new failures introduced by this overlay.
- Overall: PASS (no NEW failures attributable to this PR; PROD `node_modules` lacks `phaser` so any further tsc cleanup is out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)