### PR TITLE
feat(sanctuary v2.7): cozy/tamagotchi polish on the Companion screen [SWO_V2_COMPANION_COZY_POLISH]

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -591,6 +591,42 @@ body::before {
 }
 
 /* ============================================
+   Companion-screen cozy polish
+   (SWO_V2_COMPANION_COZY_POLISH)
+   ============================================ */
+
+/* Soft starfield behind the companion sprite. Each .cozy-star is a 2px dot
+   that twinkles independently — staggered animation-delays make the cluster
+   feel organic without using JS or extra DOM cycles. */
+.companion-cozy-stars .cozy-star {
+  position: absolute;
+  width: 2px;
+  height: 2px;
+  border-radius: 50%;
+  background: #ffd7ff;
+  box-shadow: 0 0 4px rgba(255, 215, 255, 0.6);
+  animation: sanctuaryStarTwinkle 3.4s ease-in-out infinite;
+  opacity: 0.4;
+}
+.companion-cozy-stars .cozy-star:nth-child(2) { animation-delay: 0.6s; background: #b088ff; box-shadow: 0 0 4px rgba(176, 136, 255, 0.6); }
+.companion-cozy-stars .cozy-star:nth-child(3) { animation-delay: 1.2s; background: #88e0ff; box-shadow: 0 0 4px rgba(136, 224, 255, 0.6); }
+.companion-cozy-stars .cozy-star:nth-child(4) { animation-delay: 1.8s; }
+.companion-cozy-stars .cozy-star:nth-child(5) { animation-delay: 2.4s; background: #ffe0a0; box-shadow: 0 0 4px rgba(255, 224, 160, 0.6); }
+
+/* Brief glow pulse on a stat-bar track when its underlying value just
+   changed. Uses the per-bar accent via a CSS variable so the pulse always
+   matches the bar color (orange/pink/cyan). Lives on the bar track, not the
+   fill, so it doesn't fight the fill's width transition. */
+@keyframes companionStatBarPulse {
+  0%   { box-shadow: 0 0 0 0 var(--bar-pulse-color, #ffd700); }
+  35%  { box-shadow: 0 0 8px 2px var(--bar-pulse-color, #ffd700); }
+  100% { box-shadow: 0 0 0 0 var(--bar-pulse-color, #ffd700); }
+}
+.companion-stat-bar-pulse {
+  animation: companionStatBarPulse 0.9s ease-out;
+}
+
+/* ============================================
    Cozy Gaming Station Loading Experience
    ============================================ */
 

--- a/app/sanctuary/CompanionView.tsx
+++ b/app/sanctuary/CompanionView.tsx
@@ -6,6 +6,11 @@ import dynamic from 'next/dynamic';
 import { getWalletAuthHeader } from '@/lib/clientWalletAuth';
 import { resolveCompanionMood, type MoodStatInput } from '@/lib/sanctuary/mood';
 import { describeNeeds, lowStats, type NeedStats } from '@/lib/sanctuary/needs';
+import {
+  greetingForMood,
+  lastVisitedPhrase,
+  type CozyMood,
+} from '@/lib/sanctuary/companionGreeting';
 import { MOOD_EMOJI } from '@/components/sanctuary/overlays/CompanionHUD';
 
 const SanctuaryContent = dynamic(() => import('./SanctuaryContent'), { ssr: false });
@@ -23,11 +28,31 @@ interface CompanionData {
   happiness: number | null;
   energy: number | null;
   is_sleeping: number | null;
+  stats_updated_at: string | null;
   image_url: string | null;
   constellation: string | null;
   current_activity: string;
   activity_ends_at: string | null;
 }
+
+interface SpriteReaction {
+  id: number;
+  kind: QuickAction;
+}
+
+interface StatDelta {
+  id: number;
+  stat: 'hunger' | 'happiness' | 'energy';
+  delta: number;
+}
+
+const ACTION_REACTION_EMOJI: Record<QuickAction, string[]> = {
+  feed: ['🍎', '✨'],
+  pet: ['💗', '💗', '✨'],
+  talk: ['💬', '💕'],
+  sleep: ['💤', '🌙'],
+  play: ['⭐', '✨', '💫'],
+};
 
 interface JournalEntry {
   id: number;
@@ -74,14 +99,18 @@ function StatBar({
   label,
   value,
   color,
+  pulse,
+  delta,
 }: {
   label: string;
   value: number;
   color: string;
+  pulse?: boolean;
+  delta?: number;
 }) {
   const pct = Math.max(0, Math.min(100, value));
   return (
-    <div className="space-y-1">
+    <div className="space-y-1 relative">
       <div className="flex items-center justify-between text-[8px]">
         <span className="text-gray-400 uppercase tracking-wider font-['Press_Start_2P']">
           {label}
@@ -90,12 +119,25 @@ function StatBar({
           {Math.round(value)}
         </span>
       </div>
-      <div className="h-2 bg-[#1a1a2e] rounded-full overflow-hidden border border-[#2a2a4e]">
+      <div
+        className={`h-2 bg-[#1a1a2e] rounded-full overflow-hidden border border-[#2a2a4e] ${
+          pulse ? 'companion-stat-bar-pulse' : ''
+        }`}
+        style={pulse ? ({ '--bar-pulse-color': color } as React.CSSProperties) : undefined}
+      >
         <div
           className="h-full rounded-full transition-all duration-500"
           style={{ width: `${pct}%`, backgroundColor: color }}
         />
       </div>
+      {typeof delta === 'number' && delta !== 0 && (
+        <span
+          className="companion-floating-text absolute right-0 -top-1 text-[8px] font-['Press_Start_2P'] pointer-events-none tabular-nums"
+          style={{ color, textShadow: `0 0 6px ${color}` }}
+        >
+          {delta > 0 ? `+${delta}` : `${delta}`}
+        </span>
+      )}
     </div>
   );
 }
@@ -121,7 +163,14 @@ export default function CompanionView() {
   const [chatLines, setChatLines] = useState<ChatLine[]>([]);
   const [chatDraft, setChatDraft] = useState('');
   const [chatBusy, setChatBusy] = useState(false);
+  const [spriteReactions, setSpriteReactions] = useState<SpriteReaction[]>([]);
+  const [statDeltas, setStatDeltas] = useState<StatDelta[]>([]);
+  const [recentlyChanged, setRecentlyChanged] = useState<
+    Set<'hunger' | 'happiness' | 'energy'>
+  >(() => new Set());
   const feedbackTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const reactionIdRef = useRef(0);
+  const deltaIdRef = useRef(0);
 
   const fetchCompanion = useCallback(async () => {
     if (!address) return;
@@ -146,6 +195,7 @@ export default function CompanionView() {
                 happiness: data.companion.happiness ?? null,
                 energy: data.companion.energy ?? null,
                 is_sleeping: data.companion.is_sleeping ?? null,
+                stats_updated_at: data.companion.stats_updated_at ?? null,
                 image_url: data.companion.image_url ?? null,
                 constellation: data.companion.constellation ?? null,
                 current_activity: data.companion.current_activity ?? 'lounging',
@@ -199,9 +249,48 @@ export default function CompanionView() {
     feedbackTimer.current = setTimeout(() => setFeedback(null), 1800);
   }, []);
 
+  const triggerSpriteReaction = useCallback((kind: QuickAction) => {
+    const id = ++reactionIdRef.current;
+    setSpriteReactions((prev) => [...prev, { id, kind }]);
+    setTimeout(() => {
+      setSpriteReactions((prev) => prev.filter((r) => r.id !== id));
+    }, 1100);
+  }, []);
+
+  const pushStatDelta = useCallback(
+    (stat: 'hunger' | 'happiness' | 'energy', delta: number) => {
+      if (delta === 0) return;
+      const id = ++deltaIdRef.current;
+      setStatDeltas((prev) => [...prev, { id, stat, delta }]);
+      setRecentlyChanged((prev) => {
+        const next = new Set(prev);
+        next.add(stat);
+        return next;
+      });
+      setTimeout(() => {
+        setStatDeltas((prev) => prev.filter((d) => d.id !== id));
+        setRecentlyChanged((prev) => {
+          if (!prev.has(stat)) return prev;
+          const next = new Set(prev);
+          next.delete(stat);
+          return next;
+        });
+      }, 1000);
+    },
+    [],
+  );
+
   const handleAction = useCallback(
     async (action: QuickAction) => {
       if (!address || !companion || interacting) return;
+      // Pre-emptively block sleep-action attempts with a warm message rather
+      // than firing a request that the API will reject with HTTP 409. The
+      // server still enforces this — this is just kinder UX.
+      if (companion.is_sleeping === 1 && action !== 'sleep') {
+        const name = companion.nickname || `Skrumpey #${companion.token_id}`;
+        flashFeedback(`shhh — ${name} is sleeping`);
+        return;
+      }
       setInteracting(action);
       try {
         const authHeader = await getWalletAuthHeader(address);
@@ -223,20 +312,44 @@ export default function CompanionView() {
         });
         const data = await res.json();
         if (data.success && data.companion) {
+          const prevSnapshot = {
+            hunger: companion.hunger,
+            happiness: companion.happiness,
+            energy: companion.energy,
+          };
+          const next = {
+            hunger: data.companion.hunger ?? companion.hunger,
+            happiness: data.companion.happiness ?? companion.happiness,
+            energy: data.companion.energy ?? companion.energy,
+          };
           setCompanion((prev) =>
             prev
               ? {
                   ...prev,
-                  hunger: data.companion.hunger ?? prev.hunger,
-                  happiness: data.companion.happiness ?? prev.happiness,
-                  energy: data.companion.energy ?? prev.energy,
+                  hunger: next.hunger,
+                  happiness: next.happiness,
+                  energy: next.energy,
                   is_sleeping:
                     data.companion.is_sleeping ?? prev.is_sleeping,
                   bond_score: data.companion.bond_score ?? prev.bond_score,
                   mood: data.companion.mood ?? prev.mood,
+                  stats_updated_at:
+                    data.companion.stats_updated_at ?? prev.stats_updated_at,
                 }
               : prev,
           );
+          // Floating "+N" near each stat bar that moved (uses the projected
+          // post-decay delta from server-side, so tiny rounding deltas don't
+          // create noisy +1s).
+          for (const k of ['hunger', 'happiness', 'energy'] as const) {
+            const a = prevSnapshot[k];
+            const b = next[k];
+            if (typeof a === 'number' && typeof b === 'number') {
+              const d = Math.round(b - a);
+              if (Math.abs(d) >= 2) pushStatDelta(k, d);
+            }
+          }
+          triggerSpriteReaction(action);
           flashFeedback(`${action.toUpperCase()} ✓`);
           // Refresh journal so the latest entry from the action shows up
           fetchJournal(companion.token_id);
@@ -249,7 +362,7 @@ export default function CompanionView() {
         setInteracting(null);
       }
     },
-    [address, companion, interacting, flashFeedback, fetchJournal],
+    [address, companion, interacting, flashFeedback, fetchJournal, triggerSpriteReaction, pushStatDelta],
   );
 
   const handleSendChat = useCallback(async () => {
@@ -348,51 +461,120 @@ export default function CompanionView() {
   const displayName =
     companion.nickname || `Skrumpey #${companion.token_id}`;
 
+  const greeting = greetingForMood(
+    displayName,
+    effectiveMood as CozyMood,
+    isSleeping,
+  );
+  const lastVisit = lastVisitedPhrase(companion.stats_updated_at);
+
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="text-center">
+      <div className="text-center space-y-1">
         <h1
-          className="text-lg text-[#ffd700] tracking-widest mb-1 font-['Press_Start_2P']"
+          className="text-lg text-[#ffd700] tracking-widest font-['Press_Start_2P']"
           style={{ textShadow: '0 0 20px rgba(255, 215, 0, 0.3)' }}
         >
           {displayName.toUpperCase()}
         </h1>
+        <p className="text-[#bb88ff] text-[10px] italic px-4 leading-snug">
+          {greeting}
+        </p>
         <p className="text-gray-400 text-[10px]">
           Lv.{companion.level} · Training {companion.companion_level} · Bond{' '}
           {Math.round(companion.bond_score)}
         </p>
+        {lastVisit && (
+          <p className="text-gray-500 text-[8px]">
+            {lastVisit}
+          </p>
+        )}
       </div>
 
       <div className="grid md:grid-cols-2 gap-6">
         {/* Sprite + needs */}
         <div className="pixel-card p-6 space-y-4">
           <div className="flex justify-center">
-            <div
-              className={`relative ${moodAnimClass}`}
-              data-testid="companion-sprite"
-            >
-              <div className="w-48 h-48 sm:w-56 sm:h-56 rounded-2xl overflow-hidden border-4 border-[#2a2a4e] bg-[#0a0a15] shadow-[0_0_24px_rgba(0,247,255,0.18)]">
-                {companion.image_url ? (
-                  // eslint-disable-next-line @next/next/no-img-element
-                  <img
-                    src={companion.image_url}
-                    alt={displayName}
-                    className="w-full h-full object-cover image-rendering-pixelated"
-                  />
-                ) : (
-                  <div className="w-full h-full flex items-center justify-center text-7xl">
-                    🐸
+            <div className="relative">
+              {/* Cozy ambient: a few twinkling stars behind the sprite. Pure
+                  decoration; pointer-events disabled so it never intercepts
+                  clicks on the sprite or the mood badge. */}
+              <div
+                className="absolute inset-0 pointer-events-none companion-cozy-stars"
+                aria-hidden="true"
+              >
+                <span className="cozy-star" style={{ left: '12%', top: '18%' }} />
+                <span className="cozy-star" style={{ left: '78%', top: '14%' }} />
+                <span className="cozy-star" style={{ left: '22%', top: '82%' }} />
+                <span className="cozy-star" style={{ left: '88%', top: '70%' }} />
+                <span className="cozy-star" style={{ left: '50%', top: '4%' }} />
+              </div>
+
+              <div
+                className={`relative ${moodAnimClass}`}
+                data-testid="companion-sprite"
+              >
+                <div className="w-48 h-48 sm:w-56 sm:h-56 rounded-2xl overflow-hidden border-4 border-[#2a2a4e] bg-[#0a0a15] shadow-[0_0_24px_rgba(0,247,255,0.18)]">
+                  {companion.image_url ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={companion.image_url}
+                      alt={displayName}
+                      className="w-full h-full object-cover image-rendering-pixelated"
+                    />
+                  ) : (
+                    <div className="w-full h-full flex items-center justify-center text-7xl">
+                      🐸
+                    </div>
+                  )}
+                </div>
+                <span
+                  className="absolute -top-2 -right-2 bg-black/90 border border-[#9966ff]/60 rounded-full px-2 py-1 text-lg shadow-[0_0_10px_rgba(153,102,255,0.4)]"
+                  aria-label={`Mood: ${moodLabel}`}
+                  title={`Mood: ${moodLabel}`}
+                >
+                  {moodEmoji}
+                </span>
+
+                {/* Floating reaction emojis layered above the sprite. Each
+                    reaction is short-lived (≤1.1s) and absolutely positioned
+                    so it never relayouts the card. Multiple emoji per
+                    reaction gives a small flourish per action. */}
+                {spriteReactions.length > 0 && (
+                  <div
+                    className="absolute inset-0 pointer-events-none flex items-center justify-center"
+                    aria-hidden="true"
+                  >
+                    {spriteReactions.map((r) => {
+                      const glyphs = ACTION_REACTION_EMOJI[r.kind];
+                      return (
+                        <div key={r.id} className="absolute inset-0">
+                          {glyphs.map((g, i) => {
+                            const angle = (i / glyphs.length) * Math.PI * 2;
+                            const radius = 36;
+                            const dx = Math.cos(angle) * radius;
+                            const dy = Math.sin(angle) * radius - 12;
+                            return (
+                              <span
+                                key={i}
+                                className="absolute text-2xl companion-floating-text"
+                                style={{
+                                  left: `calc(50% + ${dx}px)`,
+                                  top: `calc(50% + ${dy}px)`,
+                                  animationDelay: `${i * 60}ms`,
+                                }}
+                              >
+                                {g}
+                              </span>
+                            );
+                          })}
+                        </div>
+                      );
+                    })}
                   </div>
                 )}
               </div>
-              <span
-                className="absolute -top-2 -right-2 bg-black/90 border border-[#9966ff]/60 rounded-full px-2 py-1 text-lg shadow-[0_0_10px_rgba(153,102,255,0.4)]"
-                aria-label={`Mood: ${moodLabel}`}
-                title={`Mood: ${moodLabel}`}
-              >
-                {moodEmoji}
-              </span>
             </div>
           </div>
 
@@ -417,18 +599,33 @@ export default function CompanionView() {
               label="Hunger"
               value={companion.hunger ?? 0}
               color="#ff9944"
+              pulse={recentlyChanged.has('hunger')}
+              delta={statDeltas.find((d) => d.stat === 'hunger')?.delta}
             />
             <StatBar
               label="Happiness"
               value={companion.happiness ?? 0}
               color="#ff66aa"
+              pulse={recentlyChanged.has('happiness')}
+              delta={statDeltas.find((d) => d.stat === 'happiness')?.delta}
             />
             <StatBar
               label="Energy"
               value={companion.energy ?? 0}
               color="#66ccff"
+              pulse={recentlyChanged.has('energy')}
+              delta={statDeltas.find((d) => d.stat === 'energy')?.delta}
             />
           </div>
+
+          {isSleeping && (
+            <p
+              className="text-center text-[8px] text-[#66ccff] font-['Press_Start_2P'] tracking-wider"
+              role="status"
+            >
+              💤 Shhh — they&apos;re dreaming.
+            </p>
+          )}
         </div>
 
         {/* Actions + Journal */}
@@ -438,29 +635,35 @@ export default function CompanionView() {
               QUICK ACTIONS
             </h2>
             <div className="grid grid-cols-3 gap-2">
-              {ACTIONS.map((a) => (
-                <button
-                  key={a.id}
-                  onClick={() => handleAction(a.id)}
-                  disabled={interacting !== null}
-                  aria-label={a.label}
-                  className={`flex flex-col items-center justify-center gap-1 py-3 rounded-lg border-2 transition-all
-                    ${
-                      interacting === a.id
-                        ? 'border-[#ffd700] bg-[#ffd700]/10 shadow-[0_0_10px_rgba(255,215,0,0.3)]'
-                        : 'border-[#2a2a4e] bg-[#0a0a15] hover:border-[#9966ff]/60 hover:bg-[#1a0f3a]/40'
-                    }
-                    disabled:opacity-50 disabled:cursor-not-allowed
-                  `}
-                >
-                  <span className="text-xl leading-none">
-                    {interacting === a.id ? '⏳' : a.icon}
-                  </span>
-                  <span className="text-[7px] text-gray-300 font-['Press_Start_2P']">
-                    {a.label}
-                  </span>
-                </button>
-              ))}
+              {ACTIONS.map((a) => {
+                const muted = isSleeping && a.id !== 'sleep';
+                return (
+                  <button
+                    key={a.id}
+                    onClick={() => handleAction(a.id)}
+                    disabled={interacting !== null}
+                    aria-label={muted ? `${a.label} (sleeping)` : a.label}
+                    title={muted ? 'Companion is sleeping — wait until they wake' : a.label}
+                    className={`flex flex-col items-center justify-center gap-1 py-3 rounded-lg border-2 transition-all
+                      ${
+                        interacting === a.id
+                          ? 'border-[#ffd700] bg-[#ffd700]/10 shadow-[0_0_10px_rgba(255,215,0,0.3)]'
+                          : muted
+                            ? 'border-[#2a2a4e]/40 bg-[#0a0a15]/40 opacity-50'
+                            : 'border-[#2a2a4e] bg-[#0a0a15] hover:border-[#9966ff]/60 hover:bg-[#1a0f3a]/40'
+                      }
+                      disabled:opacity-50 disabled:cursor-not-allowed
+                    `}
+                  >
+                    <span className="text-xl leading-none">
+                      {interacting === a.id ? '⏳' : a.icon}
+                    </span>
+                    <span className="text-[7px] text-gray-300 font-['Press_Start_2P']">
+                      {a.label}
+                    </span>
+                  </button>
+                );
+              })}
             </div>
             {feedback && (
               <p

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -22,6 +22,7 @@ import {
   type CompanionStatAction,
 } from './sanctuary/companionStats';
 import { decayStats, computeNeeds, type DecayedStats } from './sanctuary/decay';
+import { journalLineForAction } from './sanctuary/companionGreeting';
 
 // Database path - stored in the repo's data directory
 const DB_PATH = process.env.DATABASE_URL?.replace('file:', '') || 
@@ -6112,13 +6113,9 @@ export function interactWithCompanion(
   const db = getDatabase();
   const addr = walletAddress.toLowerCase();
 
-  const messages: Record<CompanionStatAction, string> = {
-    feed: 'Enjoyed a tasty cosmic treat. Bond strengthened!',
-    pet: 'Received gentle pats. Feeling cozy and loved.',
-    talk: 'Had a heartfelt conversation with their owner.',
-    play: 'Burned off some cosmic zoomies. Feels alive!',
-    sleep: 'Curled up for a cosmic nap. Energy slowly returning.',
-  };
+  // Variety pool now lives in companionGreeting.journalLineForAction —
+  // deterministic given (action, mood, hour-of-day bucket) so consecutive
+  // interactions don't repeat the same flat phrase.
 
   const txn = db.transaction(() => {
     const comp = db.prepare(
@@ -6192,7 +6189,11 @@ export function interactWithCompanion(
     if (xpGain > 0) addUserXP(addr, xpGain);
 
     const bonusTag = starBonus ? ' (Star Bonus!)' : '';
-    const journal = addJournalEntry(addr, tokenId, 'interaction', messages[action] + bonusTag,
+    // Seed the variety pool with the action itself — the live trait-mood is
+    // not on SanctuaryCompanion (it comes from the meta view), but rotating
+    // by (action × hour-of-day-bucket) is enough variety for the journal.
+    const message = journalLineForAction(action, action, now.getHours());
+    const journal = addJournalEntry(addr, tokenId, 'interaction', message + bonusTag,
       JSON.stringify({
         action, bond: bondGain, xp: xpGain, starBonus,
         hunger: stats.hunger, happiness: stats.happiness, energy: stats.energy,

--- a/lib/sanctuary/__tests__/companionGreeting.test.ts
+++ b/lib/sanctuary/__tests__/companionGreeting.test.ts
@@ -1,0 +1,180 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+
+import {
+  greetingForMood,
+  journalLineForAction,
+  lastVisitedPhrase,
+  type CozyAction,
+  type CozyMood,
+} from '../companionGreeting';
+
+describe('greetingForMood', () => {
+  it('substitutes the companion name into the line', () => {
+    const out = greetingForMood('Pico', 'happy', false, 0);
+    expect(out).toContain('Pico');
+    expect(out).not.toContain('{name}');
+  });
+
+  it('returns a sleeping line when isSleeping=true regardless of mood', () => {
+    const out = greetingForMood('Pico', 'happy', true, 0);
+    expect(out.toLowerCase()).toMatch(/dream|asleep|snore/);
+  });
+
+  it('falls back to idle pool when mood is unknown', () => {
+    const out = greetingForMood('Pico', 'unknown-mood', false, 0);
+    expect(out).toBe(greetingForMood('Pico', 'idle', false, 0));
+  });
+
+  it('falls back to idle pool when mood is null', () => {
+    const out = greetingForMood('Pico', null, false, 0);
+    expect(out).toBe(greetingForMood('Pico', 'idle', false, 0));
+  });
+
+  it('is deterministic given the same inputs', () => {
+    expect(greetingForMood('Pico', 'happy', false, 0)).toBe(
+      greetingForMood('Pico', 'happy', false, 0),
+    );
+  });
+
+  it('cycles across days for the same companion+mood', () => {
+    const seen = new Set<string>();
+    for (let day = 0; day < 30; day++) {
+      seen.add(greetingForMood('Pico', 'happy', false, day));
+    }
+    expect(seen.size).toBeGreaterThan(1);
+  });
+
+  it('covers every CozyMood without throwing or returning empty', () => {
+    const moods: CozyMood[] = [
+      'happy', 'excited', 'calm', 'sleepy', 'curious',
+      'sleeping', 'hungry', 'lonely', 'idle',
+    ];
+    for (const mood of moods) {
+      const out = greetingForMood('Pico', mood, false, 0);
+      expect(out.length).toBeGreaterThan(0);
+      expect(out).toContain('Pico');
+    }
+  });
+});
+
+describe('lastVisitedPhrase', () => {
+  const now = new Date('2026-05-01T12:00:00Z');
+
+  it('returns null for missing input', () => {
+    expect(lastVisitedPhrase(null, now)).toBeNull();
+    expect(lastVisitedPhrase(undefined, now)).toBeNull();
+    expect(lastVisitedPhrase('', now)).toBeNull();
+  });
+
+  it('returns null for unparseable input', () => {
+    expect(lastVisitedPhrase('not a date', now)).toBeNull();
+  });
+
+  it('returns null for clock-skew (future timestamps)', () => {
+    expect(
+      lastVisitedPhrase('2026-05-01 12:05:00', now),
+    ).toBeNull();
+  });
+
+  it('returns null for very recent activity (<1 min) — action feedback covers it', () => {
+    expect(
+      lastVisitedPhrase('2026-05-01 11:59:30', now),
+    ).toBeNull();
+  });
+
+  it('reads the SQLite YYYY-MM-DD HH:MM:SS form as UTC', () => {
+    // 2 minutes ago in UTC.
+    const phrase = lastVisitedPhrase('2026-05-01 11:58:00', now);
+    expect(phrase).toBe('You just popped in.');
+  });
+
+  it('reads ISO-8601 timestamps too', () => {
+    const phrase = lastVisitedPhrase('2026-05-01T11:00:00.000Z', now);
+    expect(phrase).toBe('1 hour since you visited.');
+  });
+
+  it('uses minutes phrasing under an hour', () => {
+    const phrase = lastVisitedPhrase('2026-05-01 11:30:00', now);
+    expect(phrase).toBe('30 minutes since you said hi.');
+  });
+
+  it('uses singular hour at the boundary', () => {
+    const phrase = lastVisitedPhrase('2026-05-01 11:00:00', now);
+    expect(phrase).toBe('1 hour since you visited.');
+  });
+
+  it('uses plural hours past the boundary', () => {
+    const phrase = lastVisitedPhrase('2026-05-01 09:00:00', now);
+    expect(phrase).toBe('3 hours since you visited.');
+  });
+
+  it('uses "almost a day" between 24h and 48h', () => {
+    const phrase = lastVisitedPhrase('2026-04-30 09:00:00', now);
+    expect(phrase).toMatch(/almost a day/i);
+  });
+
+  it('uses "{N} days — they missed you" between 2 and 7 days', () => {
+    const phrase = lastVisitedPhrase('2026-04-28 09:00:00', now);
+    expect(phrase).toMatch(/3 days/);
+    expect(phrase).toMatch(/missed you/i);
+  });
+
+  it('uses the welcome-back phrasing past 7 days', () => {
+    const phrase = lastVisitedPhrase('2026-04-20 09:00:00', now);
+    expect(phrase).toMatch(/while/i);
+    expect(phrase).toMatch(/came back/i);
+  });
+
+  it('never scolds — none of the phrases use guilt-trip language', () => {
+    const samples = [
+      lastVisitedPhrase('2026-04-30 09:00:00', now),
+      lastVisitedPhrase('2026-04-28 09:00:00', now),
+      lastVisitedPhrase('2026-04-20 09:00:00', now),
+    ];
+    for (const s of samples) {
+      expect(s).not.toMatch(/abandon|forgot|neglect|left/i);
+    }
+  });
+});
+
+describe('journalLineForAction', () => {
+  it('returns a non-empty string for every supported action', () => {
+    const actions: CozyAction[] = ['feed', 'pet', 'talk', 'play', 'sleep'];
+    for (const action of actions) {
+      const line = journalLineForAction(action, '', 12);
+      expect(line.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('is deterministic given the same inputs', () => {
+    expect(journalLineForAction('feed', 'happy', 12)).toBe(
+      journalLineForAction('feed', 'happy', 12),
+    );
+  });
+
+  it('rotates lines across the 6 hour-of-day buckets', () => {
+    const seen = new Set<string>();
+    for (let h = 0; h < 24; h++) {
+      seen.add(journalLineForAction('feed', '', h));
+    }
+    expect(seen.size).toBeGreaterThan(1);
+  });
+
+  it('different moods at the same hour can pick different lines', () => {
+    const lines = new Set<string>();
+    for (const mood of ['happy', 'hungry', 'lonely', 'sleepy', 'idle']) {
+      lines.add(journalLineForAction('pet', mood, 12));
+    }
+    // We don't require *all* differ (5 picks from a 5-line pool can collide),
+    // but at least two of the five must be distinct.
+    expect(lines.size).toBeGreaterThan(1);
+  });
+
+  it('treats negative or out-of-range hours safely (no throw)', () => {
+    expect(() => journalLineForAction('pet', '', -7)).not.toThrow();
+    expect(() => journalLineForAction('pet', '', 99)).not.toThrow();
+    const line = journalLineForAction('pet', '', -7);
+    expect(line.length).toBeGreaterThan(0);
+  });
+});

--- a/lib/sanctuary/companionGreeting.ts
+++ b/lib/sanctuary/companionGreeting.ts
@@ -1,0 +1,261 @@
+/**
+ * Cozy/tamagotchi-voice helpers for the dedicated Companion screen
+ * (`[SWO_V2_COMPANION_COZY_POLISH]`).
+ *
+ * Three pure helpers, no DB / Phaser / React imports so they can be
+ * unit-tested in isolation and reused by CompanionView, db.ts journal
+ * messages, and any future cozy surface (mobile widget, push copy, etc.):
+ *
+ *   - greetingForMood(name, mood, isSleeping) → cozy one-liner the
+ *     companion says back at you on screen-mount or mood-change.
+ *   - lastVisitedPhrase(stats_updated_at, now) → soft, non-punishing
+ *     time-since-last-tend phrase ("you just popped in" / "they missed
+ *     you"). Always reassuring; never scolding.
+ *   - journalLineForAction(action, mood, hour) → deterministic-but-varied
+ *     journal entry line per action × time-of-day, so two consecutive
+ *     feedings don't store the same flat string.
+ */
+
+export type CozyMood =
+  | 'happy'
+  | 'excited'
+  | 'calm'
+  | 'sleepy'
+  | 'curious'
+  | 'sleeping'
+  | 'hungry'
+  | 'lonely'
+  | 'idle';
+
+export type CozyAction = 'feed' | 'pet' | 'talk' | 'sleep' | 'play';
+
+const GREETINGS_BY_MOOD: Readonly<Record<CozyMood, readonly string[]>> = Object.freeze({
+  happy: [
+    '{name} lights up when you walk in.',
+    '{name} is having a wonderful day with you.',
+    '{name} gives a tiny happy chirp.',
+  ],
+  excited: [
+    '{name} can hardly sit still — they missed you!',
+    '{name} bounces over to greet you.',
+    '{name} radiates good vibes.',
+  ],
+  calm: [
+    '{name} settles in close, content.',
+    '{name} sighs softly — all is well.',
+    '{name} watches the stars with you.',
+  ],
+  sleepy: [
+    '{name} blinks slowly — eyes heavy.',
+    '{name} curls up beside you.',
+    "{name}'s yawn is contagious.",
+  ],
+  curious: [
+    "{name}'s eyes light up — what shall we explore today?",
+    '{name} tilts their head, listening.',
+    '{name} sniffs the air, alert.',
+  ],
+  sleeping: [
+    '{name} is dreaming. Tiny snores. ✨',
+    'Shhh — {name} is fast asleep.',
+    '{name} dreams of cosmic snacks.',
+  ],
+  hungry: [
+    '{name} eyes you hopefully — could it be snack time?',
+    "{name}'s tummy is rumbling a little.",
+    '{name} sniffs around for treats.',
+  ],
+  lonely: [
+    "{name} perks up — they've been waiting for you.",
+    '{name} nuzzles your hand. Some company at last.',
+    '{name} looks relieved to see you.',
+  ],
+  idle: [
+    '{name} is here, just being.',
+    '{name} hums a tiny tune.',
+    '{name} flicks an ear in your direction.',
+  ],
+});
+
+/**
+ * Pick a cozy greeting line for the companion screen header. Deterministic
+ * given (name, mood, dayKey) so it doesn't reshuffle on every re-render —
+ * `dayKey` defaults to UTC day of year so the line refreshes once per day.
+ */
+export function greetingForMood(
+  name: string,
+  mood: CozyMood | string | null | undefined,
+  isSleeping: boolean = false,
+  dayKey: number = utcDayOfYear(new Date()),
+): string {
+  const effectiveMood: CozyMood = isSleeping
+    ? 'sleeping'
+    : isCozyMood(mood)
+      ? mood
+      : 'idle';
+  const pool = GREETINGS_BY_MOOD[effectiveMood] ?? GREETINGS_BY_MOOD.idle;
+  const line = pool[Math.abs(hashString(name) + dayKey) % pool.length];
+  return (line ?? GREETINGS_BY_MOOD.idle[0]).replace(/\{name\}/g, name);
+}
+
+/**
+ * Soft, non-punishing time-since-last-tend phrase. Returns null when the
+ * input is missing or unparseable so the UI can simply not render the line.
+ *
+ * Tone bands (deliberately reassuring, never guilt-tripping):
+ *   - <  1 min      → null  (just-tended, no message; the action feedback
+ *                            already covers the moment)
+ *   - <  5 min      → "you just popped in"
+ *   - < 60 min      → "X minutes since you said hi"
+ *   - <  6 h        → "X hours since you visited"
+ *   - <  24 h       → "X hours since you visited"
+ *   - 1–2 days      → "almost {N} days — they perk up to see you"
+ *   - 2–7 days      → "{N} days — they missed you"
+ *   - >= 7 days     → "a while — they're so happy you came back"
+ *
+ * Negative deltas (clock skew / future timestamps) collapse to null.
+ */
+export function lastVisitedPhrase(
+  statsUpdatedAt: string | null | undefined,
+  now: Date = new Date(),
+): string | null {
+  if (!statsUpdatedAt) return null;
+  const t = parseSqlOrIsoMs(statsUpdatedAt);
+  if (t === null) return null;
+  const elapsedMs = now.getTime() - t;
+  if (!(elapsedMs > 0)) return null;
+
+  const seconds = Math.floor(elapsedMs / 1000);
+  if (seconds < 60) return null;
+
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 5) return 'You just popped in.';
+  if (minutes < 60) return `${minutes} minutes since you said hi.`;
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) {
+    return hours === 1
+      ? '1 hour since you visited.'
+      : `${hours} hours since you visited.`;
+  }
+
+  const days = Math.floor(hours / 24);
+  if (days < 2) return 'Almost a day — they perk up to see you.';
+  if (days < 7) return `${days} days — they missed you.`;
+  return "It's been a while — they're so happy you came back.";
+}
+
+/**
+ * Variety pool for journal entries written on each interaction. Picks a
+ * line deterministically from (action, hour-of-day-bucket, mood) so the
+ * same action at the same hour with the same mood always picks the same
+ * line, but the next interaction (different mood or hour bucket) picks a
+ * different one — avoids the previous flat single-line repetition.
+ *
+ * Keep lines short and warm — they appear in the last-3 journal panel
+ * directly below the sprite, where tone matters more than detail.
+ */
+const ACTION_VARIANTS: Readonly<Record<CozyAction, readonly string[]>> = Object.freeze({
+  feed: [
+    'Enjoyed a tasty cosmic treat. Bond strengthened!',
+    'Devoured a stardust snack with glee.',
+    'Munched a moon-fruit slowly, savoring.',
+    'Crunched a nebula cracker. Crumbs everywhere.',
+    'Sipped warm comet broth and sighed.',
+  ],
+  pet: [
+    'Received gentle pats. Feeling cozy and loved.',
+    'Leaned into your hand and purred softly.',
+    'Closed their eyes for a long, gentle scritch.',
+    'Did the tiny happy wiggle when you reached down.',
+    'Pressed their head into your palm. Pure trust.',
+  ],
+  talk: [
+    'Had a heartfelt conversation with their owner.',
+    'Listened intently as you shared the day.',
+    'Chirped back in their own little language.',
+    'Tilted their head at every word, fascinated.',
+    'Settled in close to hear what you had to say.',
+  ],
+  play: [
+    'Burned off some cosmic zoomies. Feels alive!',
+    'Chased a dust mote across the sanctuary.',
+    'Bounced in delight, a blur of joy.',
+    'Wrestled with a star-thread until tired and grinning.',
+    'Spun in circles, then collapsed laughing.',
+  ],
+  sleep: [
+    'Curled up for a cosmic nap. Energy slowly returning.',
+    'Tucked into a starlit doze. Tiny snores.',
+    'Yawned wide, then drifted off on a moonbeam.',
+    'Settled into the cozy nest, eyes closing.',
+    'Dreaming of nebula meadows.',
+  ],
+});
+
+/**
+ * Pick a journal-line variant for an interaction. Deterministic given
+ * (action, hourBucket, moodSeed) — same inputs always pick the same line,
+ * but realistic input drift (hour ticks, mood changes) keeps the pool
+ * rotating naturally across a session.
+ *
+ * `moodSeed` is any short string ("happy", "hungry", or "" if unknown);
+ * we hash it to perturb the index so different moods at the same hour
+ * still pick different lines. Pass an empty string when no mood is known
+ * — the function still rotates by hour-of-day bucket.
+ */
+export function journalLineForAction(
+  action: CozyAction,
+  moodSeed: string = '',
+  hour: number = new Date().getHours(),
+): string {
+  const pool = ACTION_VARIANTS[action] ?? [];
+  if (pool.length === 0) return '';
+  const hourBucket = Math.floor((((hour % 24) + 24) % 24) / 4);
+  const idx = Math.abs(hashString(moodSeed) + hourBucket) % pool.length;
+  return pool[idx] ?? pool[0];
+}
+
+// ---------------------------------------------------------------------------
+// internal helpers (no exports below this line are part of the public API)
+// ---------------------------------------------------------------------------
+
+const COZY_MOODS: readonly CozyMood[] = [
+  'happy', 'excited', 'calm', 'sleepy', 'curious',
+  'sleeping', 'hungry', 'lonely', 'idle',
+];
+
+function isCozyMood(value: unknown): value is CozyMood {
+  return typeof value === 'string' && (COZY_MOODS as readonly string[]).includes(value);
+}
+
+function hashString(s: string): number {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) {
+    h = (h * 31 + s.charCodeAt(i)) | 0;
+  }
+  return h;
+}
+
+function utcDayOfYear(d: Date): number {
+  const start = Date.UTC(d.getUTCFullYear(), 0, 0);
+  return Math.floor((d.getTime() - start) / 86_400_000);
+}
+
+/**
+ * Parse the SQLite `YYYY-MM-DD HH:MM:SS` snapshot timestamps used elsewhere
+ * in db.ts (treated as UTC) or any ISO-8601 string. Returns ms-since-epoch
+ * or null when the value is unparseable. Never throws.
+ */
+function parseSqlOrIsoMs(s: string): number | null {
+  const trimmed = s.trim();
+  if (!trimmed) return null;
+  // SQLite CURRENT_TIMESTAMP form: 'YYYY-MM-DD HH:MM:SS' — append 'Z' so
+  // it parses as UTC rather than the runtime's local zone.
+  let candidate = trimmed;
+  if (/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/.test(trimmed)) {
+    candidate = trimmed.replace(' ', 'T') + 'Z';
+  }
+  const ms = Date.parse(candidate);
+  return Number.isFinite(ms) ? ms : null;
+}


### PR DESCRIPTION
## Summary

Closes the gap between V2.6 (dedicated companion surface shipped) and the companion-first direction note (`memory/evolution/swo_sanctuary_companion_first_2026-04-26.md`): the screen now feels alive between actions instead of just refreshing numbers. No new schema, no API change, no V3 touched.

`[SWO_V2_COMPANION_COZY_POLISH]`

### What's new on `/sanctuary?v=2` (Companion default landing)

- **Mood-aware greeting line** under the name — _"Pico lights up when you walk in."_ / _"Pico is dreaming. Tiny snores."_ Cycles per UTC day so repeat visits don't show the same line back-to-back. 9 moods × 3 variants each.
- **Last-visit cozy time anchor** — _"30 minutes since you said hi."_, _"3 hours since you visited."_, _"Almost a day — they perk up to see you."_, _"It's been a while — they're so happy you came back."_ Soft and reassuring across every band; never scolds. Hidden when <1 min (the action feedback already covers that moment).
- **Floating reaction emojis on the sprite per quick action** — feed→🍎✨, pet→💗💗✨, talk→💬💕, sleep→💤🌙, play→⭐✨💫. Reuses the existing `companion-floating-text` keyframe.
- **Stat-bar "+N" floating indicator + bar-glow pulse** when an action moves a stat. Per-bar accent color (orange/pink/cyan) via CSS var. Tiny rounding deltas (<2) suppressed to avoid +1 noise.
- **Cozy ambient** — 5 twinkling stars layered behind the sprite (CSS only; pointer-events disabled).
- **Sleeping-state warmth** — header reads _"Shhh — they're dreaming."_, non-sleep buttons mute visually with a "wait until they wake" tooltip, and tapping one shows a _"shhh — Pico is sleeping"_ message instead of firing a request the API rejects with HTTP 409 anyway.
- **Journal entry variety** — each interaction picks one of 5 warm variants per action × hour-of-day bucket. Wired into `interactWithCompanion` via `journalLineForAction`.

### New shared helper

`lib/sanctuary/companionGreeting.ts` — three pure functions:
- `greetingForMood(name, mood, isSleeping, dayKey)` 
- `lastVisitedPhrase(stats_updated_at, now)` — accepts both SQLite `YYYY-MM-DD HH:MM:SS` (read as UTC) and ISO-8601; clock-skew safe; returns `null` when display should be hidden.
- `journalLineForAction(action, moodSeed, hour)` — deterministic-but-varied.

No DB / Phaser / React imports. 25 vitest cases covering every CozyMood, every time-band, both timestamp formats, and a guard that none of the phrases scold the operator.

### Files

| File | Change |
|---|---|
| `app/sanctuary/CompanionView.tsx` | wire greeting / last-visit / sprite reactions / stat-deltas / sleep UX |
| `app/globals.css` | `.companion-cozy-stars` + `.companion-stat-bar-pulse` keyframes |
| `lib/db.ts` | `interactWithCompanion` now picks journal lines via `journalLineForAction` |
| `lib/sanctuary/companionGreeting.ts` | new pure helper |
| `lib/sanctuary/__tests__/companionGreeting.test.ts` | 25 vitest cases |

## Test plan

- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean on touched files (pre-existing warnings elsewhere unchanged)
- [x] `npx vitest run lib/sanctuary/__tests__/companionGreeting.test.ts` — 25/25 pass
- [x] `npx vitest run lib/sanctuary` — 536 passing total. Three pre-existing api-e2e failures on `nft-traits` distribution + `chat history limit` mock are unchanged from dev HEAD.
- [ ] Operator playtest on `?v=2`: open without a recent visit and confirm the cozy greeting + last-visit line render; click each quick action and confirm sprite emoji + bar +N + bar pulse; trigger sleep and confirm the muted-button + "Shhh" header + "shhh — Pico is sleeping" feedback when tapping a non-sleep button.
- [ ] Visual sanity on `?v=2`: stars layer should be subtle (5 small dots, twinkling), not distracting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)