### PR TITLE
fix(sanctuary v2): shrink NPC display size 60 → 48px [SWO_V2_NPC_DISPLAY_SIZE]

### DIFF
--- a/game/sprites/NPCSprite.ts
+++ b/game/sprites/NPCSprite.ts
@@ -7,9 +7,15 @@ const IDLE_BOB_AMPLITUDE = 1.5;
 const INDICATOR_BOB_SPEED = 0.004;
 const INDICATOR_BOB_AMPLITUDE = 3;
 
-const NPC_DISPLAY_HEIGHT = 60;
-const PLACEHOLDER_SCALE = 1.5;
+// Target on-screen NPC height in pixels. The painted player sprite renders
+// ~62 px tall, so 48 keeps NPCs noticeably smaller than the player instead of
+// dwarfing them.
+const NPC_DISPLAY_HEIGHT = 48;
+const PLACEHOLDER_SCALE = 1.2;
 const ALPHA_THRESHOLD = 16;
+// Minimum click hit-region in px. At a 48 px sprite the natural displayWidth
+// drops to roughly 32–40, so the floor keeps small NPCs comfortably clickable.
+const MIN_HIT_SIZE = 28;
 
 function npcFrame0TextureKey(id: string): string {
   return `npc-frame0-${id}`;
@@ -87,8 +93,8 @@ export class NPCSprite extends Phaser.GameObjects.Container {
     this.indicator.setVisible(false);
     this.add(this.indicator);
 
-    const hitW = Math.max(24, this.sprite.displayWidth);
-    const hitH = Math.max(24, this.sprite.displayHeight);
+    const hitW = Math.max(MIN_HIT_SIZE, this.sprite.displayWidth);
+    const hitH = Math.max(MIN_HIT_SIZE, this.sprite.displayHeight);
     this.setSize(hitW, hitH);
     this.setInteractive({ useHandCursor: true });
 


### PR DESCRIPTION
## Summary
Reduces the NPC on-screen height from 60 px to 48 px in `game/sprites/NPCSprite.ts` so quest NPCs no longer read as the same size (or larger) as the player. The player sprite renders ~62 px tall (240 px frame × 0.26 scale), so a 60 px NPC was visually peer-sized; 48 px keeps NPCs clearly smaller without losing readability.

- `NPC_DISPLAY_HEIGHT`: 60 → 48
- `PLACEHOLDER_SCALE`: 1.5 → 1.2 to keep the colored fallback in line with the new real-sprite height when a frame-0 crop is missing
- New `MIN_HIT_SIZE = 28` constant (was a hard-coded `24`) so click targets and pointer hit regions stay comfortable at the smaller render size
- Nameplate offset (`-halfH - 2`), quest indicator base, and ground shadow are all derived from `displayHeight`/`displayWidth`, so they reflow automatically

## Acceptance
- [x] Display constant changed (`NPC_DISPLAY_HEIGHT` 60 → 48)
- [x] Hit area / spacing constants updated (`MIN_HIT_SIZE = 28`, `PLACEHOLDER_SCALE` rebalanced)
- [ ] Screenshot diff — not feasible from this headless agent environment (no browser/Phaser canvas); the change is mechanical (one display-height constant + derived offsets), and visual review is best done locally with `npm run dev`. Manual verification suggested below.

## Test plan
- [x] `npm run type-check` — clean (0 errors)
- [x] `npx eslint game/sprites/NPCSprite.ts` — clean
- [x] `npx vitest run` — 674 passed, 4 pre-existing failures unchanged (api-e2e, see prior runs)
- [ ] Manual smoke test in browser:
  - Load `/sanctuary` (V2), confirm Spawn Fox + 8 room NPCs render visibly smaller than the player
  - Click each NPC and verify dialogue overlay still triggers (hit-region floor 28 px)
  - Confirm name tags + quest `!` indicators sit just above each NPC head with no clipping
  - Walk past NPCs and verify ground shadows still anchor to feet

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS — 459 errors before & 459 after (all pre-existing in PROD: missing `colyseus.js`, `howler` modules, V3 typing gaps; none from this diff)
- **vitest run**: PASS — 4 failed / 674 passed both before & after (api-e2e companion-chat assertions, pre-existing)
Overall: PASS (no new errors introduced; mirror restored byte-identical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)