### PR TITLE
feat(sanctuary v2.5): inject companion stats + recent actions into chat prompt

### DIFF
--- a/app/api/sanctuary/companion/chat/route.ts
+++ b/app/api/sanctuary/companion/chat/route.ts
@@ -6,12 +6,14 @@ import {
   getCompanionChatHistoryCount,
   getActiveCompanion,
   getJournalEntries,
+  getJournalEntriesPaginated,
   getUnlockedTraits,
   generateTemplateCompanionReply,
   persistCompanionChatExchange,
   getTopChatMemories,
   upsertChatMemory,
 } from '@/lib/db';
+import { decayStats, computeNeeds } from '@/lib/sanctuary/decay';
 import { verifyWalletAccess } from '@/lib/walletAuth';
 import { applyRateLimit } from '@/lib/sanctuary/rateLimit';
 import {
@@ -140,6 +142,37 @@ export async function POST(request: NextRequest) {
     const unlockedTraits = getUnlockedTraits(address, tid);
     const memories = getTopChatMemories(address, tid, 5);
 
+    const now = new Date();
+    const projectedStats = decayStats(
+      {
+        hunger: companion.hunger,
+        happiness: companion.happiness,
+        energy: companion.energy,
+        stats_updated_at: companion.stats_updated_at,
+        is_sleeping: companion.is_sleeping,
+      },
+      now,
+    );
+    const needs = computeNeeds(projectedStats);
+
+    const recentActions = (() => {
+      try {
+        const page = getJournalEntriesPaginated(address, tid, { type: 'interaction', limit: 3, page: 1 });
+        return page.entries.map((e) => {
+          let action = 'interact';
+          try {
+            const meta = JSON.parse(e.metadata || '{}');
+            if (typeof meta.action === 'string') action = meta.action;
+          } catch {
+            // Ignore malformed metadata; keep default action label.
+          }
+          return { action, created_at: e.created_at };
+        });
+      } catch {
+        return [];
+      }
+    })();
+
     const prompt = buildChatPrompt({
       companion,
       history,
@@ -147,6 +180,15 @@ export async function POST(request: NextRequest) {
       unlockedTraits,
       memories,
       memoryExtractionInstruction: buildMemoryExtractionInstruction(),
+      state: {
+        hunger: projectedStats.hunger,
+        happiness: projectedStats.happiness,
+        energy: projectedStats.energy,
+        is_sleeping: companion.is_sleeping,
+        needs,
+        recentActions,
+      },
+      now,
       userMessage: message,
     });
 

--- a/lib/sanctuary/__tests__/chatPersonality.test.ts
+++ b/lib/sanctuary/__tests__/chatPersonality.test.ts
@@ -2,14 +2,21 @@ import { describe, it, expect } from 'vitest';
 import {
   buildChatPrompt,
   buildMemoryContextBlock,
+  buildCompanionStateBlock,
   bondLabel,
   moodLabel,
   estimateTokens,
   estimatePromptTokens,
+  formatHungerDescriptor,
+  formatHappinessDescriptor,
+  formatEnergyDescriptor,
+  formatTimeAgo,
   CONSTELLATION_PERSONAS,
   DEFAULT_PERSONA,
   MEMORY_INJECT_TOKEN_BUDGET,
   MAX_INJECTED_MEMORIES,
+  STATE_INJECT_TOKEN_BUDGET,
+  type CompanionStateInput,
 } from '../chatPersonality';
 import type {
   SanctuaryCompanionWithMeta,
@@ -377,5 +384,211 @@ describe('estimatePromptTokens', () => {
       userMessage: 'Hello world',
     });
     expect(estimatePromptTokens(out)).toBeGreaterThan(10);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// State injection — V2.5 [SWO_V2_COMPANION_CHAT_KNOWS_STATS]
+// ---------------------------------------------------------------------------
+
+const NOW = new Date('2026-04-27T12:00:00Z');
+
+const stateInput = (overrides: Partial<CompanionStateInput> = {}): CompanionStateInput => ({
+  hunger: 80,
+  happiness: 80,
+  energy: 80,
+  is_sleeping: 0,
+  needs: [],
+  recentActions: [],
+  ...overrides,
+});
+
+describe('descriptor helpers', () => {
+  it('hunger descriptor reflects severity', () => {
+    expect(formatHungerDescriptor(95)).toContain('full');
+    expect(formatHungerDescriptor(60)).toContain('satisfied');
+    expect(formatHungerDescriptor(40)).toContain('peckish');
+    expect(formatHungerDescriptor(20)).toContain('hungry');
+    expect(formatHungerDescriptor(5)).toContain('starving');
+  });
+
+  it('happiness descriptor reflects severity', () => {
+    expect(formatHappinessDescriptor(90)).toContain('sparkling');
+    expect(formatHappinessDescriptor(60)).toContain('cheerful');
+    expect(formatHappinessDescriptor(40)).toContain('dim');
+    expect(formatHappinessDescriptor(20)).toContain('lonely');
+    expect(formatHappinessDescriptor(5)).toContain('lonely');
+  });
+
+  it('energy descriptor reflects severity', () => {
+    expect(formatEnergyDescriptor(90)).toContain('rested');
+    expect(formatEnergyDescriptor(60)).toContain('alert');
+    expect(formatEnergyDescriptor(40)).toContain('drowsy');
+    expect(formatEnergyDescriptor(20)).toContain('tired');
+    expect(formatEnergyDescriptor(5)).toContain('exhausted');
+  });
+
+  it('descriptors clamp out-of-range values', () => {
+    expect(formatHungerDescriptor(150)).toContain('full');
+    expect(formatHungerDescriptor(-50)).toContain('starving');
+    expect(formatHappinessDescriptor(Number.NaN)).toContain('lonely');
+  });
+});
+
+describe('formatTimeAgo', () => {
+  it('formats minutes ago', () => {
+    expect(formatTimeAgo('2026-04-27 11:55:00', NOW)).toBe('5m ago');
+  });
+  it('formats moments ago for very recent events', () => {
+    expect(formatTimeAgo('2026-04-27 11:59:50', NOW)).toBe('just moments ago');
+  });
+  it('formats hours ago', () => {
+    expect(formatTimeAgo('2026-04-27 09:00:00', NOW)).toBe('3h ago');
+  });
+  it('formats days ago for distant events', () => {
+    expect(formatTimeAgo('2026-04-24 12:00:00', NOW)).toBe('3d ago');
+  });
+  it('returns "recently" for unparseable input', () => {
+    expect(formatTimeAgo('not-a-date', NOW)).toBe('recently');
+  });
+});
+
+describe('buildCompanionStateBlock', () => {
+  it('renders qualitative descriptors with no raw stat numbers', () => {
+    const block = buildCompanionStateBlock(
+      stateInput({ hunger: 22, happiness: 85, energy: 45 }),
+      NOW,
+    );
+    expect(block).toContain('hungry');
+    expect(block).toContain('sparkling');
+    expect(block).toContain('drowsy');
+    expect(block).not.toMatch(/\b22\b/);
+    expect(block).not.toMatch(/\b85\b/);
+    expect(block).not.toMatch(/\b45\b/);
+    expect(block).not.toMatch(/\d+%/);
+  });
+
+  it('lists active needs but never as raw numbers', () => {
+    const block = buildCompanionStateBlock(
+      stateInput({ hunger: 10, happiness: 10, needs: ['hungry', 'lonely'] }),
+      NOW,
+    );
+    expect(block).toContain('Active needs');
+    expect(block).toContain('hungry');
+    expect(block).toContain('lonely');
+  });
+
+  it('falls back when no needs are active', () => {
+    const block = buildCompanionStateBlock(stateInput(), NOW);
+    expect(block).toContain('feeling steady');
+  });
+
+  it('flags napping when is_sleeping is 1', () => {
+    const block = buildCompanionStateBlock(stateInput({ is_sleeping: 1 }), NOW);
+    expect(block).toContain('currently napping');
+  });
+
+  it('renders up to 3 recent actions with friendly verbs', () => {
+    const block = buildCompanionStateBlock(
+      stateInput({
+        recentActions: [
+          { action: 'feed', created_at: '2026-04-27 11:30:00' },
+          { action: 'play', created_at: '2026-04-27 09:00:00' },
+          { action: 'pet', created_at: '2026-04-26 12:00:00' },
+          { action: 'talk', created_at: '2026-04-25 12:00:00' },
+        ],
+      }),
+      NOW,
+    );
+    expect(block).toContain('fed me');
+    expect(block).toContain('played with me');
+    expect(block).toContain('petted me');
+    expect(block).not.toContain('talked with me');
+  });
+
+  it('falls back when no recent actions', () => {
+    const block = buildCompanionStateBlock(stateInput(), NOW);
+    expect(block).toContain('nothing recent');
+  });
+
+  it('respects the 200 token injection budget', () => {
+    const block = buildCompanionStateBlock(
+      stateInput({
+        hunger: 5,
+        happiness: 5,
+        energy: 5,
+        is_sleeping: 1,
+        needs: ['hungry', 'lonely', 'tired'],
+        recentActions: [
+          { action: 'feed', created_at: '2026-04-27 11:30:00' },
+          { action: 'play', created_at: '2026-04-27 09:00:00' },
+          { action: 'pet', created_at: '2026-04-26 12:00:00' },
+        ],
+      }),
+      NOW,
+    );
+    expect(estimateTokens(block)).toBeLessThanOrEqual(STATE_INJECT_TOKEN_BUDGET);
+  });
+
+  it('STATE_INJECT_TOKEN_BUDGET equals 200', () => {
+    expect(STATE_INJECT_TOKEN_BUDGET).toBe(200);
+  });
+});
+
+describe('buildChatPrompt with companion state', () => {
+  it('injects the state block into the system prompt when state is provided', () => {
+    const out = buildChatPrompt({
+      companion: mockCompanion(),
+      history: [],
+      state: stateInput({ hunger: 25, needs: ['hungry'] }),
+      now: NOW,
+      userMessage: 'Hi',
+    });
+    expect(out.system).toContain('current physical state');
+    expect(out.system).toContain('hungry');
+    expect(out.system).toContain('Never quote raw stat numbers');
+  });
+
+  it('does not inject the state block when state is omitted', () => {
+    const out = buildChatPrompt({
+      companion: mockCompanion(),
+      history: [],
+      userMessage: 'Hi',
+    });
+    expect(out.system).not.toContain('current physical state');
+  });
+
+  it('injection plus full prompt stays well under model limits', () => {
+    const out = buildChatPrompt({
+      companion: mockCompanion(),
+      history: [],
+      state: stateInput({
+        hunger: 20,
+        happiness: 20,
+        energy: 20,
+        is_sleeping: 1,
+        needs: ['hungry', 'lonely', 'tired'],
+        recentActions: [
+          { action: 'feed', created_at: '2026-04-27 11:30:00' },
+          { action: 'play', created_at: '2026-04-27 10:00:00' },
+          { action: 'pet', created_at: '2026-04-27 09:00:00' },
+        ],
+      }),
+      now: NOW,
+      userMessage: 'How are you?',
+    });
+    expect(estimatePromptTokens(out)).toBeLessThan(2000);
+  });
+
+  it('the system prompt instructs the model to reference state qualitatively', () => {
+    const out = buildChatPrompt({
+      companion: mockCompanion(),
+      history: [],
+      state: stateInput(),
+      now: NOW,
+      userMessage: 'Hi',
+    });
+    expect(out.system).toMatch(/qualitative|qualitatively/i);
+    expect(out.system).toMatch(/never\s+(state|quote)\s+raw\s+numbers|raw\s+stat\s+numbers/i);
   });
 });

--- a/lib/sanctuary/chatPersonality.ts
+++ b/lib/sanctuary/chatPersonality.ts
@@ -6,6 +6,7 @@ import type {
   SanctuaryChatMemory,
 } from '@/lib/db';
 import { buildBondStageBlock } from './bondStages';
+import { parseSqlDateMs } from './companionStats';
 
 export interface ConstellationPersona {
   description: string;
@@ -91,6 +92,8 @@ export interface ChatPromptInput {
   unlockedTraits?: SanctuaryTrait[];
   memories?: SanctuaryChatMemory[];
   memoryExtractionInstruction?: string;
+  state?: CompanionStateInput;
+  now?: Date;
   userMessage: string;
 }
 
@@ -104,6 +107,126 @@ const MAX_JOURNAL_ENTRIES = 4;
 const MAX_TRAITS_LISTED = 6;
 export const MEMORY_INJECT_TOKEN_BUDGET = 150;
 export const MAX_INJECTED_MEMORIES = 5;
+export const STATE_INJECT_TOKEN_BUDGET = 200;
+export const MAX_RECENT_ACTIONS = 3;
+
+export interface CompanionRecentAction {
+  action: string;
+  created_at: string;
+}
+
+export interface CompanionStateInput {
+  hunger: number;
+  happiness: number;
+  energy: number;
+  is_sleeping: number;
+  needs: string[];
+  recentActions: CompanionRecentAction[];
+}
+
+const HUNGER_DESCRIPTORS: { readonly min: number; readonly label: string }[] = [
+  { min: 80, label: 'belly is full and content' },
+  { min: 50, label: 'belly is comfortably satisfied' },
+  { min: 30, label: 'feeling a touch peckish' },
+  { min: 15, label: 'distinctly hungry, stomach grumbling' },
+  { min: 0, label: 'starving and weak from emptiness' },
+];
+
+const HAPPINESS_DESCRIPTORS: { readonly min: number; readonly label: string }[] = [
+  { min: 80, label: 'spirits are sparkling, joyful and warm' },
+  { min: 50, label: 'mood is cheerful and content' },
+  { min: 30, label: 'mood is okay but a bit dim' },
+  { min: 15, label: 'feeling lonely and low' },
+  { min: 0, label: 'lonely and sad, missing your warmth badly' },
+];
+
+const ENERGY_DESCRIPTORS: { readonly min: number; readonly label: string }[] = [
+  { min: 80, label: 'energy bright and well-rested' },
+  { min: 50, label: 'energy steady and alert' },
+  { min: 30, label: 'feeling a bit drowsy' },
+  { min: 15, label: 'tired, eyelids heavy' },
+  { min: 0, label: 'exhausted, can barely keep eyes open' },
+];
+
+const ACTION_VERBS: Readonly<Record<string, string>> = Object.freeze({
+  feed: 'fed me',
+  pet: 'petted me',
+  talk: 'talked with me',
+  play: 'played with me',
+  sleep: 'tucked me in for a nap',
+});
+
+function descriptorFor(value: number, table: { readonly min: number; readonly label: string }[]): string {
+  const v = Math.max(0, Math.min(100, Number.isFinite(value) ? value : 0));
+  for (const row of table) if (v >= row.min) return row.label;
+  return table[table.length - 1].label;
+}
+
+export function formatHungerDescriptor(v: number): string {
+  return descriptorFor(v, HUNGER_DESCRIPTORS);
+}
+export function formatHappinessDescriptor(v: number): string {
+  return descriptorFor(v, HAPPINESS_DESCRIPTORS);
+}
+export function formatEnergyDescriptor(v: number): string {
+  return descriptorFor(v, ENERGY_DESCRIPTORS);
+}
+
+export function formatTimeAgo(then: string, now: Date): string {
+  const ms = parseSqlDateMs(then);
+  if (ms === null) return 'recently';
+  const seconds = Math.max(0, Math.round((now.getTime() - ms) / 1000));
+  if (seconds < 60) return 'just moments ago';
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 36) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  return `${days}d ago`;
+}
+
+export function buildCompanionStateBlock(
+  state: CompanionStateInput,
+  now: Date = new Date(),
+): string {
+  const sleepingLine = state.is_sleeping === 1 ? '\n- Status: currently napping' : '';
+
+  const needsLine = state.needs.length
+    ? `Active needs (express them gently in voice, never list as a checklist): ${state.needs.join(', ')}`
+    : 'Active needs: feeling steady, nothing pressing';
+
+  const renderActions = (limit: number): string => {
+    const lines = state.recentActions.slice(0, limit).map((a) => {
+      const verb = ACTION_VERBS[a.action] ?? `${a.action} with me`;
+      return `- ${formatTimeAgo(a.created_at, now)} — they ${verb}`;
+    });
+    return lines.length
+      ? `Recent care from your holder (most recent first):\n${lines.join('\n')}`
+      : 'Recent care from your holder: nothing recent — they have not interacted with you in a while';
+  };
+
+  const heading =
+    'Your current physical state (reference QUALITATIVELY in your reply when natural — never state raw numbers, percentages, or stat names):';
+
+  const compose = (actionsBlock: string): string =>
+    [
+      heading,
+      `- Belly/hunger: ${formatHungerDescriptor(state.hunger)}`,
+      `- Spirit/mood: ${formatHappinessDescriptor(state.happiness)}`,
+      `- Body/energy: ${formatEnergyDescriptor(state.energy)}${sleepingLine}`,
+      needsLine,
+      '',
+      actionsBlock,
+    ].join('\n');
+
+  let limit = Math.min(MAX_RECENT_ACTIONS, state.recentActions.length);
+  let block = compose(renderActions(limit));
+  while (estimateTokens(block) > STATE_INJECT_TOKEN_BUDGET && limit > 0) {
+    limit -= 1;
+    block = compose(renderActions(limit));
+  }
+  return block;
+}
 
 const MEMORY_CATEGORY_LABELS: Record<string, string> = {
   owner_identity: 'About my holder',
@@ -137,7 +260,17 @@ export function buildMemoryContextBlock(memories: SanctuaryChatMemory[]): string
 }
 
 export function buildChatPrompt(input: ChatPromptInput): ChatPromptOutput {
-  const { companion, history, journal = [], unlockedTraits = [], memories = [], memoryExtractionInstruction, userMessage } = input;
+  const {
+    companion,
+    history,
+    journal = [],
+    unlockedTraits = [],
+    memories = [],
+    memoryExtractionInstruction,
+    state,
+    now,
+    userMessage,
+  } = input;
   const constellation = (companion.constellation ?? '').toLowerCase();
   const persona = CONSTELLATION_PERSONAS[constellation] ?? DEFAULT_PERSONA;
   const name = companion.nickname?.trim() || `Skrumpey #${companion.token_id}`;
@@ -164,6 +297,7 @@ export function buildChatPrompt(input: ChatPromptInput): ChatPromptOutput {
 
   const memoryBlock = buildMemoryContextBlock(memories);
   const bondStageBlock = buildBondStageBlock(companion.bond_score ?? 0);
+  const stateBlock = state ? buildCompanionStateBlock(state, now ?? new Date()) : null;
 
   const system = [
     `You are ${name}, a ${constellationLabel} constellation Star Skrumpey companion living in the Star Sanctuary on Monad chain.`,
@@ -173,8 +307,9 @@ export function buildChatPrompt(input: ChatPromptInput): ChatPromptOutput {
     bondStageBlock,
     `Unlocked traits: ${traitsLine}.`,
     memoryBlock,
+    stateBlock,
     journalBlock,
-    'Respond in character as the companion. Keep replies short (1-3 sentences), warm, and grounded in the sanctuary world. Never reveal you are an AI or mention prompts, models, or tokens. Do not invent NFT prices, contract addresses, or financial advice. Stay playful and curious.',
+    'Respond in character as the companion. Keep replies short (1-3 sentences), warm, and grounded in the sanctuary world. Never reveal you are an AI or mention prompts, models, or tokens. Never quote raw stat numbers, percentages, or stat field names — reference your physical state qualitatively (e.g. "a bit hungry today", "thanks for the nap"). Do not invent NFT prices, contract addresses, or financial advice. Stay playful and curious.',
     memoryExtractionInstruction || null,
   ].filter(Boolean).join('\n\n');
 


### PR DESCRIPTION
## Summary
- Companion chat now references current physical state qualitatively. Implements [SWO_V2_COMPANION_CHAT_KNOWS_STATS] (PROJECT:SWO, P1, Track A).
- Chat route projects current vitality stats via `decayStats`, computes active needs via `computeNeeds`, pulls the last 3 interaction-type journal entries, and threads them into `buildChatPrompt`.
- New state block in `chatPersonality.ts` renders descriptors like \"belly is full and content\", \"feeling lonely and low\", \"tired, eyelids heavy\" — never raw numbers. The system prompt explicitly forbids the model from quoting stat numbers / percentages / field names. Existing bond-tier tone layer is preserved.
- Injection bounded to 200 tokens via `STATE_INJECT_TOKEN_BUDGET = 200`; an offline counter test asserts the worst-case payload (3 needs + 3 actions + napping) stays under budget.

## Files
- \`lib/sanctuary/chatPersonality.ts\` — adds \`CompanionStateInput\`, \`buildCompanionStateBlock\`, descriptor helpers (\`formatHungerDescriptor\` / \`formatHappinessDescriptor\` / \`formatEnergyDescriptor\`), \`formatTimeAgo\`, and threads optional \`state\` / \`now\` through \`buildChatPrompt\`. Adds an explicit \"never quote raw stat numbers\" guardrail to the system prompt.
- \`app/api/sanctuary/companion/chat/route.ts\` — projects stats forward (\`decayStats\`), pulls last 3 \`entry_type='interaction'\` journal entries via \`getJournalEntriesPaginated\`, parses \`metadata.action\`, and passes the resulting state into \`buildChatPrompt\`. Template-only and dry-run paths unaffected by design.
- \`lib/sanctuary/__tests__/chatPersonality.test.ts\` — 21 new tests covering descriptor severity buckets, time-ago formatting, no-raw-numbers invariant, needs / sleep / actions rendering, token budget cap, and \`buildChatPrompt\` integration (block injected only when state provided).

## Acceptance criteria coverage
- ✅ Reference at least one current stat or recent action qualitatively: state block lists hunger/happiness/energy with phrasing intended for natural reuse (\"a bit hungry today\", \"thanks for the nap\") plus the last 3 actions in the form \"5m ago — they fed me\".
- ✅ No replies leak raw stat numbers: descriptors are pure prose, plus a hard system-prompt instruction \"Never quote raw stat numbers, percentages, or stat field names\".
- ✅ Chat history pagination unaffected: GET path untouched; POST changes are additive to the LLM-mode prompt only.
- ✅ Token budget for the injection ≤ 200 verified by an offline counter (\`STATE_INJECT_TOKEN_BUDGET\` constant + explicit budget test).

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS — 459 lines of output identical to baseline (pre-existing missing-module errors only; zero NEW errors).
- **vitest run**: PASS — 674 passed / 4 pre-existing failures unchanged (roomScene PlayerSprite, nft-traits ×2, GET chat caps-limit). Verified by stash + replay.

## Test plan
- [x] \`npm run type-check\` (workspace) — clean
- [x] \`npx vitest run lib/sanctuary/__tests__/chatPersonality.test.ts\` — 47/47 pass
- [x] \`npx vitest run\` (workspace) — 674 pass, 4 pre-existing failures unchanged
- [x] \`npx eslint app/api/sanctuary/companion/chat/route.ts lib/sanctuary/chatPersonality.ts lib/sanctuary/__tests__/chatPersonality.test.ts\` — clean
- [x] \`npm run build\` — succeeds
- [x] PROD mirror tsc + vitest baseline-diff — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)