### PR TITLE
feat(sanctuary v2): per-companion local visit marker [SWO_V2_COMPANION_LOCAL_VISIT_MARKER]

### DIFF
--- a/app/sanctuary/CompanionView.tsx
+++ b/app/sanctuary/CompanionView.tsx
@@ -22,6 +22,11 @@ import {
   writeLastCelebratedMilestone,
   type BondMilestone,
 } from '@/lib/sanctuary/bondMilestones';
+import {
+  freshestVisitIso,
+  readLastVisit,
+  writeLastVisit,
+} from '@/lib/sanctuary/lastVisitStore';
 
 const SanctuaryContent = dynamic(() => import('./SanctuaryContent'), { ssr: false });
 
@@ -185,6 +190,11 @@ export default function CompanionView() {
     Set<'hunger' | 'happiness' | 'energy'>
   >(() => new Set());
   const [bondCelebration, setBondCelebration] = useState<BondCelebration | null>(null);
+  // Snapshot of the localStorage "last opened" marker captured the moment we
+  // first see this token id this session — so the cozy line below can refer
+  // to the *previous* page-open rather than the one happening right now (we
+  // overwrite the marker immediately afterward; see the effect below).
+  const [localVisitMs, setLocalVisitMs] = useState<number | null>(null);
   const feedbackTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const reactionIdRef = useRef(0);
   const deltaIdRef = useRef(0);
@@ -261,6 +271,17 @@ export default function CompanionView() {
       fetchJournal(companion.token_id);
     }
   }, [companion?.token_id, fetchJournal]);
+
+  // Capture the previous "you opened the screen at" marker, then immediately
+  // refresh it for the next page-open. The captured value is what feeds the
+  // cozy `lastVisitedPhrase` line — overwriting first would always show "you
+  // just popped in" no matter how long it had been.
+  useEffect(() => {
+    const tokenId = companion?.token_id;
+    if (tokenId === undefined) return;
+    setLocalVisitMs(readLastVisit(tokenId));
+    writeLastVisit(tokenId, Date.now());
+  }, [companion?.token_id]);
 
   const flashFeedback = useCallback((msg: string) => {
     setFeedback(msg);
@@ -537,7 +558,12 @@ export default function CompanionView() {
     effectiveMood as CozyMood,
     isSleeping,
   );
-  const lastVisit = lastVisitedPhrase(companion.stats_updated_at);
+  // Prefer the local "page-open" marker over `stats_updated_at` whenever it
+  // is fresher, so the cozy line refreshes on every open even when the
+  // player just lurks without interacting.
+  const lastVisit = lastVisitedPhrase(
+    freshestVisitIso(localVisitMs, companion.stats_updated_at),
+  );
 
   return (
     <div className="space-y-6">

--- a/lib/sanctuary/__tests__/lastVisitStore.test.ts
+++ b/lib/sanctuary/__tests__/lastVisitStore.test.ts
@@ -1,0 +1,177 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  LAST_VISIT_STORAGE_KEY,
+  freshestVisitIso,
+  readLastVisit,
+  writeLastVisit,
+  type StorageLike,
+} from '../lastVisitStore';
+
+class MemoryStorage implements StorageLike {
+  private map = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.map.has(key) ? (this.map.get(key) as string) : null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.map.set(key, value);
+  }
+
+  // Test-only helpers — not part of StorageLike.
+  raw(key: string): string | null {
+    return this.getItem(key);
+  }
+
+  preset(key: string, value: string): void {
+    this.map.set(key, value);
+  }
+
+  size(): number {
+    return this.map.size;
+  }
+}
+
+class ThrowingStorage implements StorageLike {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  getItem(_key: string): string | null {
+    throw new Error('storage denied');
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  setItem(_key: string, _value: string): void {
+    throw new Error('quota exceeded');
+  }
+}
+
+describe('lastVisitStore — readLastVisit / writeLastVisit', () => {
+  let storage: MemoryStorage;
+
+  beforeEach(() => {
+    storage = new MemoryStorage();
+  });
+
+  it('returns null when no marker has been written', () => {
+    expect(readLastVisit(1, storage)).toBeNull();
+    expect(readLastVisit(42, storage)).toBeNull();
+  });
+
+  it('round-trips a written marker for a single token', () => {
+    writeLastVisit(7, 1_700_000_000_000, storage);
+    expect(readLastVisit(7, storage)).toBe(1_700_000_000_000);
+  });
+
+  it('keeps multiple token ids independent in the same map', () => {
+    writeLastVisit(1, 1_000_000_000, storage);
+    writeLastVisit(2, 2_000_000_000, storage);
+    writeLastVisit(3, 3_000_000_000, storage);
+    expect(readLastVisit(1, storage)).toBe(1_000_000_000);
+    expect(readLastVisit(2, storage)).toBe(2_000_000_000);
+    expect(readLastVisit(3, storage)).toBe(3_000_000_000);
+    // All three live under the same key; storage doesn't fragment.
+    expect(storage.size()).toBe(1);
+  });
+
+  it('overwrites the existing marker for the same token without dropping siblings', () => {
+    writeLastVisit(1, 1_000, storage);
+    writeLastVisit(2, 2_000, storage);
+    writeLastVisit(1, 9_999, storage);
+    expect(readLastVisit(1, storage)).toBe(9_999);
+    expect(readLastVisit(2, storage)).toBe(2_000);
+  });
+
+  it('returns null on corrupted JSON instead of throwing', () => {
+    storage.preset(LAST_VISIT_STORAGE_KEY, '{not json');
+    expect(readLastVisit(1, storage)).toBeNull();
+    // A subsequent write recovers the slot cleanly.
+    writeLastVisit(1, 5_000, storage);
+    expect(readLastVisit(1, storage)).toBe(5_000);
+  });
+
+  it('returns null when stored value for a token is the wrong shape', () => {
+    storage.preset(
+      LAST_VISIT_STORAGE_KEY,
+      JSON.stringify({ '1': 'not-a-number', '2': null, '3': -5, '4': 12345 }),
+    );
+    expect(readLastVisit(1, storage)).toBeNull();
+    expect(readLastVisit(2, storage)).toBeNull();
+    expect(readLastVisit(3, storage)).toBeNull();
+    expect(readLastVisit(4, storage)).toBe(12345);
+  });
+
+  it('treats a null storage (SSR / unavailable) as a graceful no-op', () => {
+    expect(readLastVisit(1, null)).toBeNull();
+    expect(() => writeLastVisit(1, Date.now(), null)).not.toThrow();
+  });
+
+  it('swallows storage exceptions and never throws to the caller', () => {
+    const throwing = new ThrowingStorage();
+    expect(() => readLastVisit(1, throwing)).not.toThrow();
+    expect(readLastVisit(1, throwing)).toBeNull();
+    expect(() => writeLastVisit(1, Date.now(), throwing)).not.toThrow();
+  });
+
+  it('rejects non-finite or non-positive timestamps without writing', () => {
+    writeLastVisit(1, Number.NaN, storage);
+    writeLastVisit(1, Number.POSITIVE_INFINITY, storage);
+    writeLastVisit(1, 0, storage);
+    writeLastVisit(1, -1, storage);
+    expect(readLastVisit(1, storage)).toBeNull();
+    // Sanity: a real value still works after the bad ones were ignored.
+    writeLastVisit(1, 42_000, storage);
+    expect(readLastVisit(1, storage)).toBe(42_000);
+  });
+});
+
+describe('lastVisitStore — freshestVisitIso', () => {
+  it('returns null when both inputs are missing', () => {
+    expect(freshestVisitIso(null, null)).toBeNull();
+    expect(freshestVisitIso(null, undefined)).toBeNull();
+    expect(freshestVisitIso(null, '')).toBeNull();
+  });
+
+  it('returns the local marker when stats_updated_at is absent', () => {
+    const ms = Date.UTC(2026, 4, 1, 12, 0, 0);
+    expect(freshestVisitIso(ms, null)).toBe(new Date(ms).toISOString());
+  });
+
+  it('returns the stats timestamp when no local marker exists', () => {
+    const iso = freshestVisitIso(null, '2026-05-01 12:00:00');
+    expect(iso).toBe('2026-05-01T12:00:00.000Z');
+  });
+
+  it('prefers the local marker when it is fresher than stats_updated_at', () => {
+    const localMs = Date.UTC(2026, 4, 1, 12, 5, 0);
+    const out = freshestVisitIso(localMs, '2026-05-01 12:00:00');
+    expect(out).toBe(new Date(localMs).toISOString());
+  });
+
+  it('prefers stats_updated_at when it is fresher than the local marker', () => {
+    const localMs = Date.UTC(2026, 4, 1, 11, 55, 0);
+    const out = freshestVisitIso(localMs, '2026-05-01 12:00:00');
+    expect(out).toBe('2026-05-01T12:00:00.000Z');
+  });
+
+  it('parses ISO-8601 stats timestamps as well as the SQLite form', () => {
+    const out = freshestVisitIso(null, '2026-05-01T12:00:00.000Z');
+    expect(out).toBe('2026-05-01T12:00:00.000Z');
+  });
+
+  it('ignores unparseable stats input and falls back to the local marker', () => {
+    const localMs = Date.UTC(2026, 4, 1, 9, 0, 0);
+    expect(freshestVisitIso(localMs, 'not a date')).toBe(
+      new Date(localMs).toISOString(),
+    );
+  });
+
+  it('ignores non-finite local marker and uses the stats timestamp', () => {
+    expect(freshestVisitIso(Number.NaN, '2026-05-01 12:00:00')).toBe(
+      '2026-05-01T12:00:00.000Z',
+    );
+    expect(freshestVisitIso(-1, '2026-05-01 12:00:00')).toBe(
+      '2026-05-01T12:00:00.000Z',
+    );
+  });
+});

--- a/lib/sanctuary/lastVisitStore.ts
+++ b/lib/sanctuary/lastVisitStore.ts
@@ -1,0 +1,140 @@
+/**
+ * Per-companion "you opened the screen at" marker for
+ * `[SWO_V2_COMPANION_LOCAL_VISIT_MARKER]`.
+ *
+ * The cozy last-visited line on the Companion screen used to read off the
+ * server-side `stats_updated_at` column. That timestamp only moves when the
+ * player actually interacts (feed/pet/etc.), so opening the screen after a
+ * quiet period without acting always showed a stale "X hours since you
+ * visited" line. This module persists a per-token-id `localStorage` map of
+ * page-open timestamps independent of any server state, so the line refreshes
+ * on every page-open even when the player just lurks.
+ *
+ * Public surface:
+ *   - readLastVisit(tokenId)         → ms-since-epoch of the last marker, or null
+ *   - writeLastVisit(tokenId, nowMs) → records the marker for that token
+ *   - freshestVisitIso(localMs, statsUpdatedAt) → whichever of the two is
+ *     fresher, returned as an ISO string ready to feed `lastVisitedPhrase`.
+ *
+ * All functions accept an optional `storage` parameter so tests can pass an
+ * in-memory shim instead of relying on a DOM environment. In production the
+ * default storage resolves to `window.localStorage`, gracefully returning
+ * null when called from SSR or when storage is denied (private mode, etc.).
+ */
+
+export const LAST_VISIT_STORAGE_KEY = 'swo:sanctuary:lastVisit';
+
+export interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+function defaultStorage(): StorageLike | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function readMap(storage: StorageLike): Record<string, number> {
+  let raw: string | null;
+  try {
+    raw = storage.getItem(LAST_VISIT_STORAGE_KEY);
+  } catch {
+    return {};
+  }
+  if (!raw) return {};
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return {};
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+  const out: Record<string, number> = {};
+  for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+    if (typeof v === 'number' && Number.isFinite(v) && v > 0) {
+      out[k] = v;
+    }
+  }
+  return out;
+}
+
+/**
+ * Returns the recorded last-visit time (ms since epoch) for `tokenId`, or
+ * null when no marker has been written, when storage is unavailable, or when
+ * the persisted blob is corrupted.
+ */
+export function readLastVisit(
+  tokenId: number,
+  storage: StorageLike | null = defaultStorage(),
+): number | null {
+  if (!storage) return null;
+  if (!Number.isFinite(tokenId)) return null;
+  const map = readMap(storage);
+  const value = map[String(tokenId)];
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+    ? value
+    : null;
+}
+
+/**
+ * Records `nowMs` as the visit marker for `tokenId`. Other tokens already in
+ * the map are preserved. No-op when storage is unavailable, when `nowMs` is
+ * not a finite positive number, or when the underlying setItem throws (quota
+ * exceeded, private mode, etc.) — never throws to the caller.
+ */
+export function writeLastVisit(
+  tokenId: number,
+  nowMs: number = Date.now(),
+  storage: StorageLike | null = defaultStorage(),
+): void {
+  if (!storage) return;
+  if (!Number.isFinite(tokenId)) return;
+  if (!Number.isFinite(nowMs) || nowMs <= 0) return;
+  const map = readMap(storage);
+  map[String(tokenId)] = nowMs;
+  try {
+    storage.setItem(LAST_VISIT_STORAGE_KEY, JSON.stringify(map));
+  } catch {
+    // quota / unavailable — non-fatal; the line will simply fall back to
+    // stats_updated_at on the next render.
+  }
+}
+
+/**
+ * Returns the fresher of the two visit signals as an ISO-8601 string suitable
+ * for `lastVisitedPhrase`, or null when neither input yields a usable
+ * timestamp. The local marker wins ties — it represents an actual page-open
+ * and is what the player just observed.
+ */
+export function freshestVisitIso(
+  localMs: number | null,
+  statsUpdatedAt: string | null | undefined,
+): string | null {
+  const local =
+    typeof localMs === 'number' && Number.isFinite(localMs) && localMs > 0
+      ? localMs
+      : null;
+  const stats = parseSqlOrIsoMs(statsUpdatedAt);
+  if (local === null && stats === null) return null;
+  const winner = Math.max(local ?? -Infinity, stats ?? -Infinity);
+  if (!Number.isFinite(winner) || winner <= 0) return null;
+  return new Date(winner).toISOString();
+}
+
+function parseSqlOrIsoMs(s: string | null | undefined): number | null {
+  if (!s) return null;
+  const trimmed = s.trim();
+  if (!trimmed) return null;
+  // SQLite CURRENT_TIMESTAMP form ('YYYY-MM-DD HH:MM:SS') is stored as UTC
+  // by db.ts — append 'Z' so it parses as UTC, not the runtime's local zone.
+  let candidate = trimmed;
+  if (/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/.test(trimmed)) {
+    candidate = trimmed.replace(' ', 'T') + 'Z';
+  }
+  const ms = Date.parse(candidate);
+  return Number.isFinite(ms) ? ms : null;
+}


### PR DESCRIPTION
## Summary

Persist a per-companion *"you opened the screen at"* timestamp in
`localStorage`, independent of `stats_updated_at`, so the cozy
last-visit line on the Companion screen refreshes on every page-open
even when the player just lurks without interacting.

Today the line reads off `stats_updated_at`, which only moves when
the player actually feeds/pets/etc. Opening the screen after a quiet
period without acting always showed a stale phrase.

## Changes

- **NEW** `lib/sanctuary/lastVisitStore.ts` — pure helpers around a
  small `localStorage` map keyed by token id under
  `swo:sanctuary:lastVisit`:
  - `readLastVisit(tokenId, storage?)` — ms-since-epoch or `null`
  - `writeLastVisit(tokenId, nowMs?, storage?)` — preserves siblings,
    rejects non-finite/non-positive timestamps, swallows storage
    exceptions
  - `freshestVisitIso(localMs, statsUpdatedAt)` — returns the fresher
    of the two as an ISO-8601 string ready for `lastVisitedPhrase`
  - All functions accept an optional `StorageLike` so tests can pass
    an in-memory shim; the default resolves to `window.localStorage`
    and gracefully returns `null` from SSR / private mode
- **NEW** `lib/sanctuary/__tests__/lastVisitStore.test.ts` — 17
  vitest cases against an in-memory `MemoryStorage` shim and a
  `ThrowingStorage` shim covering: empty reads, round-trip, multiple
  tokens kept independent in one map, overwrite-without-dropping,
  corrupted JSON recovery, wrong-shape values, SSR (null storage),
  storage exceptions, and the freshness comparison (both missing,
  one missing, local newer, stats newer, ISO + SQLite parsing,
  unparseable / non-finite inputs).
- **MODIFIED** `app/sanctuary/CompanionView.tsx` — on mount, capture
  the previous local marker into state (so the cozy line refers to
  the *previous* page-open, not the one happening now), then write
  the current time as the new marker. The line uses
  `lastVisitedPhrase(freshestVisitIso(localVisitMs, stats_updated_at))`.

## Acceptance criteria

- ✅ (a) `lib/sanctuary/lastVisitStore.ts` reads/writes a per-token-id
  map in `localStorage` and is graceful when storage is unavailable
- ✅ (b) CompanionView prefers the local marker over
  `stats_updated_at` when fresher (`freshestVisitIso` returns the
  larger of the two timestamps)
- ✅ (c) ≥3 vitest cases against an in-memory storage shim — 17 in
  total

## Validations

- `npm run type-check` — clean
- `npx eslint` on changed files — clean
- `npx vitest run` — **729 passed**, 4 pre-existing failures
  (`api-e2e.test.ts` nft-traits + chat) unchanged across runs

## Mirror Validation (PROD)

The `app/sanctuary/CompanionView.tsx` overlaid by this PR imports
`@/lib/sanctuary/bondMilestones`, which was merged to `dev` in PR #278
but is not yet deployed to PROD. Re-running the baseline-diff with
the bondMilestones file co-overlaid (it is a pure pre-existing
dependency, not part of this PR's intent):

- **tsc --noEmit**: PASS — 459 errors before, 459 after (no new
  errors; the 459 are pre-existing missing-module errors in PROD,
  e.g. `colyseus.js`, `howler`)
- **vitest run**: PASS — 699 → 729 passing (+30: 17 lastVisit + 13
  bondMilestones), same 4 pre-existing api-e2e failures unchanged

Overall: **PASS**

## Test plan

- [ ] Open Sanctuary → Companion screen, note the cozy phrase
- [ ] Wait ≥5 minutes without clicking any action
- [ ] Refresh the page; phrase should now read e.g. *"5 minutes since
      you said hi."* even though `stats_updated_at` was unchanged
- [ ] Switch wallet to a different companion, then back; the line
      should still reflect the per-token marker (not bleed across)
- [ ] Test private-mode / SSR — page must not throw when
      `localStorage` is denied

🤖 Generated with [Claude Code](https://claude.com/claude-code)