### PR TITLE
feat(sanctuary v2.5): tamagotchi-style stat decay + GET stats endpoint

### DIFF
--- a/app/api/sanctuary/companion/stats/route.ts
+++ b/app/api/sanctuary/companion/stats/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getCompanionStatsSnapshot } from '@/lib/db';
+import { ethAddress, tokenId, parseSearchParams, formatZodError } from '@/lib/sanctuary/validation';
+
+const querySchema = z.object({
+  address: ethAddress,
+  token_id: tokenId,
+});
+
+/**
+ * GET /api/sanctuary/companion/stats?address=0x...&token_id=123
+ *
+ * V2.5 — returns the projected current vitality snapshot (decayed from the
+ * last persisted `stats_updated_at`) plus the labelled needs[] for any stat
+ * below NEED_THRESHOLD. Pure read — does not mutate the persisted snapshot;
+ * `interactWithCompanion` is responsible for converging the values.
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const parsed = parseSearchParams(querySchema, searchParams);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { success: false, error: formatZodError(parsed.error) },
+        { status: 400 },
+      );
+    }
+
+    const snapshot = getCompanionStatsSnapshot(parsed.data.address, parsed.data.token_id);
+    if (!snapshot) {
+      return NextResponse.json(
+        { success: false, error: 'No active companion found for this wallet/token' },
+        { status: 404 },
+      );
+    }
+
+    return NextResponse.json({ success: true, ...snapshot });
+  } catch (error) {
+    console.error('Sanctuary companion stats GET error:', error);
+    return NextResponse.json({ success: false, error: 'Failed to fetch stats' }, { status: 500 });
+  }
+}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -18,8 +18,10 @@ import crypto from 'crypto';
 import { getResilientClient } from './rpcClient';
 import {
   applyInteractionStats,
+  toSqlDate,
   type CompanionStatAction,
 } from './sanctuary/companionStats';
+import { decayStats, computeNeeds, type DecayedStats } from './sanctuary/decay';
 
 // Database path - stored in the repo's data directory
 const DB_PATH = process.env.DATABASE_URL?.replace('file:', '') || 
@@ -5730,6 +5732,10 @@ export interface SanctuaryCompanion {
   energy: number;
   is_sleeping: number;
   sleep_started_at: string | null;
+  // V2.5 — last time the persisted vitality snapshot was reconciled with
+  // wall-clock decay. `decayStats(companion, now)` projects forward from
+  // this timestamp; `tickStats` writes the projection back and bumps it.
+  stats_updated_at: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -5831,6 +5837,11 @@ function initializeSanctuary(database: Database.Database): void {
     const sql = fs.readFileSync(v24Path, 'utf-8');
     database.exec(sql);
   }
+  const v25Path = path.join(process.cwd(), 'scripts', 'init-sanctuary-v2.5.sql');
+  if (fs.existsSync(v25Path)) {
+    const sql = fs.readFileSync(v25Path, 'utf-8');
+    database.exec(sql);
+  }
   // V1.7: per-companion XP/level columns (Training Grounds). ALTER TABLE IF NOT
   // EXISTS is not portable across SQLite versions, so wrap in try/catch.
   try { database.exec('ALTER TABLE sanctuary_companions ADD COLUMN xp INTEGER NOT NULL DEFAULT 0'); }
@@ -5853,6 +5864,13 @@ function initializeSanctuary(database: Database.Database): void {
   catch { /* column already exists */ }
   try { database.exec('ALTER TABLE sanctuary_companions ADD COLUMN sleep_started_at DATETIME'); }
   catch { /* column already exists */ }
+  // V2.5: tamagotchi-style decay — `stats_updated_at` lets `decayStats`
+  // project current vitality from the persisted snapshot. Backfilled to
+  // CURRENT_TIMESTAMP for existing rows so day-1 projections are accurate.
+  try {
+    database.exec('ALTER TABLE sanctuary_companions ADD COLUMN stats_updated_at DATETIME');
+    database.exec('UPDATE sanctuary_companions SET stats_updated_at = CURRENT_TIMESTAMP WHERE stats_updated_at IS NULL');
+  } catch { /* column already exists */ }
   const rateLimitPath = path.join(process.cwd(), 'scripts', 'init-sanctuary-rate-limits.sql');
   if (fs.existsSync(rateLimitPath)) {
     const sql = fs.readFileSync(rateLimitPath, 'utf-8');
@@ -6114,19 +6132,34 @@ export function interactWithCompanion(
       throw new Error('Daily interaction limit reached. Come back tomorrow!');
     }
 
+    // First reconcile decay since the last `stats_updated_at` so the action's
+    // deltas land on the projected (not stale persisted) snapshot. V2.5 —
+    // [SWO_V2_COMPANION_STATS_SCHEMA].
+    const now = new Date();
+    const decayed = decayStats(
+      {
+        hunger: comp.hunger,
+        happiness: comp.happiness,
+        energy: comp.energy,
+        stats_updated_at: comp.stats_updated_at,
+        is_sleeping: comp.is_sleeping,
+      },
+      now,
+    );
+
     // Compute the new vitality snapshot. This throws SleepingCompanionError
     // when a non-sleep action is attempted while is_sleeping=1 and the
     // recovered energy is still below SLEEP_BLOCK_THRESHOLD.
     const stats = applyInteractionStats(
       {
-        hunger: comp.hunger,
-        happiness: comp.happiness,
-        energy: comp.energy,
+        hunger: decayed.hunger,
+        happiness: decayed.happiness,
+        energy: decayed.energy,
         is_sleeping: comp.is_sleeping,
         sleep_started_at: comp.sleep_started_at,
       },
       action,
-      new Date(),
+      now,
     );
 
     const starBonus = options?.isStar ?? false;
@@ -6142,6 +6175,7 @@ export function interactWithCompanion(
           energy = ?,
           is_sleeping = ?,
           sleep_started_at = ?,
+          stats_updated_at = ?,
           updated_at = CURRENT_TIMESTAMP
       WHERE id = ?
     `).run(
@@ -6151,6 +6185,7 @@ export function interactWithCompanion(
       stats.energy,
       stats.is_sleeping,
       stats.sleep_started_at,
+      toSqlDate(now),
       comp.id,
     );
 
@@ -6171,6 +6206,78 @@ export function interactWithCompanion(
   });
 
   return txn();
+}
+
+/**
+ * V2.5 — read-only stats projection for the GET /api/sanctuary/companion/stats
+ * route. Returns the current decayed values plus the labelled needs[] without
+ * mutating the persisted snapshot. Returns null when the wallet has no active
+ * companion for the given token id.
+ */
+export function getCompanionStatsSnapshot(
+  walletAddress: string,
+  tokenId: number,
+  now: Date = new Date(),
+): { stats: DecayedStats; needs: string[]; updated_at: string | null } | null {
+  const db = getDatabase();
+  const addr = walletAddress.toLowerCase();
+  const comp = db.prepare(
+    'SELECT * FROM sanctuary_companions WHERE wallet_address = ? AND token_id = ? AND is_active = 1'
+  ).get(addr, tokenId) as SanctuaryCompanion | undefined;
+  if (!comp) return null;
+
+  const stats = decayStats(
+    {
+      hunger: comp.hunger,
+      happiness: comp.happiness,
+      energy: comp.energy,
+      stats_updated_at: comp.stats_updated_at,
+      is_sleeping: comp.is_sleeping,
+    },
+    now,
+  );
+  return { stats, needs: computeNeeds(stats), updated_at: comp.stats_updated_at };
+}
+
+/**
+ * V2.5 — converge the persisted vitality snapshot with wall-clock decay and
+ * bump `stats_updated_at`. Idempotent: calling twice in the same second is a
+ * no-op since the elapsed delta rounds to zero. `interactWithCompanion`
+ * applies decay inline (see `decayed` snapshot above), so direct callers only
+ * need this when they want to persist decay outside an interact path — e.g.
+ * a background refresh job. Returns the updated row, or null when no active
+ * companion exists for the wallet/token pair.
+ */
+export function tickStats(
+  walletAddress: string,
+  tokenId: number,
+  now: Date = new Date(),
+): SanctuaryCompanion | null {
+  const db = getDatabase();
+  const addr = walletAddress.toLowerCase();
+  const comp = db.prepare(
+    'SELECT * FROM sanctuary_companions WHERE wallet_address = ? AND token_id = ? AND is_active = 1'
+  ).get(addr, tokenId) as SanctuaryCompanion | undefined;
+  if (!comp) return null;
+
+  const decayed = decayStats(
+    {
+      hunger: comp.hunger,
+      happiness: comp.happiness,
+      energy: comp.energy,
+      stats_updated_at: comp.stats_updated_at,
+      is_sleeping: comp.is_sleeping,
+    },
+    now,
+  );
+
+  db.prepare(`
+    UPDATE sanctuary_companions
+    SET hunger = ?, happiness = ?, energy = ?, stats_updated_at = ?
+    WHERE id = ?
+  `).run(decayed.hunger, decayed.happiness, decayed.energy, toSqlDate(now), comp.id);
+
+  return db.prepare('SELECT * FROM sanctuary_companions WHERE id = ?').get(comp.id) as SanctuaryCompanion;
 }
 
 export function addJournalEntry(

--- a/lib/sanctuary/__tests__/decay.test.ts
+++ b/lib/sanctuary/__tests__/decay.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest';
+import {
+  decayStats,
+  computeNeeds,
+  DECAY_RATES_PER_HOUR,
+  DEFAULT_STATS,
+  NEED_THRESHOLD,
+  NEED_LABELS,
+  type DecayInput,
+} from '../decay';
+
+const NOW = new Date('2026-04-26T12:00:00Z');
+
+function input(over: Partial<DecayInput> = {}): DecayInput {
+  return {
+    hunger: 100,
+    happiness: 100,
+    energy: 100,
+    stats_updated_at: '2026-04-26 12:00:00',
+    is_sleeping: 0,
+    ...over,
+  };
+}
+
+describe('DECAY_RATES_PER_HOUR', () => {
+  it('exposes positive per-hour rates for all three stats', () => {
+    expect(DECAY_RATES_PER_HOUR.hunger).toBeGreaterThan(0);
+    expect(DECAY_RATES_PER_HOUR.happiness).toBeGreaterThan(0);
+    expect(DECAY_RATES_PER_HOUR.energy).toBeGreaterThan(0);
+  });
+});
+
+describe('DEFAULT_STATS', () => {
+  it('matches the V2.5 spec defaults (80/80/80)', () => {
+    expect(DEFAULT_STATS).toEqual({ hunger: 80, happiness: 80, energy: 80 });
+  });
+});
+
+describe('decayStats', () => {
+  it('returns clamped originals when stats_updated_at is null', () => {
+    const r = decayStats(input({ stats_updated_at: null, hunger: 75, happiness: 60, energy: 40 }), NOW);
+    expect(r).toEqual({ hunger: 75, happiness: 60, energy: 40 });
+  });
+
+  it('returns clamped originals when stats_updated_at is unparseable', () => {
+    const r = decayStats(input({ stats_updated_at: 'garbage', hunger: 50 }), NOW);
+    expect(r.hunger).toBe(50);
+  });
+
+  it('returns clamped originals when now is earlier than the snapshot (clock-skew)', () => {
+    const past = new Date('2026-04-26T08:00:00Z');
+    const r = decayStats(input({ stats_updated_at: '2026-04-26 12:00:00', hunger: 70 }), past);
+    expect(r.hunger).toBe(70);
+  });
+
+  it('decays each stat by its per-hour rate after 1 hour', () => {
+    const start = '2026-04-26 11:00:00'; // 1h earlier
+    const r = decayStats(input({ stats_updated_at: start }), NOW);
+    expect(r.hunger).toBe(100 - DECAY_RATES_PER_HOUR.hunger);
+    expect(r.happiness).toBe(100 - DECAY_RATES_PER_HOUR.happiness);
+    expect(r.energy).toBe(100 - DECAY_RATES_PER_HOUR.energy);
+  });
+
+  it('handles fractional hours', () => {
+    const start = '2026-04-26 11:30:00'; // 0.5h earlier
+    const r = decayStats(input({ stats_updated_at: start, hunger: 50 }), NOW);
+    // 50 - 0.5 * 2 = 49 (rounded)
+    expect(r.hunger).toBe(50 - Math.round(DECAY_RATES_PER_HOUR.hunger * 0.5));
+  });
+
+  it('decays monotonically across N hours (never increases)', () => {
+    let last = { hunger: 100, happiness: 100, energy: 100 };
+    for (let h = 1; h <= 50; h++) {
+      // Build a snapshot h hours before NOW
+      const snapshotMs = NOW.getTime() - h * 3_600_000;
+      const snapshot = new Date(snapshotMs).toISOString().replace('T', ' ').slice(0, 19);
+      const r = decayStats(input({ stats_updated_at: snapshot }), NOW);
+      expect(r.hunger).toBeLessThanOrEqual(last.hunger);
+      expect(r.happiness).toBeLessThanOrEqual(last.happiness);
+      expect(r.energy).toBeLessThanOrEqual(last.energy);
+      last = r;
+    }
+  });
+
+  it('clamps decay at 0 (never goes negative across many hours)', () => {
+    // 1000 hours of decay from 100 must floor at 0 for each stat.
+    const start = new Date(NOW.getTime() - 1000 * 3_600_000).toISOString().replace('T', ' ').slice(0, 19);
+    const r = decayStats(input({ stats_updated_at: start }), NOW);
+    expect(r.hunger).toBe(0);
+    expect(r.happiness).toBe(0);
+    expect(r.energy).toBe(0);
+  });
+
+  it('clamps inputs at 100 even before applying decay', () => {
+    const r = decayStats(input({ stats_updated_at: null, hunger: 250 }), NOW);
+    expect(r.hunger).toBe(100);
+  });
+
+  it('suppresses energy decay while is_sleeping = 1', () => {
+    const start = '2026-04-26 11:00:00'; // 1h earlier
+    const r = decayStats(input({ stats_updated_at: start, is_sleeping: 1, energy: 60 }), NOW);
+    expect(r.energy).toBe(60); // unchanged — sleep recovery handled elsewhere
+    // Hunger and happiness still decay while sleeping.
+    expect(r.hunger).toBeLessThan(100);
+    expect(r.happiness).toBeLessThan(100);
+  });
+
+  it('returns deterministic values for a fixed clock', () => {
+    const a = decayStats(input({ stats_updated_at: '2026-04-26 06:00:00' }), NOW);
+    const b = decayStats(input({ stats_updated_at: '2026-04-26 06:00:00' }), NOW);
+    expect(a).toEqual(b);
+  });
+});
+
+describe('computeNeeds', () => {
+  it('returns empty when all stats are above threshold', () => {
+    expect(computeNeeds({ hunger: 80, happiness: 80, energy: 80 })).toEqual([]);
+  });
+
+  it('flags hungry when hunger < threshold', () => {
+    expect(computeNeeds({ hunger: NEED_THRESHOLD - 1, happiness: 80, energy: 80 })).toEqual([NEED_LABELS.hunger]);
+  });
+
+  it('flags lonely when happiness < threshold', () => {
+    expect(computeNeeds({ hunger: 80, happiness: NEED_THRESHOLD - 1, energy: 80 })).toEqual([NEED_LABELS.happiness]);
+  });
+
+  it('flags tired when energy < threshold', () => {
+    expect(computeNeeds({ hunger: 80, happiness: 80, energy: NEED_THRESHOLD - 1 })).toEqual([NEED_LABELS.energy]);
+  });
+
+  it('preserves stable hunger→happiness→energy ordering when multiple needs fire', () => {
+    expect(computeNeeds({ hunger: 5, happiness: 5, energy: 5 })).toEqual([
+      NEED_LABELS.hunger,
+      NEED_LABELS.happiness,
+      NEED_LABELS.energy,
+    ]);
+  });
+
+  it('does NOT flag a stat that is exactly at the threshold', () => {
+    expect(computeNeeds({ hunger: NEED_THRESHOLD, happiness: NEED_THRESHOLD, energy: NEED_THRESHOLD })).toEqual([]);
+  });
+});

--- a/lib/sanctuary/decay.ts
+++ b/lib/sanctuary/decay.ts
@@ -1,0 +1,122 @@
+/**
+ * Tamagotchi-style stat decay (V2.5, [SWO_V2_COMPANION_STATS_SCHEMA]).
+ *
+ * `decayStats` is a pure projection of where a companion's vitality values
+ * "should be" right now given the last-known snapshot and the elapsed time.
+ * No DB / Phaser / React imports here so the helper can be unit-tested in
+ * isolation and reused by the GET /api/sanctuary/companion/stats route, the
+ * server-side `tickStats` mutator in db.ts, and any in-world HUD code.
+ */
+
+import { clampStat, parseSqlDateMs } from './companionStats';
+
+export type DecayableStat = 'hunger' | 'happiness' | 'energy';
+
+/**
+ * Per-stat decay applied per real-time hour. All values are positive — the
+ * stat is _decreased_ by this amount per elapsed hour (lower = needs
+ * attention). Energy decay only applies while awake; while is_sleeping = 1
+ * energy is recovered separately by `computeEnergyAfterSleep`.
+ *
+ * Hand-tuned so a fully fed/happy/awake companion crosses the soft "need"
+ * threshold (30) within a comfortable check-in window:
+ *   hunger    100 → 30 in 35 h (≈ 1.5 days)
+ *   happiness 100 → 30 in 70 h (≈ 3 days)
+ *   energy    100 → 30 in 70 h (sleep recovers this faster)
+ */
+export const DECAY_RATES_PER_HOUR: Readonly<Record<DecayableStat, number>> = Object.freeze({
+  hunger: 2,
+  happiness: 1,
+  energy: 1,
+});
+
+/**
+ * Fallback baseline used when seeding fresh stat snapshots. The V2.4 column
+ * defaults on sanctuary_companions are kept as-is for back-compat, but new
+ * callers (and any null-handling in decayStats) should treat 80/80/80 as the
+ * canonical "freshly initialised" state.
+ */
+export const DEFAULT_STATS: Readonly<Record<DecayableStat, number>> = Object.freeze({
+  hunger: 80,
+  happiness: 80,
+  energy: 80,
+});
+
+/**
+ * Stats below this value surface as a "need" in the GET stats endpoint and
+ * in CompanionHUD alerts (V2.4 [SWO_V2_COMPANION_NEED_ALERTS] used the same
+ * threshold; kept consistent here on purpose).
+ */
+export const NEED_THRESHOLD = 30;
+
+/** Human-readable label for each decayable stat surfaced in the needs list. */
+export const NEED_LABELS: Readonly<Record<DecayableStat, string>> = Object.freeze({
+  hunger: 'hungry',
+  happiness: 'lonely',
+  energy: 'tired',
+});
+
+/**
+ * Minimum projection input. Accepts either the full {@link SanctuaryCompanion}
+ * shape or a hand-rolled snapshot — the helper only touches the fields below.
+ */
+export interface DecayInput {
+  hunger: number;
+  happiness: number;
+  energy: number;
+  stats_updated_at: string | null;
+  is_sleeping?: number;
+}
+
+export interface DecayedStats {
+  hunger: number;
+  happiness: number;
+  energy: number;
+}
+
+/**
+ * Project the current vitality stats from a persisted snapshot, given the
+ * elapsed time since `stats_updated_at`. Pure — does not write.
+ *
+ * Behaviour:
+ *   - Each stat is reduced by DECAY_RATES_PER_HOUR[stat] × hours.
+ *   - Energy decay is _suppressed_ while is_sleeping = 1 (sleep recovery is
+ *     handled by computeEnergyAfterSleep in companionStats.ts).
+ *   - Results clamp to the canonical 0–100 range via {@link clampStat}.
+ *   - If `stats_updated_at` is null/unparseable or `now` is earlier than
+ *     the snapshot, the original (clamped) values are returned unchanged so
+ *     time-skew or fresh inserts cannot accidentally amplify a stat.
+ */
+export function decayStats(input: DecayInput, now: Date): DecayedStats {
+  const hunger = clampStat(input.hunger);
+  const happiness = clampStat(input.happiness);
+  const energy = clampStat(input.energy);
+
+  if (!input.stats_updated_at) {
+    return { hunger, happiness, energy };
+  }
+  const startedMs = parseSqlDateMs(input.stats_updated_at);
+  if (startedMs === null) {
+    return { hunger, happiness, energy };
+  }
+  const elapsedHours = (now.getTime() - startedMs) / 3_600_000;
+  if (!(elapsedHours > 0)) {
+    return { hunger, happiness, energy };
+  }
+
+  const sleeping = input.is_sleeping === 1;
+  return {
+    hunger: clampStat(hunger - DECAY_RATES_PER_HOUR.hunger * elapsedHours),
+    happiness: clampStat(happiness - DECAY_RATES_PER_HOUR.happiness * elapsedHours),
+    energy: sleeping ? energy : clampStat(energy - DECAY_RATES_PER_HOUR.energy * elapsedHours),
+  };
+}
+
+/** List of human-readable need labels for stats that fell below NEED_THRESHOLD. */
+export function computeNeeds(stats: DecayedStats): string[] {
+  const needs: string[] = [];
+  if (stats.hunger < NEED_THRESHOLD) needs.push(NEED_LABELS.hunger);
+  if (stats.happiness < NEED_THRESHOLD) needs.push(NEED_LABELS.happiness);
+  if (stats.energy < NEED_THRESHOLD) needs.push(NEED_LABELS.energy);
+  return needs;
+}

--- a/scripts/init-sanctuary-v2.5.sql
+++ b/scripts/init-sanctuary-v2.5.sql
@@ -1,0 +1,15 @@
+-- Star Sanctuary — V2.5 Schema: Tamagotchi-style stats decay
+-- Run from lib/db.ts initializeSanctuary().
+--
+-- Adds the `stats_updated_at` column to sanctuary_companions so the pure
+-- helper `decayStats` (lib/sanctuary/decay.ts) can project the current
+-- vitality values from the persisted snapshot. Server-side `tickStats`
+-- in lib/db.ts converges the persisted values whenever an `interact`
+-- path runs, so the column is always reasonably fresh.
+--
+-- The column is additive — V2.4 stat columns (hunger/happiness/energy +
+-- is_sleeping/sleep_started_at) remain untouched.
+--
+-- SQLite lacks portable ALTER TABLE IF NOT EXISTS, so the actual
+-- ADD COLUMN statement is wrapped in try/catch in lib/db.ts. This file
+-- documents the target shape and is safe to re-run on existing DBs.


### PR DESCRIPTION
## Summary
Implements `[SWO_V2_COMPANION_STATS_SCHEMA]` — a tamagotchi-style stat-decay foundation on top of the V2.4 vitality columns.

- New `lib/sanctuary/decay.ts` exposes the pure `decayStats(companion, now)` projection helper, per-stat decay rates (`hunger 2/h`, `happiness 1/h`, `energy 1/h`), default 80/80/80 baseline, and the 30-pt soft "needs" threshold. Energy decay is suppressed while `is_sleeping = 1` so existing sleep recovery (`computeEnergyAfterSleep`) stays authoritative.
- `sanctuary_companions` gains a backfilled `stats_updated_at DATETIME` column via `scripts/init-sanctuary-v2.5.sql` + an additive `ALTER TABLE` in `initializeSanctuary` (existing rows backfilled to `CURRENT_TIMESTAMP`).
- `interactWithCompanion` now reconciles decay before applying interaction deltas and bumps `stats_updated_at` on each turn, so persisted vitality converges with wall-clock decay automatically.
- New `tickStats(addr, tokenId)` server helper for callers that want to persist decay outside an interact path (e.g. background refresh).
- New `GET /api/sanctuary/companion/stats?address=…&token_id=…` returns `{ stats, needs[], updated_at }` as a deterministic, pure read.

## Acceptance criteria
- [x] SQLite migration ships, additive only, backfill of `stats_updated_at = now`
- [x] `DEFAULT_STATS = { hunger: 80, energy: 80, happiness: 80 }` exposed (and asserted in tests)
- [x] `decayStats` unit-tested for monotonic decay across N hours and capped at 0/100
- [x] Stats GET returns deterministic values for a fixed clock (`getCompanionStatsSnapshot(addr, tokenId, now)` accepts an injected `now`)
- [x] `npm run type-check` clean
- [x] `npm run test` — 18 new decay tests pass; only pre-existing failures remain (roomScene v3, api-e2e nft-traits ×2, chat history limit)

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS (2.7s) — 459 errors before AND after overlay (no new errors introduced; pre-existing PROD errors are missing `colyseus.js`/`howler` modules, etc.)
- **vitest run**: PASS — baseline 619 passed / 4 failed → after overlay 637 passed / 4 failed (same 4 pre-existing failures, +18 new decay tests)
Overall: PASS

## Test plan
- [ ] Run `npm run type-check` — clean
- [ ] Run `npx vitest run lib/sanctuary/__tests__/decay.test.ts` — 18/18 pass
- [ ] Hit `GET /api/sanctuary/companion/stats?address=0x…&token_id=123` and confirm `{ success, stats, needs, updated_at }` shape
- [ ] Trigger any `feed`/`pet`/`talk`/`play`/`sleep` call and verify `stats_updated_at` advances and decayed values apply before deltas

🤖 Generated with [Claude Code](https://claude.com/claude-code)