### PR TITLE
feat(sanctuary v2.4): derive companion mood from vitality stats

### DIFF
--- a/components/sanctuary/overlays/CompanionHUD.tsx
+++ b/components/sanctuary/overlays/CompanionHUD.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import EventBus from '@/components/sanctuary/EventBus';
 import { getWalletAuthHeader } from '@/lib/clientWalletAuth';
+import { resolveCompanionMood, type MoodStatInput } from '@/lib/sanctuary/mood';
 
 interface CompanionData {
   nickname: string | null;
@@ -16,6 +17,11 @@ interface CompanionData {
   current_activity: string;
   activity_ends_at: string | null;
   equipped_cosmetics: string | null;
+  // V2.4 vitality stats (optional — null/undefined for legacy companions)
+  hunger: number | null;
+  happiness: number | null;
+  energy: number | null;
+  is_sleeping: number | null;
 }
 
 interface CompanionHUDProps {
@@ -28,6 +34,11 @@ const MOOD_EMOJI: Record<string, string> = {
   calm: '\u{1F60C}',
   sleepy: '\u{1F634}',
   curious: '\u{1F9D0}',
+  // V2.4 stat-derived moods
+  sleeping: '\u{1F4A4}',
+  hungry: '\u{1F37D}\u{FE0F}',
+  lonely: '\u{1F62E}\u{200D}\u{1F4A8}',
+  idle: '\u{1F643}',
 };
 
 const XP_PER_LEVEL = 100;
@@ -118,6 +129,10 @@ export default function CompanionHUD({ walletAddress }: CompanionHUDProps) {
           current_activity: data.companion.current_activity ?? 'lounging',
           activity_ends_at: data.companion.activity_ends_at ?? null,
           equipped_cosmetics: equipped,
+          hunger: data.companion.hunger ?? null,
+          happiness: data.companion.happiness ?? null,
+          energy: data.companion.energy ?? null,
+          is_sleeping: data.companion.is_sleeping ?? null,
         });
         // Push the loadout into the Phaser scene so cosmetic layers render.
         EventBus.emit('companion-cosmetics', equipped);
@@ -239,7 +254,17 @@ export default function CompanionHUD({ walletAddress }: CompanionHUDProps) {
 
   const displayName =
     companion.nickname || `Skrumpey #${companion.token_id}`;
-  const moodEmoji = MOOD_EMOJI[companion.mood ?? ''] ?? '\u{1F438}';
+  const statsInput: MoodStatInput | null =
+    companion.hunger !== null && companion.happiness !== null && companion.energy !== null
+      ? {
+          hunger: companion.hunger,
+          happiness: companion.happiness,
+          energy: companion.energy,
+          is_sleeping: companion.is_sleeping ?? 0,
+        }
+      : null;
+  const effectiveMood = resolveCompanionMood(statsInput, companion.mood);
+  const moodEmoji = MOOD_EMOJI[effectiveMood ?? ''] ?? '\u{1F438}';
   const bondPct = Math.min((companion.bond_score / 100) * 100, 100);
   const xp = xpProgress(companion.total_xp, companion.level);
   const xpPct = xp.needed > 0 ? Math.min((xp.current / xp.needed) * 100, 100) : 100;

--- a/game/sprites/CompanionSprite.ts
+++ b/game/sprites/CompanionSprite.ts
@@ -7,6 +7,25 @@ import {
   type CosmeticSlot,
   type EquippedCosmetics,
 } from '../systems/CosmeticSystem';
+import {
+  deriveMoodFromStats,
+  statMoodToAnimationMood,
+  type MoodStatInput,
+} from '@/lib/sanctuary/mood';
+
+const VALID_MOODS: ReadonlyArray<CompanionMood> = ['happy', 'calm', 'sleepy', 'excited', 'curious', 'idle'];
+function isCompanionMood(value: string): value is CompanionMood {
+  return (VALID_MOODS as readonly string[]).includes(value);
+}
+
+function statsArePopulated(stats: MoodStatInput | null | undefined): stats is MoodStatInput {
+  if (!stats) return false;
+  return (
+    Number.isFinite(stats.hunger) &&
+    Number.isFinite(stats.happiness) &&
+    Number.isFinite(stats.energy)
+  );
+}
 
 const LERP_FACTOR = 0.15;
 const FOLLOW_DISTANCE = 20;
@@ -157,6 +176,23 @@ export class CompanionSprite extends Phaser.GameObjects.Container {
     if (this.animSystem.setMood(mood)) {
       this.refreshTexture();
     }
+  }
+
+  /**
+   * Update mood from a current vitality snapshot. Prefers stats-derived mood
+   * (V2.4 companions); falls back to the supplied trait mood for legacy
+   * companions whose stats have not yet been populated. The derived StatMood
+   * is mapped to an existing CompanionMood animation — no new art.
+   */
+  setMoodFromStats(stats: MoodStatInput | null | undefined, traitMood: string | null | undefined) {
+    if (!this.animSystem) return;
+    let target: CompanionMood | null = null;
+    if (statsArePopulated(stats)) {
+      target = statMoodToAnimationMood(deriveMoodFromStats(stats));
+    } else if (traitMood && isCompanionMood(traitMood)) {
+      target = traitMood;
+    }
+    if (target) this.setMood(target);
   }
 
   async setConstellation(constellation: Constellation) {

--- a/lib/sanctuary/__tests__/mood.test.ts
+++ b/lib/sanctuary/__tests__/mood.test.ts
@@ -1,0 +1,169 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+
+import {
+  deriveMoodFromStats,
+  resolveCompanionMood,
+  statMoodToAnimationMood,
+  HAPPY_STAT_THRESHOLD,
+  LOW_STAT_THRESHOLD,
+  type MoodStatInput,
+  type StatMood,
+} from '../mood';
+
+const balanced = (): MoodStatInput => ({ hunger: 50, happiness: 50, energy: 50 });
+
+describe('deriveMoodFromStats', () => {
+  describe('sleeping branch', () => {
+    it('returns "sleeping" when is_sleeping=1, regardless of stats', () => {
+      expect(
+        deriveMoodFromStats({ hunger: 0, happiness: 0, energy: 0, is_sleeping: 1 }),
+      ).toBe('sleeping');
+      expect(
+        deriveMoodFromStats({ hunger: 100, happiness: 100, energy: 100, is_sleeping: 1 }),
+      ).toBe('sleeping');
+    });
+
+    it('does not trigger when is_sleeping is 0, null, or undefined', () => {
+      const stats = balanced();
+      expect(deriveMoodFromStats({ ...stats, is_sleeping: 0 })).not.toBe('sleeping');
+      expect(deriveMoodFromStats({ ...stats, is_sleeping: null })).not.toBe('sleeping');
+      expect(deriveMoodFromStats(stats)).not.toBe('sleeping');
+    });
+  });
+
+  describe('hungry branch', () => {
+    it('returns "hungry" when hunger is the unique min and < 30', () => {
+      expect(
+        deriveMoodFromStats({ hunger: 10, happiness: 80, energy: 80 }),
+      ).toBe('hungry');
+    });
+
+    it('respects the 30 cutoff (29 → hungry, 30 → not hungry)', () => {
+      expect(
+        deriveMoodFromStats({ hunger: 29, happiness: 80, energy: 80 }),
+      ).toBe('hungry');
+      // 30 is NOT < 30 so this falls through (and 30/80/80 is not "all ≥ 60" so → idle)
+      expect(
+        deriveMoodFromStats({ hunger: 30, happiness: 80, energy: 80 }),
+      ).toBe('idle');
+    });
+  });
+
+  describe('sleepy branch', () => {
+    it('returns "sleepy" when energy is the unique min and < 30', () => {
+      expect(
+        deriveMoodFromStats({ hunger: 80, happiness: 80, energy: 10 }),
+      ).toBe('sleepy');
+    });
+  });
+
+  describe('lonely branch', () => {
+    it('returns "lonely" when happiness is the unique min and < 30', () => {
+      expect(
+        deriveMoodFromStats({ hunger: 80, happiness: 10, energy: 80 }),
+      ).toBe('lonely');
+    });
+  });
+
+  describe('happy branch', () => {
+    it('returns "happy" when ALL stats are ≥ 60', () => {
+      expect(
+        deriveMoodFromStats({ hunger: 60, happiness: 60, energy: 60 }),
+      ).toBe('happy');
+      expect(
+        deriveMoodFromStats({ hunger: 100, happiness: 100, energy: 100 }),
+      ).toBe('happy');
+    });
+
+    it('returns "idle" when at least one stat is below 60 (but none is critically low)', () => {
+      expect(
+        deriveMoodFromStats({ hunger: 59, happiness: 80, energy: 80 }),
+      ).toBe('idle');
+    });
+  });
+
+  describe('idle branch', () => {
+    it('returns "idle" when stats are mediocre (no min < 30, not all ≥ 60)', () => {
+      expect(
+        deriveMoodFromStats({ hunger: 40, happiness: 40, energy: 40 }),
+      ).toBe('idle');
+      expect(
+        deriveMoodFromStats({ hunger: 50, happiness: 30, energy: 50 }),
+      ).toBe('idle');
+    });
+  });
+
+  describe('tie-breaking', () => {
+    it('prefers "hungry" over "sleepy" when hunger and energy are tied at the min', () => {
+      expect(
+        deriveMoodFromStats({ hunger: 10, happiness: 80, energy: 10 }),
+      ).toBe('hungry');
+    });
+
+    it('prefers "sleepy" over "lonely" when energy and happiness are tied at the min', () => {
+      expect(
+        deriveMoodFromStats({ hunger: 80, happiness: 10, energy: 10 }),
+      ).toBe('sleepy');
+    });
+
+    it('returns "hungry" when all three are tied at the min and < 30', () => {
+      expect(
+        deriveMoodFromStats({ hunger: 5, happiness: 5, energy: 5 }),
+      ).toBe('hungry');
+    });
+  });
+
+  describe('threshold constants', () => {
+    it('exposes the documented thresholds so callers can stay in sync', () => {
+      expect(LOW_STAT_THRESHOLD).toBe(30);
+      expect(HAPPY_STAT_THRESHOLD).toBe(60);
+    });
+  });
+});
+
+describe('resolveCompanionMood', () => {
+  it('uses derived mood when stats are populated (V2.4 companions)', () => {
+    expect(
+      resolveCompanionMood({ hunger: 100, happiness: 100, energy: 100 }, 'curious'),
+    ).toBe('happy');
+    expect(
+      resolveCompanionMood({ hunger: 5, happiness: 80, energy: 80 }, 'happy'),
+    ).toBe('hungry');
+  });
+
+  it('falls back to trait mood when stats are null (legacy companions)', () => {
+    expect(resolveCompanionMood(null, 'calm')).toBe('calm');
+    expect(resolveCompanionMood(undefined, 'curious')).toBe('curious');
+  });
+
+  it('returns null when neither stats nor a trait mood are available', () => {
+    expect(resolveCompanionMood(null, null)).toBeNull();
+    expect(resolveCompanionMood(undefined, undefined)).toBeNull();
+  });
+
+  it('falls back to trait mood when stats object is malformed (NaN values)', () => {
+    expect(
+      resolveCompanionMood(
+        { hunger: NaN, happiness: 50, energy: 50 } as MoodStatInput,
+        'happy',
+      ),
+    ).toBe('happy');
+  });
+});
+
+describe('statMoodToAnimationMood', () => {
+  it('maps every StatMood to a valid existing CompanionMood — no new art', () => {
+    const mappings: Array<[StatMood, string]> = [
+      ['sleeping', 'sleepy'],
+      ['sleepy', 'sleepy'],
+      ['hungry', 'curious'],
+      ['lonely', 'calm'],
+      ['happy', 'happy'],
+      ['idle', 'idle'],
+    ];
+    for (const [statMood, expectedAnimation] of mappings) {
+      expect(statMoodToAnimationMood(statMood)).toBe(expectedAnimation);
+    }
+  });
+});

--- a/lib/sanctuary/mood.ts
+++ b/lib/sanctuary/mood.ts
@@ -1,0 +1,109 @@
+/**
+ * Pure mood-derivation helper for V2.4 companion vitality stats
+ * (`[SWO_V2_COMPANION_MOOD_FROM_STATS]`).
+ *
+ * Mood is computed deterministically from the current (decay-projected)
+ * vitality snapshot — `hunger`, `happiness`, `energy`, `is_sleeping` — and
+ * collapses to one of six labels the rest of the system reasons about.
+ * Trait-derived mood from the NFT metadata remains the fallback when stats
+ * are not yet populated (legacy companions during the V2.4 rollout).
+ *
+ * No DB / Phaser / React imports — keeps the helper trivially unit-testable
+ * and reusable from the API handler, CompanionSprite, and CompanionHUD.
+ */
+import type { CompanionMood } from '@/game/systems/AnimationSystem';
+
+export type StatMood = 'sleeping' | 'hungry' | 'sleepy' | 'lonely' | 'happy' | 'idle';
+
+/** Subset of CompanionStatSnapshot needed for mood derivation. */
+export interface MoodStatInput {
+  hunger: number;
+  happiness: number;
+  energy: number;
+  is_sleeping?: number | null;
+}
+
+/** Single stat below this threshold drives the dominant negative mood. */
+export const LOW_STAT_THRESHOLD = 30;
+/** All stats at-or-above this threshold drive the `happy` mood. */
+export const HAPPY_STAT_THRESHOLD = 60;
+
+/**
+ * Derive a {@link StatMood} from a current vitality snapshot.
+ *
+ * Mapping (initial — may be tuned):
+ *   - `is_sleeping` → `sleeping`
+ *   - min stat is hunger and < 30 → `hungry`
+ *   - min stat is energy and < 30 → `sleepy`
+ *   - min stat is happiness and < 30 → `lonely`
+ *   - all stats ≥ 60 → `happy`
+ *   - otherwise → `idle`
+ *
+ * Ties on minimum stat are broken in priority order:
+ * `hunger` > `energy` > `happiness` (most-urgent need wins).
+ */
+export function deriveMoodFromStats(stats: MoodStatInput): StatMood {
+  if (stats.is_sleeping === 1) return 'sleeping';
+
+  const { hunger, happiness, energy } = stats;
+  const min = Math.min(hunger, happiness, energy);
+
+  if (min < LOW_STAT_THRESHOLD) {
+    if (hunger === min) return 'hungry';
+    if (energy === min) return 'sleepy';
+    return 'lonely';
+  }
+
+  if (
+    hunger >= HAPPY_STAT_THRESHOLD &&
+    happiness >= HAPPY_STAT_THRESHOLD &&
+    energy >= HAPPY_STAT_THRESHOLD
+  ) {
+    return 'happy';
+  }
+
+  return 'idle';
+}
+
+/**
+ * Resolve the effective mood for a companion. Prefers the stat-derived mood
+ * when {@link MoodStatInput} is populated; falls back to the trait-mood
+ * string for legacy companions that have not yet been migrated to V2.4
+ * vitality stats. Returns `null` when neither source is available.
+ */
+export function resolveCompanionMood(
+  stats: MoodStatInput | null | undefined,
+  traitMood: string | null | undefined,
+): StatMood | string | null {
+  if (stats && areStatsPopulated(stats)) {
+    return deriveMoodFromStats(stats);
+  }
+  return traitMood ?? null;
+}
+
+function areStatsPopulated(stats: MoodStatInput): boolean {
+  return (
+    Number.isFinite(stats.hunger) &&
+    Number.isFinite(stats.happiness) &&
+    Number.isFinite(stats.energy)
+  );
+}
+
+/**
+ * Map a derived {@link StatMood} to the existing animation moods the sprite
+ * pipeline already supports — no new art is introduced. `sleeping` and
+ * `sleepy` share the same animation; `hungry` reuses `curious`; `lonely`
+ * reuses `calm`.
+ */
+const STAT_MOOD_TO_ANIMATION: Readonly<Record<StatMood, CompanionMood>> = Object.freeze({
+  sleeping: 'sleepy',
+  sleepy: 'sleepy',
+  hungry: 'curious',
+  lonely: 'calm',
+  happy: 'happy',
+  idle: 'idle',
+});
+
+export function statMoodToAnimationMood(mood: StatMood): CompanionMood {
+  return STAT_MOOD_TO_ANIMATION[mood];
+}


### PR DESCRIPTION
## Summary
- New pure helper `lib/sanctuary/mood.ts` derives a six-label mood
  (`sleeping`/`hungry`/`sleepy`/`lonely`/`happy`/`idle`) from a current
  vitality snapshot (`hunger` / `happiness` / `energy` / `is_sleeping`).
  Trait-derived mood remains the fallback when stats aren't yet populated
  (legacy companions during the V2.4 rollout).
- `CompanionSprite.setMoodFromStats(stats, traitMood)` routes through the
  helper and maps the derived `StatMood` to an existing `CompanionMood`
  animation — no new art (sleeping→sleepy, hungry→curious, lonely→calm).
- `CompanionHUD` now resolves the displayed mood via the helper and ships
  emoji entries for the new V2.4 mood labels; legacy companions keep their
  trait-mood emoji unchanged.
- 18 unit tests cover all five mood branches, threshold edges, tie-breaking,
  the legacy trait-mood fallback, and the `StatMood` → animation mapping.

Refs: `[SWO_V2_COMPANION_MOOD_FROM_STATS]` (Track A, P0).

The runtime "≤1s after a stat change" target lights up automatically once
the V2.4 stats land in the companion API response (PR #265). Until then,
`statsArePopulated` is false and behavior is identical to today.

## Test plan
- [x] `npm run type-check` — 0 errors
- [x] `npx eslint` on changed files — clean
- [x] `npx vitest run` — 587 passed (incl. 18 new mood tests); 5 pre-existing
      failures unrelated (roomScene v3, api-e2e nft-traits ×2, chat history
      limit, interact invalid-action message)
- [x] `npm run build` — green

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS — 459 errors before vs 459 after (same set;
  diff = 0 new errors). Pre-existing errors are missing-module noise
  (`phaser`, `colyseus.js`, `howler`) plus PlayerSpriteV3 strictness — not
  introduced by this PR.
- **vitest run**: PASS — 587 passed including 18 new mood tests; same 5
  pre-existing failures as workspace, no new ones.
- Mirror restored byte-identical (changed files reverted, new files removed).

Overall: **PASS**

🤖 Generated with [Claude Code](https://claude.com/claude-code)