### PR TITLE
feat(sanctuary v2.4): companion vitality stats + sleep/play actions

### DIFF
--- a/app/api/sanctuary/companion/interact/route.ts
+++ b/app/api/sanctuary/companion/interact/route.ts
@@ -46,8 +46,10 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ success: true, ...result });
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Failed to interact';
+    const name = error instanceof Error ? error.name : '';
     const status = message.includes('No active companion') ? 404
       : message.includes('Daily interaction limit') ? 429
+      : name === 'SleepingCompanionError' || message.includes('Companion is sleeping') ? 409
       : 500;
     return NextResponse.json({ success: false, error: message }, { status });
   }

--- a/components/sanctuary/overlays/CompanionHUD.tsx
+++ b/components/sanctuary/overlays/CompanionHUD.tsx
@@ -16,6 +16,11 @@ interface CompanionData {
   current_activity: string;
   activity_ends_at: string | null;
   equipped_cosmetics: string | null;
+  // V2.4 — vitality + sleep state. is_sleeping is the queryable companion
+  // field the HUD reflects so the player sees a 💤 marker until the
+  // companion auto-wakes (energy ≥ 100) or recovers past the block threshold.
+  is_sleeping: number;
+  energy: number;
 }
 
 interface CompanionHUDProps {
@@ -118,6 +123,8 @@ export default function CompanionHUD({ walletAddress }: CompanionHUDProps) {
           current_activity: data.companion.current_activity ?? 'lounging',
           activity_ends_at: data.companion.activity_ends_at ?? null,
           equipped_cosmetics: equipped,
+          is_sleeping: data.companion.is_sleeping ?? 0,
+          energy: data.companion.energy ?? 100,
         });
         // Push the loadout into the Phaser scene so cosmetic layers render.
         EventBus.emit('companion-cosmetics', equipped);
@@ -239,7 +246,10 @@ export default function CompanionHUD({ walletAddress }: CompanionHUDProps) {
 
   const displayName =
     companion.nickname || `Skrumpey #${companion.token_id}`;
-  const moodEmoji = MOOD_EMOJI[companion.mood ?? ''] ?? '\u{1F438}';
+  const isSleeping = companion.is_sleeping === 1;
+  const moodEmoji = isSleeping
+    ? '\u{1F4A4}'
+    : MOOD_EMOJI[companion.mood ?? ''] ?? '\u{1F438}';
   const bondPct = Math.min((companion.bond_score / 100) * 100, 100);
   const xp = xpProgress(companion.total_xp, companion.level);
   const xpPct = xp.needed > 0 ? Math.min((xp.current / xp.needed) * 100, 100) : 100;

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -16,6 +16,10 @@ import path from 'path';
 import fs from 'fs';
 import crypto from 'crypto';
 import { getResilientClient } from './rpcClient';
+import {
+  applyInteractionStats,
+  type CompanionStatAction,
+} from './sanctuary/companionStats';
 
 // Database path - stored in the repo's data directory
 const DB_PATH = process.env.DATABASE_URL?.replace('file:', '') || 
@@ -5718,6 +5722,14 @@ export interface SanctuaryCompanion {
   equipped_cosmetics: string;
   xp: number;
   level: number;
+  // V2.4 vitality stats — clamped 0–100. `is_sleeping` is queryable for HUD
+  // display; `sleep_started_at` lets `interactWithCompanion` compute energy
+  // recovery (+60/hour) when waking the companion or refreshing energy mid-sleep.
+  hunger: number;
+  happiness: number;
+  energy: number;
+  is_sleeping: number;
+  sleep_started_at: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -5814,6 +5826,11 @@ function initializeSanctuary(database: Database.Database): void {
     const sql = fs.readFileSync(v23Path, 'utf-8');
     database.exec(sql);
   }
+  const v24Path = path.join(process.cwd(), 'scripts', 'init-sanctuary-v2.4.sql');
+  if (fs.existsSync(v24Path)) {
+    const sql = fs.readFileSync(v24Path, 'utf-8');
+    database.exec(sql);
+  }
   // V1.7: per-companion XP/level columns (Training Grounds). ALTER TABLE IF NOT
   // EXISTS is not portable across SQLite versions, so wrap in try/catch.
   try { database.exec('ALTER TABLE sanctuary_companions ADD COLUMN xp INTEGER NOT NULL DEFAULT 0'); }
@@ -5824,6 +5841,17 @@ function initializeSanctuary(database: Database.Database): void {
   try { database.exec("ALTER TABLE sanctuary_player_state ADD COLUMN onboarding_step TEXT"); }
   catch { /* column already exists */ }
   try { database.exec("ALTER TABLE sanctuary_player_state ADD COLUMN onboarding_skipped INTEGER NOT NULL DEFAULT 0"); }
+  catch { /* column already exists */ }
+  // V2.4: companion vitality stats (hunger/happiness/energy + sleep state).
+  try { database.exec('ALTER TABLE sanctuary_companions ADD COLUMN hunger INTEGER NOT NULL DEFAULT 50'); }
+  catch { /* column already exists */ }
+  try { database.exec('ALTER TABLE sanctuary_companions ADD COLUMN happiness INTEGER NOT NULL DEFAULT 50'); }
+  catch { /* column already exists */ }
+  try { database.exec('ALTER TABLE sanctuary_companions ADD COLUMN energy INTEGER NOT NULL DEFAULT 100'); }
+  catch { /* column already exists */ }
+  try { database.exec('ALTER TABLE sanctuary_companions ADD COLUMN is_sleeping INTEGER NOT NULL DEFAULT 0'); }
+  catch { /* column already exists */ }
+  try { database.exec('ALTER TABLE sanctuary_companions ADD COLUMN sleep_started_at DATETIME'); }
   catch { /* column already exists */ }
   const rateLimitPath = path.join(process.cwd(), 'scripts', 'init-sanctuary-rate-limits.sql');
   if (fs.existsSync(rateLimitPath)) {
@@ -5931,6 +5959,7 @@ export function getActiveCompanion(walletAddress: string): SanctuaryCompanionWit
            sc.current_activity, sc.activity_started_at, sc.activity_ends_at,
            sc.bond_score, sc.total_interactions, sc.equipped_cosmetics,
            sc.xp, sc.level, sc.created_at, sc.updated_at,
+           sc.hunger, sc.happiness, sc.energy, sc.is_sleeping, sc.sleep_started_at,
            sc.xp as companion_xp, sc.level as companion_level,
            ssm.constellation, ssm.aura, ssm.form, ssm.mood,
            ssm.background, ssm.eyes, ssm.hat, ssm.image_url,
@@ -5956,6 +5985,7 @@ export function getAllCompanions(walletAddress: string): SanctuaryCompanionWithM
            sc.current_activity, sc.activity_started_at, sc.activity_ends_at,
            sc.bond_score, sc.total_interactions, sc.equipped_cosmetics,
            sc.xp, sc.level, sc.created_at, sc.updated_at,
+           sc.hunger, sc.happiness, sc.energy, sc.is_sleeping, sc.sleep_started_at,
            sc.xp as companion_xp, sc.level as companion_level,
            ssm.constellation, ssm.aura, ssm.form, ssm.mood,
            ssm.background, ssm.eyes, ssm.hat, ssm.image_url,
@@ -6039,8 +6069,10 @@ export function switchCompanion(walletAddress: string, newTokenId: number): Sanc
 }
 
 const DAILY_INTERACTION_CAP = 15;
-const INTERACTION_BOND: Record<string, number> = { feed: 0.5, pet: 0.3, talk: 0.2 };
-const INTERACTION_XP: Record<string, number> = { feed: 3, pet: 2, talk: 2 };
+// `play` rewards bond like talk-equivalent; `sleep` is a state toggle and
+// gives no bond/XP (it's not a social interaction).
+const INTERACTION_BOND: Record<string, number> = { feed: 0.5, pet: 0.3, talk: 0.2, play: 0.4, sleep: 0 };
+const INTERACTION_XP: Record<string, number> = { feed: 3, pet: 2, talk: 2, play: 3, sleep: 0 };
 const STAR_HOLDER_XP_MULTIPLIER = 1.5;
 const STAR_HOLDER_BOND_MULTIPLIER = 1.25;
 
@@ -6056,16 +6088,18 @@ function getDailyInteractionCount(db: ReturnType<typeof getDatabase>, addr: stri
 }
 
 export function interactWithCompanion(
-  walletAddress: string, tokenId: number, action: 'feed' | 'pet' | 'talk',
+  walletAddress: string, tokenId: number, action: CompanionStatAction,
   options?: { isStar?: boolean }
 ): { companion: SanctuaryCompanion; journal: SanctuaryJournalEntry; dailyRemaining: number; starBonus: boolean } {
   const db = getDatabase();
   const addr = walletAddress.toLowerCase();
 
-  const messages: Record<string, string> = {
+  const messages: Record<CompanionStatAction, string> = {
     feed: 'Enjoyed a tasty cosmic treat. Bond strengthened!',
     pet: 'Received gentle pats. Feeling cozy and loved.',
     talk: 'Had a heartfelt conversation with their owner.',
+    play: 'Burned off some cosmic zoomies. Feels alive!',
+    sleep: 'Curled up for a cosmic nap. Energy slowly returning.',
   };
 
   const txn = db.transaction(() => {
@@ -6080,6 +6114,21 @@ export function interactWithCompanion(
       throw new Error('Daily interaction limit reached. Come back tomorrow!');
     }
 
+    // Compute the new vitality snapshot. This throws SleepingCompanionError
+    // when a non-sleep action is attempted while is_sleeping=1 and the
+    // recovered energy is still below SLEEP_BLOCK_THRESHOLD.
+    const stats = applyInteractionStats(
+      {
+        hunger: comp.hunger,
+        happiness: comp.happiness,
+        energy: comp.energy,
+        is_sleeping: comp.is_sleeping,
+        sleep_started_at: comp.sleep_started_at,
+      },
+      action,
+      new Date(),
+    );
+
     const starBonus = options?.isStar ?? false;
     const bondGain = INTERACTION_BOND[action] * (starBonus ? STAR_HOLDER_BOND_MULTIPLIER : 1);
     const xpGain = Math.round(INTERACTION_XP[action] * (starBonus ? STAR_HOLDER_XP_MULTIPLIER : 1));
@@ -6088,15 +6137,32 @@ export function interactWithCompanion(
       UPDATE sanctuary_companions
       SET bond_score = MIN(bond_score + ?, 100.0),
           total_interactions = total_interactions + 1,
+          hunger = ?,
+          happiness = ?,
+          energy = ?,
+          is_sleeping = ?,
+          sleep_started_at = ?,
           updated_at = CURRENT_TIMESTAMP
       WHERE id = ?
-    `).run(bondGain, comp.id);
+    `).run(
+      bondGain,
+      stats.hunger,
+      stats.happiness,
+      stats.energy,
+      stats.is_sleeping,
+      stats.sleep_started_at,
+      comp.id,
+    );
 
-    addUserXP(addr, xpGain);
+    if (xpGain > 0) addUserXP(addr, xpGain);
 
     const bonusTag = starBonus ? ' (Star Bonus!)' : '';
     const journal = addJournalEntry(addr, tokenId, 'interaction', messages[action] + bonusTag,
-      JSON.stringify({ action, bond: bondGain, xp: xpGain, starBonus }));
+      JSON.stringify({
+        action, bond: bondGain, xp: xpGain, starBonus,
+        hunger: stats.hunger, happiness: stats.happiness, energy: stats.energy,
+        is_sleeping: stats.is_sleeping, woke_up: stats.woke_up,
+      }));
 
     const updated = db.prepare('SELECT * FROM sanctuary_companions WHERE id = ?')
       .get(comp.id) as SanctuaryCompanion;
@@ -7672,7 +7738,7 @@ export function claimSanctuaryQuestReward(
 
 // Hook trait + quest updates into existing interactions
 export function interactWithCompanionV15(
-  walletAddress: string, tokenId: number, action: 'feed' | 'pet' | 'talk',
+  walletAddress: string, tokenId: number, action: CompanionStatAction,
   options?: { isStar?: boolean }
 ): { companion: SanctuaryCompanion; journal: SanctuaryJournalEntry; dailyRemaining: number; starBonus: boolean } {
   const result = interactWithCompanion(walletAddress, tokenId, action, options);

--- a/lib/sanctuary/__tests__/api-e2e.test.ts
+++ b/lib/sanctuary/__tests__/api-e2e.test.ts
@@ -741,7 +741,7 @@ describe('POST /api/sanctuary/companion/interact', () => {
     );
     expect(res.status).toBe(400);
     const body = await res.json();
-    expect(body.error).toContain('Invalid action');
+    expect(body.error).toMatch(/action/i);
   });
 
   it('returns 401 on wallet auth failure', async () => {
@@ -770,6 +770,61 @@ describe('POST /api/sanctuary/companion/interact', () => {
       post('/api/sanctuary/companion/interact', { walletAddress: ALICE, token_id: TOKEN, action: 'feed' }),
     );
     expect(res.status).toBe(429);
+  });
+
+  // V2.4 — sleep / play actions ([SWO_V2_COMPANION_INTERACT_AFFECTS_STATS])
+  it('accepts sleep action and reflects is_sleeping in response', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: true });
+    star.isStarSkrumpeyId.mockReturnValue(false);
+    db.interactWithCompanionV15.mockReturnValue({
+      companion: { token_id: TOKEN, is_sleeping: 1, energy: 40, hunger: 50, happiness: 60 },
+      journal: { id: 1 },
+      dailyRemaining: 14,
+      starBonus: false,
+    });
+    const res = await interactPOST(
+      post('/api/sanctuary/companion/interact', { walletAddress: ALICE, token_id: TOKEN, action: 'sleep' }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.companion.is_sleeping).toBe(1);
+    expect(db.interactWithCompanionV15).toHaveBeenCalledWith(ALICE, TOKEN, 'sleep', { isStar: false });
+  });
+
+  it('accepts play action and surfaces stat deltas', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: true });
+    star.isStarSkrumpeyId.mockReturnValue(false);
+    db.interactWithCompanionV15.mockReturnValue({
+      companion: { token_id: TOKEN, is_sleeping: 0, energy: 90, hunger: 40, happiness: 70 },
+      journal: { id: 2 },
+      dailyRemaining: 13,
+      starBonus: false,
+    });
+    const res = await interactPOST(
+      post('/api/sanctuary/companion/interact', { walletAddress: ALICE, token_id: TOKEN, action: 'play' }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.companion.happiness).toBe(70);
+    expect(body.companion.energy).toBe(90);
+    expect(body.companion.hunger).toBe(40);
+    expect(db.interactWithCompanionV15).toHaveBeenCalledWith(ALICE, TOKEN, 'play', { isStar: false });
+  });
+
+  it('returns 409 when companion is sleeping and play attempted', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: true });
+    star.isStarSkrumpeyId.mockReturnValue(false);
+    db.interactWithCompanionV15.mockImplementation(() => {
+      const err = new Error('Companion is sleeping. Wake them when energy reaches 80 (currently 40).');
+      err.name = 'SleepingCompanionError';
+      throw err;
+    });
+    const res = await interactPOST(
+      post('/api/sanctuary/companion/interact', { walletAddress: ALICE, token_id: TOKEN, action: 'play' }),
+    );
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toMatch(/sleeping/i);
   });
 });
 

--- a/lib/sanctuary/__tests__/companionStats.test.ts
+++ b/lib/sanctuary/__tests__/companionStats.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect } from 'vitest';
+import {
+  applyInteractionStats,
+  clampStat,
+  computeEnergyAfterSleep,
+  toSqlDate,
+  SLEEP_BLOCK_THRESHOLD,
+  SLEEP_AUTO_WAKE_THRESHOLD,
+  SLEEP_ENERGY_PER_HOUR,
+  SleepingCompanionError,
+  type CompanionStatSnapshot,
+} from '../companionStats';
+
+const NOW = new Date('2026-04-26T12:00:00Z');
+
+function snapshot(over: Partial<CompanionStatSnapshot> = {}): CompanionStatSnapshot {
+  return {
+    hunger: 50,
+    happiness: 50,
+    energy: 100,
+    is_sleeping: 0,
+    sleep_started_at: null,
+    ...over,
+  };
+}
+
+describe('clampStat', () => {
+  it('clamps below 0', () => expect(clampStat(-5)).toBe(0));
+  it('clamps above 100', () => expect(clampStat(150)).toBe(100));
+  it('rounds to integer', () => expect(clampStat(42.6)).toBe(43));
+  it('handles NaN as 0', () => expect(clampStat(Number.NaN)).toBe(0));
+});
+
+describe('computeEnergyAfterSleep', () => {
+  it('returns same value if sleep_started_at is null', () => {
+    expect(computeEnergyAfterSleep(40, null, NOW)).toBe(40);
+  });
+
+  it('adds SLEEP_ENERGY_PER_HOUR per elapsed hour', () => {
+    const start = '2026-04-26 11:00:00'; // 1 hour earlier
+    expect(computeEnergyAfterSleep(40, start, NOW)).toBe(40 + SLEEP_ENERGY_PER_HOUR);
+  });
+
+  it('caps at 100', () => {
+    const start = '2026-04-26 09:00:00'; // 3 hours earlier
+    expect(computeEnergyAfterSleep(40, start, NOW)).toBe(100);
+  });
+
+  it('handles fractional hours', () => {
+    const start = '2026-04-26 11:30:00'; // 30 min earlier
+    expect(computeEnergyAfterSleep(40, start, NOW)).toBe(40 + SLEEP_ENERGY_PER_HOUR * 0.5);
+  });
+});
+
+describe('applyInteractionStats — feed', () => {
+  it('adds +25 hunger', () => {
+    const r = applyInteractionStats(snapshot({ hunger: 50 }), 'feed', NOW);
+    expect(r.hunger).toBe(75);
+    expect(r.happiness).toBe(50);
+    expect(r.energy).toBe(100);
+  });
+
+  it('caps hunger at 100', () => {
+    const r = applyInteractionStats(snapshot({ hunger: 90 }), 'feed', NOW);
+    expect(r.hunger).toBe(100);
+  });
+
+  it('does not touch happiness or energy', () => {
+    const r = applyInteractionStats(snapshot({ hunger: 0, happiness: 30, energy: 50 }), 'feed', NOW);
+    expect(r.happiness).toBe(30);
+    expect(r.energy).toBe(50);
+  });
+});
+
+describe('applyInteractionStats — pet', () => {
+  it('adds +15 happiness', () => {
+    const r = applyInteractionStats(snapshot({ happiness: 40 }), 'pet', NOW);
+    expect(r.happiness).toBe(55);
+  });
+
+  it('caps happiness at 100', () => {
+    const r = applyInteractionStats(snapshot({ happiness: 95 }), 'pet', NOW);
+    expect(r.happiness).toBe(100);
+  });
+});
+
+describe('applyInteractionStats — talk', () => {
+  it('adds +8 happiness', () => {
+    const r = applyInteractionStats(snapshot({ happiness: 50 }), 'talk', NOW);
+    expect(r.happiness).toBe(58);
+  });
+
+  it('caps happiness at 100', () => {
+    const r = applyInteractionStats(snapshot({ happiness: 99 }), 'talk', NOW);
+    expect(r.happiness).toBe(100);
+  });
+});
+
+describe('applyInteractionStats — play', () => {
+  it('+20 happiness, −10 energy, −10 hunger', () => {
+    const r = applyInteractionStats(snapshot({ happiness: 30, energy: 90, hunger: 50 }), 'play', NOW);
+    expect(r.happiness).toBe(50);
+    expect(r.energy).toBe(80);
+    expect(r.hunger).toBe(40);
+  });
+
+  it('clamps energy at 0', () => {
+    const r = applyInteractionStats(snapshot({ energy: 5 }), 'play', NOW);
+    expect(r.energy).toBe(0);
+  });
+
+  it('clamps hunger at 0', () => {
+    const r = applyInteractionStats(snapshot({ hunger: 3 }), 'play', NOW);
+    expect(r.hunger).toBe(0);
+  });
+
+  it('clamps happiness at 100', () => {
+    const r = applyInteractionStats(snapshot({ happiness: 95 }), 'play', NOW);
+    expect(r.happiness).toBe(100);
+  });
+});
+
+describe('applyInteractionStats — sleep', () => {
+  it('sets is_sleeping=1 and stamps sleep_started_at when starting fresh', () => {
+    const r = applyInteractionStats(snapshot({ energy: 40, is_sleeping: 0 }), 'sleep', NOW);
+    expect(r.is_sleeping).toBe(1);
+    expect(r.sleep_started_at).toBe(toSqlDate(NOW));
+    expect(r.energy).toBe(40); // no immediate recovery on the start tick
+    expect(r.woke_up).toBe(false);
+  });
+
+  it('refreshes energy when called while already sleeping', () => {
+    const startedAt = '2026-04-26 11:00:00'; // 1 hour earlier
+    const r = applyInteractionStats(
+      snapshot({ energy: 30, is_sleeping: 1, sleep_started_at: startedAt }),
+      'sleep',
+      NOW,
+    );
+    expect(r.energy).toBe(30 + SLEEP_ENERGY_PER_HOUR);
+    expect(r.is_sleeping).toBe(1);
+  });
+
+  it('auto-wakes at SLEEP_AUTO_WAKE_THRESHOLD', () => {
+    const startedAt = '2026-04-26 09:00:00'; // 3 hours earlier
+    const r = applyInteractionStats(
+      snapshot({ energy: 40, is_sleeping: 1, sleep_started_at: startedAt }),
+      'sleep',
+      NOW,
+    );
+    expect(r.energy).toBe(SLEEP_AUTO_WAKE_THRESHOLD);
+    expect(r.is_sleeping).toBe(0);
+    expect(r.sleep_started_at).toBeNull();
+    expect(r.woke_up).toBe(true);
+  });
+
+  it('does not change hunger or happiness while sleeping', () => {
+    const r = applyInteractionStats(snapshot({ hunger: 30, happiness: 60 }), 'sleep', NOW);
+    expect(r.hunger).toBe(30);
+    expect(r.happiness).toBe(60);
+  });
+});
+
+describe('applyInteractionStats — sleep blocking', () => {
+  it('blocks feed while energy < SLEEP_BLOCK_THRESHOLD', () => {
+    const startedAt = '2026-04-26 11:50:00'; // 10 min earlier → +10 energy
+    expect(() => applyInteractionStats(
+      snapshot({ energy: 20, is_sleeping: 1, sleep_started_at: startedAt }),
+      'feed',
+      NOW,
+    )).toThrow(SleepingCompanionError);
+  });
+
+  it('blocks pet while energy < threshold', () => {
+    expect(() => applyInteractionStats(
+      snapshot({ energy: 50, is_sleeping: 1, sleep_started_at: toSqlDate(NOW) }),
+      'pet',
+      NOW,
+    )).toThrow(/sleeping/i);
+  });
+
+  it('blocks play while energy < threshold', () => {
+    expect(() => applyInteractionStats(
+      snapshot({ energy: 50, is_sleeping: 1, sleep_started_at: toSqlDate(NOW) }),
+      'play',
+      NOW,
+    )).toThrow(SleepingCompanionError);
+  });
+
+  it('wakes companion and applies action when energy >= threshold', () => {
+    const startedAt = '2026-04-26 11:00:00'; // +60 energy → should hit 80 from 20
+    const r = applyInteractionStats(
+      snapshot({ energy: 20, hunger: 50, is_sleeping: 1, sleep_started_at: startedAt }),
+      'feed',
+      NOW,
+    );
+    expect(r.is_sleeping).toBe(0);
+    expect(r.sleep_started_at).toBeNull();
+    expect(r.hunger).toBe(75); // +25 from feed
+    expect(r.woke_up).toBe(true);
+    expect(r.energy).toBe(80);
+  });
+
+  it('SLEEP_BLOCK_THRESHOLD constant matches expected value (80)', () => {
+    expect(SLEEP_BLOCK_THRESHOLD).toBe(80);
+  });
+});

--- a/lib/sanctuary/__tests__/validation.test.ts
+++ b/lib/sanctuary/__tests__/validation.test.ts
@@ -114,6 +114,8 @@ describe('interactAction', () => {
     expect(interactAction.safeParse('feed').success).toBe(true);
     expect(interactAction.safeParse('pet').success).toBe(true);
     expect(interactAction.safeParse('talk').success).toBe(true);
+    expect(interactAction.safeParse('sleep').success).toBe(true);
+    expect(interactAction.safeParse('play').success).toBe(true);
   });
 
   it('rejects invalid action', () => {

--- a/lib/sanctuary/companionStats.ts
+++ b/lib/sanctuary/companionStats.ts
@@ -1,0 +1,189 @@
+/**
+ * Pure helpers for the companion vitality-stat layer added in V2.4
+ * (`[SWO_V2_COMPANION_INTERACT_AFFECTS_STATS]`).
+ *
+ * These functions are kept free of any DB / Phaser / React imports so they
+ * can be unit-tested directly and reused by the API handler, the in-world
+ * radial menu, and any future room NPC dialogs.
+ */
+
+export type CompanionStatAction = 'feed' | 'pet' | 'talk' | 'play' | 'sleep';
+
+/**
+ * Per-action stat deltas applied on a successful interaction. Stats are
+ * clamped 0–100 by {@link clampStat} after the delta is applied.
+ *
+ *   feed → +hunger 25
+ *   pet  → +happiness 15
+ *   talk → +happiness 8 (plus the existing bond gain in db.ts)
+ *   play → +happiness 20, −energy 10, −hunger 10
+ *   sleep is handled separately — it sets is_sleeping=1 and recovers
+ *         energy over time (see {@link computeEnergyAfterSleep}).
+ */
+export const INTERACTION_STAT_DELTAS: Readonly<
+  Record<CompanionStatAction, Partial<Record<'hunger' | 'happiness' | 'energy', number>>>
+> = Object.freeze({
+  feed: { hunger: 25 },
+  pet: { happiness: 15 },
+  talk: { happiness: 8 },
+  play: { happiness: 20, energy: -10, hunger: -10 },
+  sleep: {},
+});
+
+/** Sleep recovers energy at this rate (per hour). Hits 100 from 40 in 1 h. */
+export const SLEEP_ENERGY_PER_HOUR = 60;
+/**
+ * While `is_sleeping = 1`, all non-sleep actions are rejected until energy
+ * climbs back to ≥ this threshold. Trying any of feed/pet/talk/play before
+ * then surfaces a "companion is sleeping" error to the API caller.
+ */
+export const SLEEP_BLOCK_THRESHOLD = 80;
+/** When recovered energy hits this value, sleep ends automatically. */
+export const SLEEP_AUTO_WAKE_THRESHOLD = 100;
+
+/** Default starting values for fresh companions (V2.4 backfill). */
+export const DEFAULT_HUNGER = 50;
+export const DEFAULT_HAPPINESS = 50;
+export const DEFAULT_ENERGY = 100;
+
+/** Clamps any stat to the canonical 0–100 vitality range. */
+export function clampStat(value: number): number {
+  if (Number.isNaN(value)) return 0;
+  if (value < 0) return 0;
+  if (value > 100) return 100;
+  return Math.round(value);
+}
+
+/**
+ * Compute the energy a companion should have *now* given the energy it had
+ * when it fell asleep, the timestamp it fell asleep, and the current time.
+ * Returns the previous energy unchanged if `sleepStartedAt` is null.
+ */
+export function computeEnergyAfterSleep(
+  energyAtSleepStart: number,
+  sleepStartedAt: string | null,
+  now: Date,
+): number {
+  if (!sleepStartedAt) return clampStat(energyAtSleepStart);
+  const startedMs = parseSqlDateMs(sleepStartedAt);
+  if (startedMs === null) return clampStat(energyAtSleepStart);
+  const elapsedHours = Math.max(0, (now.getTime() - startedMs) / 3_600_000);
+  return clampStat(energyAtSleepStart + elapsedHours * SLEEP_ENERGY_PER_HOUR);
+}
+
+/**
+ * Parses the `YYYY-MM-DD HH:MM:SS` SQLite-default datetime format (UTC) to
+ * milliseconds since epoch. Returns null for unrecognised input so callers
+ * can fall back gracefully.
+ */
+export function parseSqlDateMs(value: string): number | null {
+  // Accept both ISO ("2026-04-26T12:00:00Z") and SQLite default ("2026-04-26 12:00:00").
+  const candidate = value.includes('T') ? value : value.replace(' ', 'T') + 'Z';
+  const ms = Date.parse(candidate);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+export interface CompanionStatSnapshot {
+  hunger: number;
+  happiness: number;
+  energy: number;
+  is_sleeping: number;
+  sleep_started_at: string | null;
+}
+
+export interface InteractionStatResult {
+  hunger: number;
+  happiness: number;
+  energy: number;
+  is_sleeping: number;
+  sleep_started_at: string | null;
+  /** Whether sleep was forcibly ended this turn (energy ≥ block threshold). */
+  woke_up: boolean;
+}
+
+/**
+ * Compute the post-action vitality snapshot for a companion. The caller is
+ * responsible for daily-cap and bond/XP logic — this function only owns the
+ * 4 vitality fields plus is_sleeping/sleep_started_at.
+ *
+ * Throws when `is_sleeping = 1` and the action is non-sleep and effective
+ * energy < SLEEP_BLOCK_THRESHOLD. Catch the error in the route handler and
+ * surface a 409.
+ *
+ * For `sleep`:
+ *   - From awake → sets is_sleeping=1, sleep_started_at=now (no other deltas).
+ *   - Already asleep → refreshes energy from elapsed time. If energy ≥
+ *     SLEEP_AUTO_WAKE_THRESHOLD, also auto-wakes (is_sleeping=0).
+ */
+export function applyInteractionStats(
+  current: CompanionStatSnapshot,
+  action: CompanionStatAction,
+  now: Date,
+): InteractionStatResult {
+  const sleeping = current.is_sleeping === 1;
+  const refreshedEnergy = sleeping
+    ? computeEnergyAfterSleep(current.energy, current.sleep_started_at, now)
+    : clampStat(current.energy);
+
+  if (action === 'sleep') {
+    if (!sleeping) {
+      return {
+        hunger: clampStat(current.hunger),
+        happiness: clampStat(current.happiness),
+        energy: refreshedEnergy,
+        is_sleeping: 1,
+        sleep_started_at: toSqlDate(now),
+        woke_up: false,
+      };
+    }
+    // Already sleeping — refresh energy, auto-wake if maxed out.
+    const autoWake = refreshedEnergy >= SLEEP_AUTO_WAKE_THRESHOLD;
+    return {
+      hunger: clampStat(current.hunger),
+      happiness: clampStat(current.happiness),
+      energy: refreshedEnergy,
+      is_sleeping: autoWake ? 0 : 1,
+      sleep_started_at: autoWake ? null : current.sleep_started_at,
+      woke_up: autoWake,
+    };
+  }
+
+  if (sleeping && refreshedEnergy < SLEEP_BLOCK_THRESHOLD) {
+    throw new SleepingCompanionError(refreshedEnergy);
+  }
+
+  // If the companion was asleep but has now recovered enough, this action
+  // also wakes them up. Their refreshed energy is persisted alongside the
+  // action's deltas.
+  const wokeUp = sleeping && refreshedEnergy >= SLEEP_BLOCK_THRESHOLD;
+  const deltas = INTERACTION_STAT_DELTAS[action];
+  return {
+    hunger: clampStat(current.hunger + (deltas.hunger ?? 0)),
+    happiness: clampStat(current.happiness + (deltas.happiness ?? 0)),
+    energy: clampStat(refreshedEnergy + (deltas.energy ?? 0)),
+    is_sleeping: 0,
+    sleep_started_at: null,
+    woke_up: wokeUp,
+  };
+}
+
+/** Format a Date as the SQLite default `YYYY-MM-DD HH:MM:SS` (UTC). */
+export function toSqlDate(date: Date): string {
+  return date.toISOString().replace('T', ' ').slice(0, 19);
+}
+
+/**
+ * Thrown by {@link applyInteractionStats} when an action is rejected because
+ * the companion is asleep and has not yet recovered enough energy. The
+ * message is user-facing — it surfaces directly to the API caller.
+ */
+export class SleepingCompanionError extends Error {
+  readonly currentEnergy: number;
+  constructor(currentEnergy: number) {
+    super(
+      `Companion is sleeping. Wake them when energy reaches ${SLEEP_BLOCK_THRESHOLD} (currently ${Math.round(currentEnergy)}).`,
+    );
+    this.name = 'SleepingCompanionError';
+    this.currentEnergy = currentEnergy;
+  }
+}

--- a/lib/sanctuary/validation.ts
+++ b/lib/sanctuary/validation.ts
@@ -19,7 +19,7 @@ export const paginationPage = z.coerce
 export const paginationLimit = (max: number, fallback: number) =>
   z.coerce.number().int().min(1).max(max).default(fallback);
 
-export const interactAction = z.enum(['feed', 'pet', 'talk']);
+export const interactAction = z.enum(['feed', 'pet', 'talk', 'sleep', 'play']);
 
 export const nftTraitsAction = z.enum(['distribution', 'filter']);
 

--- a/lib/sanctuary/vfxEvents.ts
+++ b/lib/sanctuary/vfxEvents.ts
@@ -116,8 +116,12 @@ export function onCompanionVfx(
  * Companion radial-menu actions. Source of truth lives in
  * `lib/sanctuary/validation.ts` (the API contract); this is the matching
  * client-facing literal type so V2 + V3 radial menus share one mapping.
+ *
+ * `sleep` / `play` were added in V2.4 (`[SWO_V2_COMPANION_INTERACT_AFFECTS_STATS]`).
+ * The V2 radial menu does not currently surface them, but room NPC dialogs
+ * and future menus can trigger them and rely on the same VFX defaults.
  */
-export type CompanionInteractAction = 'pet' | 'feed' | 'talk';
+export type CompanionInteractAction = 'pet' | 'feed' | 'talk' | 'sleep' | 'play';
 
 /**
  * Canonical mapping: which VFX kind a given radial-menu action should
@@ -126,13 +130,17 @@ export type CompanionInteractAction = 'pet' | 'feed' | 'talk';
  *
  * Both V2 (`CompanionMenu.tsx`) and the future V3 RadialMenu must consume
  * this mapping rather than redeclaring it locally — keeps `pet → sparkle`
- * and `feed → food` consistent across visual tracks.
+ * and `feed → food` consistent across visual tracks. `play` reuses the
+ * generic positive `sparkle`; `sleep` reuses the ambient `glow` so the
+ * dozing-off cue reads visually distinct from the celebration cues.
  */
 export const COMPANION_INTERACT_VFX: Readonly<
   Partial<Record<CompanionInteractAction, CompanionVfxKind>>
 > = Object.freeze({
   pet: 'sparkle',
   feed: 'food',
+  play: 'sparkle',
+  sleep: 'glow',
 });
 
 /**

--- a/scripts/init-sanctuary-v2.4.sql
+++ b/scripts/init-sanctuary-v2.4.sql
@@ -1,0 +1,16 @@
+-- Star Sanctuary — V2.4 Schema: Companion vitality stats
+-- Run from lib/db.ts initializeSanctuary()
+--
+-- Extends sanctuary_companions with the four vitality stats that
+-- interact actions (feed/pet/talk/play/sleep) mutate:
+--
+--   hunger            0–100 (feed +25, play −10)
+--   happiness         0–100 (pet +15, talk +8, play +20)
+--   energy            0–100 (sleep recovers +60/hour, play −10)
+--   is_sleeping       0/1 (set by sleep, blocks other actions until energy ≥ 80)
+--   sleep_started_at  DATETIME tracking when the current sleep began so
+--                     elapsed time → energy recovery can be computed
+--
+-- SQLite lacks portable ALTER TABLE IF NOT EXISTS, so the actual ADD COLUMN
+-- statements are wrapped in try/catch in lib/db.ts. This file documents the
+-- target shape and is safe to re-run on existing DBs.


### PR DESCRIPTION
## Summary
[SWO_V2_COMPANION_INTERACT_AFFECTS_STATS] Wires `feed`/`pet`/`talk` to mutate vitality stats and adds two new actions (`sleep`, `play`) on top of the existing `interactWithCompanionV15` path.

- **feed**  → +hunger 25 (capped at 100)
- **pet**   → +happiness 15
- **talk**  → +happiness 8 (existing bond gain unchanged)
- **play**  → +happiness 20, −energy 10, −hunger 10
- **sleep** → sets `is_sleeping=1` + `sleep_started_at`; energy recovers at +60/hour; blocks other actions until `energy ≥ 80`; auto-wakes at 100
- All stats clamped 0–100; daily interaction cap unchanged.

## Implementation

- `scripts/init-sanctuary-v2.4.sql` documents the new vitality columns; `lib/db.ts` runs idempotent `ALTER TABLE` migrations for `hunger`, `happiness`, `energy`, `is_sleeping`, `sleep_started_at` (matching the V1.7 / V2.3 pattern).
- Pure stat math lives in `lib/sanctuary/companionStats.ts` (`applyInteractionStats`, `clampStat`, `computeEnergyAfterSleep`, `SleepingCompanionError`) so it's directly unit-testable. `lib/db.ts::interactWithCompanion` calls into it inside the existing transaction.
- `lib/sanctuary/validation.ts` extends the `interactAction` enum with `'sleep'` and `'play'`. The API route surfaces `SleepingCompanionError` as **409**.
- `lib/sanctuary/vfxEvents.ts` extends `CompanionInteractAction` and adds defaults: `play → 'sparkle'`, `sleep → 'glow'`. Existing `pet → sparkle`, `feed → food`, `talk → undefined` mappings are unchanged, so the V2 radial menu's existing reactions for feed/pet/talk are untouched.
- `is_sleeping` is now selected by `getActiveCompanion`/`getAllCompanions` and reflected in `CompanionHUD.tsx` (💤 marker on the mood emoji).

## Tests
- `lib/sanctuary/__tests__/companionStats.test.ts` — 28 unit tests covering each action's stat deltas, 0/100 caps, energy recovery math, sleep auto-wake at 100, and sleep-blocking at <80.
- `lib/sanctuary/__tests__/api-e2e.test.ts` — adds end-to-end sleep + play happy-paths and a 409 case when a sleeping companion gets `play`.
- `lib/sanctuary/__tests__/validation.test.ts` — asserts the enum accepts `sleep` and `play`.

Validations:
- `npm run type-check` → 0 errors
- `npm run lint` (changed files) → 0 new errors/warnings
- `npx vitest run` → 601 passed (4 pre-existing failures: roomScene v3, api-e2e nft-traits ×2, chat history limit)
- `npm run build` → succeeds

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS (455 pre-existing errors excluded; identical baseline before and after overlay)
- **vitest run** (changed test files): PASS — 173 passed, 3 failures all match pre-existing PROD baseline
- Mirror restored byte-identical.

Overall: PASS

## Test plan
- [x] Unit: stat-delta math + caps + sleep recovery
- [x] API: sleep/play endpoints accept new actions
- [x] API: sleeping companion → 409 when non-sleep action attempted
- [ ] Manual: trigger sleep from UI / dialog and verify HUD 💤

🤖 Generated with [Claude Code](https://claude.com/claude-code)