### PR TITLE
feat(sanctuary v1): formalize archival posture (banner + tracker notes)

### DIFF
--- a/app/sanctuary/SanctuaryContent.tsx
+++ b/app/sanctuary/SanctuaryContent.tsx
@@ -928,6 +928,27 @@ function CompanionPicker({
   );
 }
 
+function V1ArchiveBanner() {
+  return (
+    <div className="pixel-card p-4 mb-4 border-2 border-[#ffd700]/50 bg-gradient-to-r from-[#ffd700]/10 via-[#9966ff]/10 to-[#ffd700]/10">
+      <div className="flex flex-col sm:flex-row items-center justify-between gap-3">
+        <div className="text-center sm:text-left">
+          <p className="text-[#ffd700] text-[10px] tracking-wider mb-1">SANCTUARY HAS MOVED</p>
+          <p className="text-gray-400 text-[8px]">
+            This is the legacy V1 surface (kept for deep links). Open the new Sanctuary for the latest experience.
+          </p>
+        </div>
+        <a
+          href="?v=2"
+          className="flex-shrink-0 px-4 py-2 rounded-lg bg-[#ffd700]/20 border border-[#ffd700]/60 text-[#ffd700] text-[9px] tracking-wider hover:bg-[#ffd700]/30 hover:border-[#ffd700] transition-all"
+        >
+          OPEN NEW SANCTUARY →
+        </a>
+      </div>
+    </div>
+  );
+}
+
 function StarBadge() {
   return (
     <div className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-[#ffd700]/15 border border-[#ffd700]/40">
@@ -1106,6 +1127,7 @@ function HolderSanctuary() {
 
   return (
     <div className="space-y-6">
+      <V1ArchiveBanner />
       <div className="text-center mb-6">
         <h1
           className="text-lg text-[#ffd700] tracking-widest mb-1"
@@ -1208,6 +1230,7 @@ export default function SanctuaryContent() {
   if (!gated) {
     return (
       <div className="space-y-6">
+        <V1ArchiveBanner />
         <div className="text-center mb-6">
           <h1
             className="text-lg text-[#ffd700] tracking-widest mb-1"

--- a/docs/SANCTUARY_V3_DEFERRED.md
+++ b/docs/SANCTUARY_V3_DEFERRED.md
@@ -11,6 +11,7 @@ This file is a snapshot of what V3 contains so we don't lose track.
 - **Reachable:** Yes — `?v=3` still routes to `SanctuaryV3` via `app/sanctuary/SanctuaryRouter.tsx`.
 - **Promoted:** No — not linked from the main UI; only direct-URL access.
 - **Iteration:** Paused. No new commits to `game/v3/`, `public/sanctuary-v3/`, or `scripts/v3/` without an explicit decision to revive V3.
+- **V1:** Fallback-only as of 2026-04-27. The legacy V1 surface still renders when no `?v=` param is set, kept for deep-link compatibility; it now displays an in-page banner directing players to `?v=2`. No new feature work on V1.
 
 ---
 

--- a/memory/evolution/SWO_TRACKER.md
+++ b/memory/evolution/SWO_TRACKER.md
@@ -1,0 +1,9 @@
+# SWO Tracker
+
+High-level state of major Sanctuary surfaces.
+
+## Sanctuary surfaces
+
+- **V2 (Companion + World hub)** — primary, default landing. Companion view at `/sanctuary?v=2` (default when V2 flag is on or `?v=2` is set); world hub at `/sanctuary?v=2&world=1`.
+- **V3 (FM-tilemap pixel rebuild)** — paused. Reachable at `/sanctuary?v=3` for in-progress demo only. See `swo_sanctuary_v3_deferred_2026-04-26.md`.
+- **V1 (legacy painted hub) — fallback only as of 2026-04-27.** Still rendered when no `?v=` param is present and the V2 flag is off. Kept for deep-link compatibility; in-page banner directs users to `?v=2`. No new feature work; do not remove without a deep-link audit.

--- a/memory/evolution/swo_sanctuary_v3_deferred_2026-04-26.md
+++ b/memory/evolution/swo_sanctuary_v3_deferred_2026-04-26.md
@@ -1,0 +1,9 @@
+# Sanctuary V3 — deferred (2026-04-26)
+
+Mirror of `docs/SANCTUARY_V3_DEFERRED.md` for the evolution-memory log. See that file for the full snapshot.
+
+## Status (2026-04-26)
+
+- **V2** is primary. Companion view is the default `?v=2` landing; `?v=2&world=1` reaches the painted hub.
+- **V3** (FM tilemap rebuild) is paused at `?v=3`. No new commits to `game/v3/`, `public/sanctuary-v3/`, or `scripts/v3/` without an explicit revival decision.
+- **V1 is fallback-only as of 2026-04-27.** Still served at `/sanctuary` (no `?v=` param, V2 flag off) so deep links keep working, but the V1 surface now displays a banner directing players to `?v=2`. No new feature work on V1.


### PR DESCRIPTION
## Summary
- Adds a "Sanctuary has moved — open the new Sanctuary" banner inside the V1 surface (`SanctuaryContent.tsx`) with a CTA linking to `?v=2`. Banner shows on both gated (holder) and ungated (public) V1 paths.
- Keeps all V1 code intact so existing deep links still work.
- Documents V1's fallback-only posture in `docs/SANCTUARY_V3_DEFERRED.md` and adds new `memory/evolution/SWO_TRACKER.md` + `memory/evolution/swo_sanctuary_v3_deferred_2026-04-26.md` evolution-log notes.

## Acceptance criteria
- [x] Banner ships in V1 surface
- [x] CTA `?v=2` link works (routes through `SanctuaryRouter` → `CompanionView`/`SanctuaryV2`)
- [x] Tracker note added (`memory/evolution/SWO_TRACKER.md`)
- [x] V3-deferred doc updated (`memory/evolution/swo_sanctuary_v3_deferred_2026-04-26.md` + `docs/SANCTUARY_V3_DEFERRED.md`)
- [x] No V1 code removed

## Test plan
- [x] `npm run type-check` — clean (0 errors)
- [x] `npx vitest run` — 674 passed, 4 pre-existing failures unchanged
- [x] `npx eslint app/sanctuary/SanctuaryContent.tsx` — only pre-existing warnings/errors; banner code adds no new lint issues

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS — 459 errors before & after overlay (no new errors from this change)
- **vitest run**: PASS — 653 passed, 4 pre-existing failures unchanged
- Overall: **PASS**

🤖 Generated with [Claude Code](https://claude.com/claude-code)