### PR TITLE
feat(sanctuary v2.4): soft companion need alerts in HUD

### DIFF
--- a/components/sanctuary/overlays/CompanionHUD.tsx
+++ b/components/sanctuary/overlays/CompanionHUD.tsx
@@ -4,6 +4,13 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import EventBus from '@/components/sanctuary/EventBus';
 import { getWalletAuthHeader } from '@/lib/clientWalletAuth';
 import { resolveCompanionMood, type MoodStatInput } from '@/lib/sanctuary/mood';
+import {
+  alertIcon,
+  describeNeeds,
+  lowStats,
+  newlyCrossed,
+  type NeedStats,
+} from '@/lib/sanctuary/needs';
 
 interface CompanionData {
   nickname: string | null;
@@ -97,6 +104,11 @@ export default function CompanionHUD({ walletAddress }: CompanionHUDProps) {
   const [claiming, setClaiming] = useState(false);
   const [claimFeedback, setClaimFeedback] = useState<string | null>(null);
   const prevAwayRef = useRef<boolean>(false);
+  // Tracks the last observed vitality snapshot so we can detect downward
+  // crossings of the alert threshold. The visible alert state is derived
+  // from the current snapshot, but `prevNeedsRef` lets us emit the
+  // companion-need-alert event at most once per stat per cross.
+  const prevNeedsRef = useRef<NeedStats | null>(null);
 
   const fetchStarBalance = useCallback(async () => {
     if (!walletAddress) return;
@@ -183,6 +195,20 @@ export default function CompanionHUD({ walletAddress }: CompanionHUDProps) {
     }
   }, [onQuest]);
 
+  useEffect(() => {
+    if (!companion) return;
+    const next: NeedStats = {
+      hunger: companion.hunger,
+      happiness: companion.happiness,
+      energy: companion.energy,
+    };
+    const crossed = newlyCrossed(prevNeedsRef.current, next);
+    if (crossed.length > 0) {
+      EventBus.emit('companion-need-alert', { stats: crossed });
+    }
+    prevNeedsRef.current = next;
+  }, [companion]);
+
   const onEnter = useCallback((payload: { name: string }) => {
     setLocationName(payload.name);
     setLocationVisible(true);
@@ -207,6 +233,14 @@ export default function CompanionHUD({ walletAddress }: CompanionHUDProps) {
 
   const openTraits = useCallback(() => {
     EventBus.emit('traits-overlay-toggle');
+  }, []);
+
+  const openCompanionMenu = useCallback(() => {
+    if (typeof window === 'undefined') return;
+    EventBus.emit('companion-clicked', {
+      screenX: window.innerWidth / 2,
+      screenY: window.innerHeight / 2,
+    });
   }, []);
 
   const handleClaim = useCallback(async () => {
@@ -274,6 +308,16 @@ export default function CompanionHUD({ walletAddress }: CompanionHUDProps) {
   const compXp = companionXpProgress(companion.companion_xp, companion.companion_level);
   const compXpPct = compXp.needed > 0 ? Math.min((compXp.current / compXp.needed) * 100, 100) : 100;
 
+  const needSnapshot: NeedStats = {
+    hunger: companion.hunger,
+    happiness: companion.happiness,
+    energy: companion.energy,
+  };
+  const lowNeeds = lowStats(needSnapshot);
+  const alertVisible = lowNeeds.length > 0;
+  const alertGlyph = alertIcon(lowNeeds);
+  const alertTooltip = describeNeeds(needSnapshot);
+
   const questName = onQuest
     ? companion.current_activity.slice('exploring:'.length)
     : null;
@@ -297,6 +341,23 @@ export default function CompanionHUD({ walletAddress }: CompanionHUDProps) {
             {starBalance.toLocaleString()}
           </span>
         </div>
+      )}
+
+      {/* Need alert badge — soft, non-blocking, appears when any vitality
+          stat drops below NEED_ALERT_THRESHOLD. Click jumps to the
+          companion radial menu so the user can feed/pet/talk. The slot is
+          absolutely positioned so toggling visibility never relayouts the
+          rest of the HUD. */}
+      {alertVisible && (
+        <button
+          type="button"
+          onClick={openCompanionMenu}
+          className="absolute top-12 right-2 z-20 flex items-center justify-center w-7 h-7 bg-black/80 border border-[#ff6644]/70 rounded-full text-base leading-none pointer-events-auto select-none shadow-[0_0_8px_rgba(255,102,68,0.35)] hover:bg-[#3a1410]/80 hover:border-[#ff8866] transition-colors animate-pulse"
+          aria-label={`Companion needs attention: ${alertTooltip}`}
+          title={`${alertTooltip} — tap to interact`}
+        >
+          <span aria-hidden="true">{alertGlyph}</span>
+        </button>
       )}
 
       {/* Companion status bar */}

--- a/lib/sanctuary/__tests__/needs.test.ts
+++ b/lib/sanctuary/__tests__/needs.test.ts
@@ -1,0 +1,141 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+
+import {
+  alertIcon,
+  describeNeeds,
+  lowStats,
+  newlyCrossed,
+  NEED_ALERT_THRESHOLD,
+  type NeedKey,
+  type NeedStats,
+} from '../needs';
+
+const balanced = (): NeedStats => ({ hunger: 80, happiness: 80, energy: 80 });
+
+describe('lowStats', () => {
+  it('returns empty when every stat is at or above threshold', () => {
+    expect(lowStats(balanced())).toEqual([]);
+    expect(lowStats({ hunger: 30, happiness: 30, energy: 30 })).toEqual([]);
+  });
+
+  it('returns the keys strictly below threshold in canonical order', () => {
+    expect(
+      lowStats({ hunger: 10, happiness: 80, energy: 80 }),
+    ).toEqual(['hunger']);
+    expect(
+      lowStats({ hunger: 80, happiness: 5, energy: 80 }),
+    ).toEqual(['happiness']);
+    expect(
+      lowStats({ hunger: 80, happiness: 80, energy: 1 }),
+    ).toEqual(['energy']);
+    expect(
+      lowStats({ hunger: 5, happiness: 5, energy: 5 }),
+    ).toEqual(['hunger', 'happiness', 'energy']);
+  });
+
+  it('skips null/undefined stats (legacy companions without vitality)', () => {
+    expect(
+      lowStats({ hunger: null, happiness: undefined, energy: 5 }),
+    ).toEqual(['energy']);
+    expect(
+      lowStats({ hunger: null, happiness: null, energy: null }),
+    ).toEqual([]);
+  });
+
+  it('honors a custom threshold override', () => {
+    expect(lowStats({ hunger: 50, happiness: 50, energy: 50 }, 60)).toEqual([
+      'hunger',
+      'happiness',
+      'energy',
+    ]);
+  });
+
+  it('uses NEED_ALERT_THRESHOLD = 30 by default', () => {
+    expect(NEED_ALERT_THRESHOLD).toBe(30);
+    expect(lowStats({ hunger: 29, happiness: 80, energy: 80 })).toEqual([
+      'hunger',
+    ]);
+    expect(lowStats({ hunger: 30, happiness: 80, energy: 80 })).toEqual([]);
+  });
+});
+
+describe('newlyCrossed', () => {
+  it('returns no crossings when prev is null (initial observation)', () => {
+    expect(
+      newlyCrossed(null, { hunger: 5, happiness: 5, energy: 5 }),
+    ).toEqual([]);
+    expect(
+      newlyCrossed(undefined, { hunger: 5, happiness: 5, energy: 5 }),
+    ).toEqual([]);
+  });
+
+  it('reports stats that transitioned ≥threshold → <threshold', () => {
+    const prev: NeedStats = { hunger: 50, happiness: 50, energy: 50 };
+    const next: NeedStats = { hunger: 10, happiness: 50, energy: 50 };
+    expect(newlyCrossed(prev, next)).toEqual(['hunger']);
+  });
+
+  it('does NOT refire while a stat stays below threshold', () => {
+    const prev: NeedStats = { hunger: 20, happiness: 50, energy: 50 };
+    const next: NeedStats = { hunger: 5, happiness: 50, energy: 50 };
+    // hunger was already low — same cross, no new fire.
+    expect(newlyCrossed(prev, next)).toEqual([]);
+  });
+
+  it('refires after a stat recovers and drops again', () => {
+    const low: NeedStats = { hunger: 10, happiness: 50, energy: 50 };
+    const recovered: NeedStats = { hunger: 80, happiness: 50, energy: 50 };
+    const lowAgain: NeedStats = { hunger: 10, happiness: 50, energy: 50 };
+    expect(newlyCrossed(low, recovered)).toEqual([]);
+    expect(newlyCrossed(recovered, lowAgain)).toEqual(['hunger']);
+  });
+
+  it('reports independent crossings per stat', () => {
+    const prev: NeedStats = { hunger: 50, happiness: 50, energy: 50 };
+    const next: NeedStats = { hunger: 5, happiness: 5, energy: 50 };
+    expect(newlyCrossed(prev, next).sort()).toEqual(
+      (['hunger', 'happiness'] as NeedKey[]).sort(),
+    );
+  });
+});
+
+describe('describeNeeds', () => {
+  it('returns empty string when nothing is low', () => {
+    expect(describeNeeds(balanced())).toBe('');
+  });
+
+  it('lists each low stat with its action hint', () => {
+    const text = describeNeeds({ hunger: 5, happiness: 5, energy: 5 });
+    expect(text).toContain('Hungry');
+    expect(text).toContain('Lonely');
+    expect(text).toContain('Sleepy');
+    expect(text).toContain('feed');
+    expect(text).toContain('talk');
+    expect(text).toContain('rest');
+  });
+
+  it('omits non-low stats from the description', () => {
+    const text = describeNeeds({ hunger: 5, happiness: 80, energy: 80 });
+    expect(text).toContain('Hungry');
+    expect(text).not.toContain('Lonely');
+    expect(text).not.toContain('Sleepy');
+  });
+});
+
+describe('alertIcon', () => {
+  it('returns empty string when no stats are low', () => {
+    expect(alertIcon([])).toBe('');
+  });
+
+  it('returns a stat-specific icon when exactly one stat is low', () => {
+    const oneIcon = alertIcon(['hunger']);
+    expect(oneIcon).toBeTruthy();
+    expect(oneIcon).not.toBe('\u{26A0}\u{FE0F}');
+  });
+
+  it('collapses to the generic warning glyph when multiple stats are low', () => {
+    expect(alertIcon(['hunger', 'happiness'])).toBe('\u{26A0}\u{FE0F}');
+    expect(alertIcon(['hunger', 'happiness', 'energy'])).toBe('\u{26A0}\u{FE0F}');
+  });
+});

--- a/lib/sanctuary/needs.ts
+++ b/lib/sanctuary/needs.ts
@@ -1,0 +1,113 @@
+/**
+ * Pure helper for V2.4 companion vitality need alerts
+ * (`[SWO_V2_COMPANION_NEED_ALERTS]`).
+ *
+ * Identifies which vitality stats (`hunger`, `happiness`, `energy`) have
+ * dropped below the soft-alert threshold so the HUD can render a single
+ * non-blocking alert badge. Also exposes downward-crossing detection so the
+ * caller can ensure each per-stat alert fires at most once per cross
+ * (i.e. does not re-fire while the stat stays low).
+ *
+ * No DB / Phaser / React imports — keeps the helper trivially unit-testable
+ * and reusable from CompanionHUD and any future need-driven UI.
+ */
+
+export const NEED_ALERT_THRESHOLD = 30;
+
+export type NeedKey = 'hunger' | 'happiness' | 'energy';
+
+/** Subset of the companion vitality snapshot needed to derive alerts. */
+export interface NeedStats {
+  hunger: number | null | undefined;
+  happiness: number | null | undefined;
+  energy: number | null | undefined;
+}
+
+const NEED_KEYS: readonly NeedKey[] = ['hunger', 'happiness', 'energy'] as const;
+
+const NEED_LABEL: Readonly<Record<NeedKey, string>> = Object.freeze({
+  hunger: 'Hungry',
+  happiness: 'Lonely',
+  energy: 'Sleepy',
+});
+
+/** Action hint shown in the tooltip — matches CompanionMenu radial actions. */
+const NEED_HINT: Readonly<Record<NeedKey, string>> = Object.freeze({
+  hunger: 'feed',
+  happiness: 'talk',
+  energy: 'rest',
+});
+
+const NEED_ICON: Readonly<Record<NeedKey, string>> = Object.freeze({
+  hunger: '\u{1F37D}\u{FE0F}',
+  happiness: '\u{1F4AC}',
+  energy: '\u{1F4A4}',
+});
+
+function isLow(value: number | null | undefined, threshold: number): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value < threshold;
+}
+
+/**
+ * Returns the stats currently below the soft-alert threshold, in canonical
+ * order (`hunger`, `happiness`, `energy`). Null/undefined stats (legacy
+ * companions without V2.4 vitality data) are skipped.
+ */
+export function lowStats(
+  stats: NeedStats,
+  threshold: number = NEED_ALERT_THRESHOLD,
+): NeedKey[] {
+  const out: NeedKey[] = [];
+  for (const key of NEED_KEYS) {
+    if (isLow(stats[key], threshold)) out.push(key);
+  }
+  return out;
+}
+
+/**
+ * Returns the stats that have newly crossed below the threshold this update
+ * (were ≥threshold previously, now <threshold). Use to enforce the
+ * "fires at most once per stat per cross" contract — once a stat is low and
+ * acknowledged, it should not refire until it crosses back up and down.
+ *
+ * `prev = null` represents the very first observation, in which case no
+ * crossings are reported (we never alert on initial mount even if the stat
+ * is already low — only on observed transitions).
+ */
+export function newlyCrossed(
+  prev: NeedStats | null | undefined,
+  next: NeedStats,
+  threshold: number = NEED_ALERT_THRESHOLD,
+): NeedKey[] {
+  if (!prev) return [];
+  const wasLow = new Set(lowStats(prev, threshold));
+  return lowStats(next, threshold).filter((k) => !wasLow.has(k));
+}
+
+/** Tooltip text describing every currently-low stat with action hints. */
+export function describeNeeds(
+  stats: NeedStats,
+  threshold: number = NEED_ALERT_THRESHOLD,
+): string {
+  const low = lowStats(stats, threshold);
+  if (low.length === 0) return '';
+  return low.map((k) => `${NEED_LABEL[k]} — ${NEED_HINT[k]}`).join(' · ');
+}
+
+/**
+ * Pick a single icon for the alert badge. When exactly one stat is low we
+ * surface its specific glyph; with multiple low stats we collapse to the
+ * generic warning glyph so the HUD remains a single icon.
+ */
+export function alertIcon(low: readonly NeedKey[]): string {
+  if (low.length === 0) return '';
+  if (low.length === 1) return NEED_ICON[low[0]];
+  return '\u{26A0}\u{FE0F}';
+}
+
+export const NEED_ALERT_INTERNALS = Object.freeze({
+  NEED_KEYS,
+  NEED_LABEL,
+  NEED_HINT,
+  NEED_ICON,
+});


### PR DESCRIPTION
## Summary
Implements `[SWO_V2_COMPANION_NEED_ALERTS]`: a single soft, non-blocking alert badge in `CompanionHUD.tsx` that lights up when any V2.4 vitality stat (hunger / happiness / energy) drops below 30. The badge has a tooltip listing each low stat with its action hint (`feed`, `talk`, `rest`) and is click-to-open — clicking it emits `companion-clicked` to surface the radial CompanionMenu so the player can act.

- New pure helper **`lib/sanctuary/needs.ts`** with `lowStats`, `newlyCrossed`, `describeNeeds`, `alertIcon`, and `NEED_ALERT_THRESHOLD = 30`. No DB / Phaser / React imports — trivially unit-testable.
- **`components/sanctuary/overlays/CompanionHUD.tsx`** renders the badge as an `absolute`-positioned button at `top-12 right-2` so toggling visibility never relayouts the existing HUD (pixel-stable). The HUD also emits `companion-need-alert` at most once per stat per downward crossing via `newlyCrossed`, satisfying the "fires at most once per stat per cross" contract.
- Legacy companions (vitality stats `null`) are skipped — alert never appears for them.

### Acceptance criteria
- [x] Alert appears at threshold (any stat < 30)
- [x] Clears automatically once the relevant action raises the stat back above threshold (state derives from current snapshot)
- [x] Never fires more than once per stat per downward cross (`newlyCrossed` gates the EventBus emission)
- [x] HUD remains pixel-stable when the alert toggles (badge is absolutely positioned in an empty slot)
- [x] Never auto-opens an overlay; click is required
- [x] Never blocks gameplay (`pointer-events-auto` on the badge only, ambient HUD unchanged)

## Test plan
- [x] `npm run type-check` — 0 errors
- [x] `npx eslint` on changed files — clean (no warnings/errors)
- [x] `npx vitest run` — 16 new tests pass (`lib/sanctuary/__tests__/needs.test.ts`); 619 other tests pass; 4 pre-existing failures unrelated (roomScene v3, api-e2e nft-traits ×2, chat history limit) — confirmed via `git stash` baseline.

## Mirror Validation (PROD)
Baseline before overlay: tsc 459 errors, vitest 5 failed / 569 passed. After overlaying the three changed files (plus the not-yet-deployed `lib/sanctuary/mood.ts` it imports through):
- **tsc --noEmit**: PASS — 459 errors (0 new; the +1 delta seen without `mood.ts` overlaid is a not-yet-deployed-module artifact, excluded from the baseline-diff)
- **vitest run**: PASS — 5 failed / 585 passed (16 new tests passing, 0 new failures)
- Overall: **PASS**
- Mirror restored byte-identical (verified via `diff`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)