### PR TITLE
feat(sanctuary v2): celebrate bond milestone crossings [SWO_V2_COMPANION_BOND_MILESTONE_CELEBRATE]

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -627,6 +627,45 @@ body::before {
 }
 
 /* ============================================
+   Bond-milestone celebration
+   (SWO_V2_COMPANION_BOND_MILESTONE_CELEBRATE)
+   ============================================ */
+
+/* Brief 2.5s banner that slides down from above the sprite when a bond
+   milestone (25/50/75/100) is reached. Pure CSS so the React component just
+   mounts the element and unmounts after the trigger duration. */
+@keyframes bondMilestoneBannerIn {
+  0%   { opacity: 0; transform: translate(-50%, -16px) scale(0.92); }
+  15%  { opacity: 1; transform: translate(-50%, 0) scale(1); }
+  85%  { opacity: 1; transform: translate(-50%, 0) scale(1); }
+  100% { opacity: 0; transform: translate(-50%, -8px) scale(0.96); }
+}
+.companion-bond-banner {
+  animation: bondMilestoneBannerIn 2.5s ease-out forwards;
+}
+
+/* Heart confetti — each .heart-particle spawns at the sprite center and
+   drifts outward + upward for ~2s. Per-particle CSS variables (--dx, --dy,
+   --rot, --delay) let the React layer randomize trajectories without
+   redefining the keyframes. */
+@keyframes bondHeartFloat {
+  0%   { opacity: 0; transform: translate(-50%, -50%) scale(0.4) rotate(0deg); }
+  20%  { opacity: 1; transform: translate(calc(-50% + calc(var(--dx, 0px) * 0.4)), calc(-50% + calc(var(--dy, 0px) * 0.4))) scale(1) rotate(calc(var(--rot, 0deg) * 0.4)); }
+  100% { opacity: 0; transform: translate(calc(-50% + var(--dx, 0px)), calc(-50% + var(--dy, 0px))) scale(0.7) rotate(var(--rot, 0deg)); }
+}
+.heart-particle {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  font-size: 18px;
+  pointer-events: none;
+  opacity: 0;
+  animation: bondHeartFloat 2.2s ease-out forwards;
+  animation-delay: var(--delay, 0ms);
+  text-shadow: 0 0 6px rgba(255, 102, 170, 0.7);
+}
+
+/* ============================================
    Cozy Gaming Station Loading Experience
    ============================================ */
 

--- a/app/sanctuary/CompanionView.tsx
+++ b/app/sanctuary/CompanionView.tsx
@@ -12,6 +12,16 @@ import {
   type CozyMood,
 } from '@/lib/sanctuary/companionGreeting';
 import { MOOD_EMOJI } from '@/components/sanctuary/overlays/CompanionHUD';
+import EventBus from '@/components/sanctuary/EventBus';
+import { emitCompanionVfx } from '@/lib/sanctuary/vfxEvents';
+import {
+  bondMilestoneBanner,
+  crossedBondMilestones,
+  highestMilestone,
+  readLastCelebratedMilestone,
+  writeLastCelebratedMilestone,
+  type BondMilestone,
+} from '@/lib/sanctuary/bondMilestones';
 
 const SanctuaryContent = dynamic(() => import('./SanctuaryContent'), { ssr: false });
 
@@ -82,6 +92,12 @@ const NEED_LABEL: Record<'hunger' | 'happiness' | 'energy', string> = {
   happiness: 'Lonely — let’s talk',
   energy: 'Sleepy — needs rest',
 };
+
+interface BondCelebration {
+  id: number;
+  milestone: BondMilestone;
+  message: string;
+}
 
 const MOOD_LABEL: Record<string, string> = {
   happy: 'Happy',
@@ -168,9 +184,12 @@ export default function CompanionView() {
   const [recentlyChanged, setRecentlyChanged] = useState<
     Set<'hunger' | 'happiness' | 'energy'>
   >(() => new Set());
+  const [bondCelebration, setBondCelebration] = useState<BondCelebration | null>(null);
   const feedbackTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const reactionIdRef = useRef(0);
   const deltaIdRef = useRef(0);
+  const celebrationIdRef = useRef(0);
+  const celebrationTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const fetchCompanion = useCallback(async () => {
     if (!address) return;
@@ -257,6 +276,32 @@ export default function CompanionView() {
     }, 1100);
   }, []);
 
+  const triggerBondCelebration = useCallback(
+    (milestone: BondMilestone, name: string) => {
+      const id = ++celebrationIdRef.current;
+      const message = bondMilestoneBanner(milestone, name);
+      setBondCelebration({ id, milestone, message });
+      // Emit a `heart` VFX through the shared contract so the V2 world
+      // CompanionMenu (and any other listener) renders a matching burst.
+      // Coordinates are best-effort screen-center for the screen surface;
+      // the V2 world listener resolves its own anchoring per scene.
+      if (typeof window !== 'undefined') {
+        emitCompanionVfx(EventBus, {
+          kind: 'heart',
+          x: window.innerWidth / 2,
+          y: window.innerHeight / 2,
+          durationMs: 2200,
+          source: `bond-milestone-${milestone}`,
+        });
+      }
+      if (celebrationTimer.current) clearTimeout(celebrationTimer.current);
+      celebrationTimer.current = setTimeout(() => {
+        setBondCelebration((prev) => (prev && prev.id === id ? null : prev));
+      }, 2500);
+    },
+    [],
+  );
+
   const pushStatDelta = useCallback(
     (stat: 'hunger' | 'happiness' | 'energy', delta: number) => {
       if (delta === 0) return;
@@ -322,6 +367,8 @@ export default function CompanionView() {
             happiness: data.companion.happiness ?? companion.happiness,
             energy: data.companion.energy ?? companion.energy,
           };
+          const prevBond = companion.bond_score;
+          const nextBond = data.companion.bond_score ?? prevBond;
           setCompanion((prev) =>
             prev
               ? {
@@ -331,13 +378,31 @@ export default function CompanionView() {
                   energy: next.energy,
                   is_sleeping:
                     data.companion.is_sleeping ?? prev.is_sleeping,
-                  bond_score: data.companion.bond_score ?? prev.bond_score,
+                  bond_score: nextBond,
                   mood: data.companion.mood ?? prev.mood,
                   stats_updated_at:
                     data.companion.stats_updated_at ?? prev.stats_updated_at,
                 }
               : prev,
           );
+          // Detect upward crossings of [25, 50, 75, 100] and fire one
+          // celebration moment per threshold per companion. lastCelebrated
+          // is persisted in localStorage so a refresh or a wobble around the
+          // threshold cannot retrigger a banner that was already shown.
+          const lastCelebrated = readLastCelebratedMilestone(companion.token_id);
+          const crossings = crossedBondMilestones(
+            prevBond,
+            nextBond,
+            lastCelebrated,
+          );
+          const top = highestMilestone(crossings);
+          if (top !== null) {
+            triggerBondCelebration(
+              top,
+              companion.nickname || `Skrumpey #${companion.token_id}`,
+            );
+            writeLastCelebratedMilestone(companion.token_id, top);
+          }
           // Floating "+N" near each stat bar that moved (uses the projected
           // post-decay delta from server-side, so tiny rounding deltas don't
           // create noisy +1s).
@@ -362,8 +427,14 @@ export default function CompanionView() {
         setInteracting(null);
       }
     },
-    [address, companion, interacting, flashFeedback, fetchJournal, triggerSpriteReaction, pushStatDelta],
+    [address, companion, interacting, flashFeedback, fetchJournal, triggerSpriteReaction, pushStatDelta, triggerBondCelebration],
   );
+
+  useEffect(() => {
+    return () => {
+      if (celebrationTimer.current) clearTimeout(celebrationTimer.current);
+    };
+  }, []);
 
   const handleSendChat = useCallback(async () => {
     if (!address || !companion || chatBusy) return;
@@ -536,6 +607,55 @@ export default function CompanionView() {
                 >
                   {moodEmoji}
                 </span>
+
+                {/* Bond-milestone celebration: brief banner above the sprite
+                    plus heart confetti drifting outward. Auto-clears after
+                    ≤2.5s via celebrationTimer. */}
+                {bondCelebration && (
+                  <>
+                    <div
+                      key={`banner-${bondCelebration.id}`}
+                      className="companion-bond-banner absolute left-1/2 -top-10 z-20 pointer-events-none whitespace-nowrap rounded border border-[#ff66aa]/70 bg-black/85 px-3 py-1 text-[8px] font-['Press_Start_2P'] tracking-wider text-[#ff99cc] shadow-[0_0_12px_rgba(255,102,170,0.45)]"
+                      role="status"
+                      aria-live="polite"
+                    >
+                      {bondCelebration.message}
+                    </div>
+                    <div
+                      key={`hearts-${bondCelebration.id}`}
+                      className="absolute inset-0 pointer-events-none z-10"
+                      aria-hidden="true"
+                    >
+                      {Array.from({ length: 10 }).map((_, i) => {
+                        // Deterministic spread around the sprite — angles
+                        // evenly distributed so the burst always feels full,
+                        // with a small per-particle delay so they don't all
+                        // fire on exactly the same frame.
+                        const angle = (i / 10) * Math.PI * 2;
+                        const distance = 60 + (i % 3) * 12;
+                        const dx = Math.cos(angle) * distance;
+                        const dy = Math.sin(angle) * distance - 20;
+                        const rot = (i % 2 === 0 ? 1 : -1) * (15 + (i % 4) * 5);
+                        return (
+                          <span
+                            key={i}
+                            className="heart-particle"
+                            style={
+                              {
+                                '--dx': `${dx.toFixed(0)}px`,
+                                '--dy': `${dy.toFixed(0)}px`,
+                                '--rot': `${rot}deg`,
+                                '--delay': `${i * 35}ms`,
+                              } as React.CSSProperties
+                            }
+                          >
+                            {i % 3 === 0 ? '💖' : i % 3 === 1 ? '💗' : '✨'}
+                          </span>
+                        );
+                      })}
+                    </div>
+                  </>
+                )}
 
                 {/* Floating reaction emojis layered above the sprite. Each
                     reaction is short-lived (≤1.1s) and absolutely positioned

--- a/components/sanctuary/overlays/CompanionMenu.tsx
+++ b/components/sanctuary/overlays/CompanionMenu.tsx
@@ -8,6 +8,12 @@ import {
   vfxKindForInteractAction,
   type CompanionInteractAction,
 } from '@/lib/sanctuary/vfxEvents';
+import {
+  crossedBondMilestones,
+  highestMilestone,
+  readLastCelebratedMilestone,
+  writeLastCelebratedMilestone,
+} from '@/lib/sanctuary/bondMilestones';
 
 type InteractAction = CompanionInteractAction;
 
@@ -180,6 +186,35 @@ export default function CompanionMenu({
         } else {
           addFloatingText('+2 Bond', '#ff66aa', pos.x - 20, pos.y - 40);
           addFloatingText('+5 XP', '#ffd700', pos.x + 20, pos.y - 55);
+        }
+
+        // [SWO_V2_COMPANION_BOND_MILESTONE_CELEBRATE]: detect upward bond
+        // crossings of [25, 50, 75, 100] and fire one `heart` VFX burst per
+        // threshold per companion. The persisted watermark is shared with
+        // the Companion screen via localStorage so a celebration in one
+        // surface won't replay in the other.
+        if (companion && typeof tokenId === 'number') {
+          const nextBond = typeof companion.bond_score === 'number'
+            ? companion.bond_score
+            : null;
+          const gained = typeof companion.bond_gained === 'number'
+            ? companion.bond_gained
+            : 0;
+          const prevBond = nextBond !== null ? nextBond - gained : null;
+          const lastCelebrated = readLastCelebratedMilestone(tokenId);
+          const top = highestMilestone(
+            crossedBondMilestones(prevBond, nextBond, lastCelebrated),
+          );
+          if (top !== null) {
+            emitCompanionVfx(EventBus, {
+              kind: 'heart',
+              x: pos.x,
+              y: pos.y,
+              durationMs: 2200,
+              source: `bond-milestone-${top}`,
+            });
+            writeLastCelebratedMilestone(tokenId, top);
+          }
         }
 
         EventBus.emit('companion-interacted', { action, companion: data.companion });

--- a/lib/sanctuary/__tests__/bondMilestones.test.ts
+++ b/lib/sanctuary/__tests__/bondMilestones.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+
+import {
+  BOND_MILESTONES,
+  bondMilestoneBanner,
+  crossedBondMilestones,
+  highestMilestone,
+} from '../bondMilestones';
+
+describe('crossedBondMilestones', () => {
+  it('does not double-fire on identical bond scores', () => {
+    expect(crossedBondMilestones(25, 25)).toEqual([]);
+    expect(crossedBondMilestones(50, 50)).toEqual([]);
+    expect(crossedBondMilestones(0, 0)).toEqual([]);
+    expect(crossedBondMilestones(100, 100)).toEqual([]);
+  });
+
+  it('fires once on an upward crossing of a single threshold', () => {
+    expect(crossedBondMilestones(24, 25)).toEqual([25]);
+    expect(crossedBondMilestones(20, 30)).toEqual([25]);
+    expect(crossedBondMilestones(49, 55)).toEqual([50]);
+    expect(crossedBondMilestones(74, 80)).toEqual([75]);
+    expect(crossedBondMilestones(99, 100)).toEqual([100]);
+  });
+
+  it('does not fire on downward movement', () => {
+    expect(crossedBondMilestones(30, 20)).toEqual([]);
+    expect(crossedBondMilestones(60, 40)).toEqual([]);
+    expect(crossedBondMilestones(100, 0)).toEqual([]);
+    expect(crossedBondMilestones(26, 24)).toEqual([]);
+  });
+
+  it('reports every threshold crossed in a single jump, sorted ascending', () => {
+    expect(crossedBondMilestones(0, 100)).toEqual([25, 50, 75, 100]);
+    expect(crossedBondMilestones(20, 60)).toEqual([25, 50]);
+    expect(crossedBondMilestones(60, 90)).toEqual([75]);
+    expect(crossedBondMilestones(40, 80)).toEqual([50, 75]);
+  });
+
+  it('treats null/undefined prev as a first observation (no crossings)', () => {
+    expect(crossedBondMilestones(null, 30)).toEqual([]);
+    expect(crossedBondMilestones(undefined, 90)).toEqual([]);
+    expect(crossedBondMilestones(null, 100)).toEqual([]);
+  });
+
+  it('respects lastCelebrated to prevent re-fire after wobble', () => {
+    // Score crossed 25 once already (lastCelebrated=25), then decayed to 23
+    // and climbed back to 27 — we must NOT re-fire 25.
+    expect(crossedBondMilestones(23, 27, 25)).toEqual([]);
+    // But a brand-new threshold beyond lastCelebrated still fires.
+    expect(crossedBondMilestones(40, 60, 25)).toEqual([50]);
+    // lastCelebrated does not block higher thresholds in a big jump.
+    expect(crossedBondMilestones(20, 80, 25)).toEqual([50, 75]);
+  });
+
+  it('clamps out-of-range / non-finite inputs safely', () => {
+    expect(crossedBondMilestones(-10, 30)).toEqual([25]);
+    expect(crossedBondMilestones(50, 200)).toEqual([75, 100]);
+    expect(crossedBondMilestones(Number.NaN, 50)).toEqual([]);
+    expect(crossedBondMilestones(50, Number.POSITIVE_INFINITY)).toEqual([]);
+  });
+
+  it('does not fire when next equals prev exactly at a threshold (no upward cross)', () => {
+    // A score that lands ON a threshold from below DOES fire (24 -> 25).
+    // A score that stays AT the threshold (25 -> 25) does NOT.
+    expect(crossedBondMilestones(24, 25)).toEqual([25]);
+    expect(crossedBondMilestones(25, 25)).toEqual([]);
+    expect(crossedBondMilestones(25, 26)).toEqual([]);
+  });
+});
+
+describe('highestMilestone', () => {
+  it('returns null for an empty list', () => {
+    expect(highestMilestone([])).toBeNull();
+  });
+
+  it('returns the largest milestone in the list', () => {
+    expect(highestMilestone([25])).toBe(25);
+    expect(highestMilestone([25, 50, 75])).toBe(75);
+    expect(highestMilestone([100, 25])).toBe(100);
+  });
+});
+
+describe('bondMilestoneBanner', () => {
+  it('includes the companion name in every milestone banner', () => {
+    for (const m of BOND_MILESTONES) {
+      const text = bondMilestoneBanner(m, 'Pico');
+      expect(text).toContain('Pico');
+      expect(text.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('falls back to a generic noun when name is empty', () => {
+    expect(bondMilestoneBanner(25, '')).toContain('your companion');
+    expect(bondMilestoneBanner(50, '   ')).toContain('your companion');
+  });
+});
+
+describe('BOND_MILESTONES contract', () => {
+  it('is exactly [25, 50, 75, 100]', () => {
+    expect([...BOND_MILESTONES]).toEqual([25, 50, 75, 100]);
+  });
+});

--- a/lib/sanctuary/bondMilestones.ts
+++ b/lib/sanctuary/bondMilestones.ts
@@ -1,0 +1,130 @@
+/**
+ * Pure helper for `[SWO_V2_COMPANION_BOND_MILESTONE_CELEBRATE]`.
+ *
+ * Detects when a companion's `bond_score` crosses one of the milestone
+ * thresholds [25, 50, 75, 100] in the upward direction between two
+ * consecutive observations. Each crossed threshold is reported once per
+ * companion — callers persist the highest-celebrated threshold (per token)
+ * and pass it back in as `lastCelebrated` so a stat that wobbles around a
+ * threshold cannot retrigger the same celebration.
+ *
+ * No DB / Phaser / React imports — kept trivially unit-testable so the
+ * Companion screen, V2 CompanionMenu, and any future surface can share one
+ * detector.
+ */
+
+export const BOND_MILESTONES: readonly number[] = [25, 50, 75, 100] as const;
+
+export type BondMilestone = (typeof BOND_MILESTONES)[number];
+
+/**
+ * Returns the milestones that were crossed upward strictly between `prev`
+ * and `next`, excluding any threshold ≤ `lastCelebrated`. Output is sorted
+ * ascending and deduplicated.
+ *
+ * Rules:
+ *  - prev = null/undefined (first observation): no crossings reported. We
+ *    only celebrate observed transitions, never initial mount, even if the
+ *    bond is already past a threshold.
+ *  - next ≤ prev: no upward crossings, returns []. Downward movement never
+ *    fires a celebration.
+ *  - lastCelebrated guards against re-firing if the persisted history
+ *    already covers a threshold (e.g. after a refresh, or after a small
+ *    decay nudges the score back below 25 then back above).
+ *  - Non-finite / NaN inputs collapse to safe behaviour (no crossings).
+ */
+export function crossedBondMilestones(
+  prev: number | null | undefined,
+  next: number | null | undefined,
+  lastCelebrated: number | null | undefined = null,
+): BondMilestone[] {
+  const before = clampScore(prev);
+  const after = clampScore(next);
+  if (before === null || after === null) return [];
+  if (after <= before) return [];
+  const guard = typeof lastCelebrated === 'number' && Number.isFinite(lastCelebrated)
+    ? lastCelebrated
+    : -Infinity;
+  return BOND_MILESTONES.filter(
+    (m) => m > before && m <= after && m > guard,
+  );
+}
+
+/** Convenience: highest milestone in a list (or null). */
+export function highestMilestone(
+  milestones: readonly BondMilestone[],
+): BondMilestone | null {
+  if (milestones.length === 0) return null;
+  return milestones.reduce((a, b) => (b > a ? b : a));
+}
+
+/**
+ * Player-facing celebration banner copy for a milestone.
+ * `name` is the companion's display name (nickname or "Skrumpey #N").
+ */
+export function bondMilestoneBanner(
+  milestone: BondMilestone,
+  name: string,
+): string {
+  const safeName = name && name.trim().length > 0 ? name.trim() : 'your companion';
+  switch (milestone) {
+    case 25:
+      return `\u{1F497} You and ${safeName} are growing closer.`;
+    case 50:
+      return `\u{1F497} Halfway bonded — ${safeName} truly trusts you now.`;
+    case 75:
+      return `\u{1F497} ${safeName} has chosen you as their person.`;
+    case 100:
+      return `\u{1F497} Devoted forever — ${safeName} loves you completely.`;
+    default:
+      return `\u{1F497} You and ${safeName} are growing closer.`;
+  }
+}
+
+function clampScore(value: number | null | undefined): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null;
+  if (value < 0) return 0;
+  if (value > 100) return 100;
+  return value;
+}
+
+/**
+ * Persisted "highest milestone already celebrated" guard, keyed by token id.
+ * Lives in `localStorage` so a refresh / second surface (Companion screen +
+ * V2 world menu) cannot re-fire the same banner. Browser-only — server
+ * callers should pass `lastCelebrated` directly to `crossedBondMilestones`.
+ */
+export const BOND_MILESTONE_STORAGE_PREFIX = 'swo:sanctuary:bondMilestone:';
+
+export function readLastCelebratedMilestone(tokenId: number): number | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(
+      `${BOND_MILESTONE_STORAGE_PREFIX}${tokenId}`,
+    );
+    if (!raw) return null;
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeLastCelebratedMilestone(
+  tokenId: number,
+  milestone: number,
+): void {
+  if (typeof window === 'undefined') return;
+  try {
+    const current = readLastCelebratedMilestone(tokenId);
+    // Never lower the watermark — only ratchet upward.
+    if (current !== null && current >= milestone) return;
+    window.localStorage.setItem(
+      `${BOND_MILESTONE_STORAGE_PREFIX}${tokenId}`,
+      String(milestone),
+    );
+  } catch {
+    // localStorage may be unavailable (private mode); celebrations will
+    // simply re-fire on a subsequent crossing — non-fatal.
+  }
+}


### PR DESCRIPTION
## Summary
- New `lib/sanctuary/bondMilestones.ts` pure detector that flags upward crossings of `bond_score` over `[25, 50, 75, 100]` between consecutive observations, with a `lastCelebrated` watermark for cross-session idempotency.
- Companion screen (`app/sanctuary/CompanionView.tsx`) renders a brief banner like "💗 You and Pico are growing closer." above the sprite plus heart confetti for ≤2.5s on each new milestone crossing, and emits the shared `companion-vfx` `heart` event so any other listener (V3, future analytics, etc.) can react.
- V2 world `CompanionMenu` (`components/sanctuary/overlays/CompanionMenu.tsx`) uses the same detector + a shared localStorage watermark so an in-world interaction that crosses a milestone fires a matching `heart` VFX burst at the radial-menu position.
- 13 vitest cases on the threshold-crossing detector — no double-fire on identical bonds, fires on upward cross, no-fire on downward, big-jump multi-threshold, null-prev handling, wobble guard, and clamp behaviour.
- No API change; persistence keyed by token id so celebrations don't leak between Skrumpeys.

## Acceptance check
- (a) Crossing detected once per threshold per companion (idempotent, persisted in `localStorage` under `swo:sanctuary:bondMilestone:<tokenId>`; the watermark only ratchets upward, so wobble around a threshold cannot retrigger).
- (b) Banner + confetti render for ≤2.5s and self-clear via `celebrationTimer`.
- (c) Both surfaces emit a `heart` VFX through `emitCompanionVfx` so the shared event bus carries the burst into the V2 world.
- (d) 13 vitest cases (well over the 3 required), all passing.
- (e) No API change.

## Test plan
- [x] `npm run type-check` — clean (workspace).
- [x] `npx eslint app/sanctuary/CompanionView.tsx components/sanctuary/overlays/CompanionMenu.tsx lib/sanctuary/bondMilestones.ts lib/sanctuary/__tests__/bondMilestones.test.ts` — clean.
- [x] `npx vitest run` — 712 passed, 4 pre-existing failures unchanged (roomScene + nft-traits + chat limit, all unrelated to this change).
- [ ] Manual: open `/sanctuary` (Companion screen), interact past bond 25 → confirm banner + confetti, then trigger 26→24→26 → confirm no re-fire.
- [ ] Manual: open the V2 world, click the Skrumpey, pet/feed past a milestone → confirm heart VFX burst on the radial-menu surface.

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS — pre-existing errors (PlayerSpriteV3, colyseus, howler module stubs) unchanged; 0 NEW errors.
- **vitest run**: PASS — baseline 674 passed / 4 failed → after overlay 687 passed / 4 failed (+13 new bondMilestones tests, 4 pre-existing failures unchanged).
Overall: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)