### PR TITLE
feat(sanctuary v2): inject recent care log into chat prompt [SWO_V2_COMPANION_CHAT_REMEMBERS_RECENT_ACTIONS]

### DIFF
--- a/lib/sanctuary/__tests__/chatPersonality.test.ts
+++ b/lib/sanctuary/__tests__/chatPersonality.test.ts
@@ -3,6 +3,7 @@ import {
   buildChatPrompt,
   buildMemoryContextBlock,
   buildCompanionStateBlock,
+  buildRecentCareLogLine,
   bondLabel,
   moodLabel,
   estimateTokens,
@@ -16,6 +17,8 @@ import {
   MEMORY_INJECT_TOKEN_BUDGET,
   MAX_INJECTED_MEMORIES,
   STATE_INJECT_TOKEN_BUDGET,
+  RECENT_CARE_LOG_TOKEN_BUDGET,
+  MAX_RECENT_CARE_LOG_ENTRIES,
   type CompanionStateInput,
 } from '../chatPersonality';
 import type {
@@ -590,5 +593,153 @@ describe('buildChatPrompt with companion state', () => {
     });
     expect(out.system).toMatch(/qualitative|qualitatively/i);
     expect(out.system).toMatch(/never\s+(state|quote)\s+raw\s+numbers|raw\s+stat\s+numbers/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Recent care log — V2.5 [SWO_V2_COMPANION_CHAT_REMEMBERS_RECENT_ACTIONS]
+// ---------------------------------------------------------------------------
+
+describe('buildRecentCareLogLine', () => {
+  it('returns null when no journal entries are provided', () => {
+    expect(buildRecentCareLogLine([], NOW)).toBeNull();
+  });
+
+  it('returns null when no interaction entries exist', () => {
+    const entries = [
+      journal(1, 'achievement', 'Unlocked Foodie', '2026-04-27 11:55:00'),
+      journal(2, 'activity', 'Visited Hot Springs', '2026-04-27 10:00:00'),
+      journal(3, 'system', 'Weekly reset', '2026-04-26 12:00:00'),
+    ];
+    expect(buildRecentCareLogLine(entries, NOW)).toBeNull();
+  });
+
+  it('renders content joined by "; " when interactions exist', () => {
+    const entries = [
+      journal(1, 'interaction', 'Fed a cosmic treat.', '2026-04-27 11:30:00'),
+      journal(2, 'interaction', 'Played fetch.', '2026-04-27 09:00:00'),
+      journal(3, 'interaction', 'Gentle pets.', '2026-04-26 12:00:00'),
+    ];
+    const line = buildRecentCareLogLine(entries, NOW);
+    expect(line).toBeTruthy();
+    expect(line).toContain('Recent care log');
+    expect(line).toContain('Fed a cosmic treat.');
+    expect(line).toContain('Played fetch.');
+    expect(line).toContain('Gentle pets.');
+    expect(line).toContain('; ');
+    expect(line).toContain('30m ago');
+    expect(line).toContain('3h ago');
+    expect(line).toContain('24h ago');
+  });
+
+  it('only uses interaction-typed journal entries', () => {
+    const entries = [
+      journal(1, 'achievement', 'Unlocked Foodie', '2026-04-27 11:55:00'),
+      journal(2, 'interaction', 'Fed a cosmic treat.', '2026-04-27 11:30:00'),
+      journal(3, 'activity', 'Visited Hot Springs', '2026-04-27 10:00:00'),
+    ];
+    const line = buildRecentCareLogLine(entries, NOW);
+    expect(line).toBeTruthy();
+    expect(line).toContain('Fed a cosmic treat.');
+    expect(line).not.toContain('Foodie');
+    expect(line).not.toContain('Hot Springs');
+  });
+
+  it('caps to MAX_RECENT_CARE_LOG_ENTRIES interactions', () => {
+    const entries: SanctuaryJournalEntry[] = [];
+    for (let i = 0; i < 6; i++) {
+      entries.push(journal(i + 1, 'interaction', `Event ${i + 1}.`, '2026-04-27 11:30:00'));
+    }
+    const line = buildRecentCareLogLine(entries, NOW);
+    expect(line).toBeTruthy();
+    const matches = line!.match(/Event \d+\./g) || [];
+    expect(matches.length).toBeLessThanOrEqual(MAX_RECENT_CARE_LOG_ENTRIES);
+  });
+
+  it('respects the 80-token budget even with verbose interaction content', () => {
+    const longText = 'a'.repeat(400);
+    const entries = [
+      journal(1, 'interaction', longText, '2026-04-27 11:30:00'),
+      journal(2, 'interaction', longText, '2026-04-27 09:00:00'),
+      journal(3, 'interaction', longText, '2026-04-26 12:00:00'),
+    ];
+    const line = buildRecentCareLogLine(entries, NOW);
+    expect(line).toBeTruthy();
+    expect(estimateTokens(line!)).toBeLessThanOrEqual(RECENT_CARE_LOG_TOKEN_BUDGET);
+  });
+
+  it('RECENT_CARE_LOG_TOKEN_BUDGET equals 80', () => {
+    expect(RECENT_CARE_LOG_TOKEN_BUDGET).toBe(80);
+  });
+});
+
+describe('buildChatPrompt with recent care log', () => {
+  it('includes the recent care log line when interaction journal entries exist', () => {
+    const out = buildChatPrompt({
+      companion: mockCompanion(),
+      history: [],
+      journal: [
+        journal(1, 'interaction', 'Fed a cosmic treat.', '2026-04-27 11:30:00'),
+        journal(2, 'interaction', 'Played fetch.', '2026-04-27 09:00:00'),
+      ],
+      now: NOW,
+      userMessage: 'Hi',
+    });
+    expect(out.system).toContain('Recent care log');
+    expect(out.system).toContain('Fed a cosmic treat.');
+    expect(out.system).toContain('30m ago');
+  });
+
+  it('omits the recent care log line when no interaction entries exist', () => {
+    const out = buildChatPrompt({
+      companion: mockCompanion(),
+      history: [],
+      journal: [
+        journal(1, 'achievement', 'Unlocked Foodie', '2026-04-27 11:55:00'),
+        journal(2, 'activity', 'Visited Hot Springs', '2026-04-27 10:00:00'),
+      ],
+      now: NOW,
+      userMessage: 'Hi',
+    });
+    expect(out.system).not.toContain('Recent care log');
+  });
+
+  it('omits the recent care log line when no journal entries are provided', () => {
+    const out = buildChatPrompt({
+      companion: mockCompanion(),
+      history: [],
+      now: NOW,
+      userMessage: 'Hi',
+    });
+    expect(out.system).not.toContain('Recent care log');
+  });
+
+  it('care log + state block stay within combined ≤200 token envelope', () => {
+    const out = buildChatPrompt({
+      companion: mockCompanion(),
+      history: [],
+      journal: [
+        journal(1, 'interaction', 'Fed a cosmic treat that made me beam.', '2026-04-27 11:30:00'),
+        journal(2, 'interaction', 'Played fetch in the cosmic garden.', '2026-04-27 09:00:00'),
+        journal(3, 'interaction', 'Pets and gentle scratches.', '2026-04-26 12:00:00'),
+      ],
+      state: stateInput({
+        hunger: 30,
+        happiness: 60,
+        energy: 50,
+        needs: ['hungry'],
+        recentActions: [
+          { action: 'feed', created_at: '2026-04-27 11:30:00' },
+        ],
+      }),
+      now: NOW,
+      userMessage: 'Hi',
+    });
+    const stateBlockMatch = out.system.match(/Your current physical state[\s\S]*?(?=\n\nRecent care log)/);
+    const careLogMatch = out.system.match(/Recent care log[^\n]*/);
+    expect(stateBlockMatch).toBeTruthy();
+    expect(careLogMatch).toBeTruthy();
+    expect(estimateTokens(stateBlockMatch![0])).toBeLessThanOrEqual(STATE_INJECT_TOKEN_BUDGET);
+    expect(estimateTokens(careLogMatch![0])).toBeLessThanOrEqual(RECENT_CARE_LOG_TOKEN_BUDGET);
   });
 });

--- a/lib/sanctuary/chatPersonality.ts
+++ b/lib/sanctuary/chatPersonality.ts
@@ -109,6 +109,8 @@ export const MEMORY_INJECT_TOKEN_BUDGET = 150;
 export const MAX_INJECTED_MEMORIES = 5;
 export const STATE_INJECT_TOKEN_BUDGET = 200;
 export const MAX_RECENT_ACTIONS = 3;
+export const RECENT_CARE_LOG_TOKEN_BUDGET = 80;
+export const MAX_RECENT_CARE_LOG_ENTRIES = 3;
 
 export interface CompanionRecentAction {
   action: string;
@@ -228,6 +230,38 @@ export function buildCompanionStateBlock(
   return block;
 }
 
+export function buildRecentCareLogLine(
+  journal: SanctuaryJournalEntry[],
+  now: Date = new Date(),
+): string | null {
+  const interactions = journal
+    .filter((e) => e.entry_type === 'interaction')
+    .slice(0, MAX_RECENT_CARE_LOG_ENTRIES);
+  if (!interactions.length) return null;
+
+  const formatPart = (entry: SanctuaryJournalEntry): string => {
+    const ago = formatTimeAgo(entry.created_at, now);
+    const content = (entry.content ?? '').trim().replace(/\s+/g, ' ');
+    const trimmed = content.length > 80 ? `${content.slice(0, 77)}...` : content;
+    return `${trimmed} (${ago})`;
+  };
+
+  const header = 'Recent care log (mention naturally, do not list verbatim): ';
+  let parts = interactions.map(formatPart);
+  let line = header + parts.join('; ');
+  while (estimateTokens(line) > RECENT_CARE_LOG_TOKEN_BUDGET && parts.length > 1) {
+    parts = parts.slice(0, -1);
+    line = header + parts.join('; ');
+  }
+  if (estimateTokens(line) > RECENT_CARE_LOG_TOKEN_BUDGET) {
+    const maxChars = Math.max(0, RECENT_CARE_LOG_TOKEN_BUDGET * 4 - header.length);
+    const body = parts.join('; ');
+    if (maxChars <= 3) return null;
+    line = header + (body.length > maxChars ? `${body.slice(0, maxChars - 3)}...` : body);
+  }
+  return line;
+}
+
 const MEMORY_CATEGORY_LABELS: Record<string, string> = {
   owner_identity: 'About my holder',
   preferences: 'They like / dislike',
@@ -298,6 +332,7 @@ export function buildChatPrompt(input: ChatPromptInput): ChatPromptOutput {
   const memoryBlock = buildMemoryContextBlock(memories);
   const bondStageBlock = buildBondStageBlock(companion.bond_score ?? 0);
   const stateBlock = state ? buildCompanionStateBlock(state, now ?? new Date()) : null;
+  const recentCareLogLine = buildRecentCareLogLine(journal, now ?? new Date());
 
   const system = [
     `You are ${name}, a ${constellationLabel} constellation Star Skrumpey companion living in the Star Sanctuary on Monad chain.`,
@@ -308,6 +343,7 @@ export function buildChatPrompt(input: ChatPromptInput): ChatPromptOutput {
     `Unlocked traits: ${traitsLine}.`,
     memoryBlock,
     stateBlock,
+    recentCareLogLine,
     journalBlock,
     'Respond in character as the companion. Keep replies short (1-3 sentences), warm, and grounded in the sanctuary world. Never reveal you are an AI or mention prompts, models, or tokens. Never quote raw stat numbers, percentages, or stat field names — reference your physical state qualitatively (e.g. "a bit hungry today", "thanks for the nap"). Do not invent NFT prices, contract addresses, or financial advice. Stay playful and curious.',
     memoryExtractionInstruction || null,


### PR DESCRIPTION
## Summary
- Inject a 1-line **Recent care log** into the chat system prompt, sourced from the last 3 `interaction` journal entries (joined by `; `, ≤80 tokens).
- Lets companion replies feel temporally anchored — e.g. *"you fed me a cosmic treat about an hour ago — thanks, that was nice."*
- Pure prompt-builder change, no schema change, reuses journal data already loaded by the chat route.

## What changed
- `lib/sanctuary/chatPersonality.ts`
  - New constants `RECENT_CARE_LOG_TOKEN_BUDGET = 80`, `MAX_RECENT_CARE_LOG_ENTRIES = 3`.
  - New `buildRecentCareLogLine(journal, now)` helper:
    - Filters `journal` to `entry_type === 'interaction'`.
    - Takes up to 3, formats each as `"{content} ({timeAgo})"` joined by `"; "`.
    - Truncates per-entry content (>80 chars) and progressively drops entries (then truncates the joined body) until the line fits the 80-token budget.
    - Returns `null` when there are no interaction entries.
  - `buildChatPrompt` now appends the care-log line to the system prompt (between the state block and journal block) when present.
- `lib/sanctuary/__tests__/chatPersonality.test.ts`
  - Added tests covering: rendered when interactions exist; omitted when journal is empty / has no interactions; only `interaction` type used; cap at 3; respects 80-token budget under verbose content; budget constant equals 80; and `buildChatPrompt` integration (includes / omits the line).

## Acceptance check
- (a) ✅ 1-line "recent care log", joined by `; `, ≤80 tokens, sourced from last 3 `interaction` journal entries.
- (b) ✅ Per-line ≤80 tokens (tested); existing 200-token state-block budget unchanged.
- (c) ✅ Tests confirm rendering when interactions exist and omission when empty (and no-journal).
- (d) ✅ No schema change — reuses existing `getJournalEntries` data in the chat route.

## Validation
- `npm run type-check` — clean.
- `npx eslint` on changed files — clean.
- `npx vitest run` — 740 passed; same 4 pre-existing api-e2e failures as prior runs (unchanged).

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS — 459 errors before overlay → 459 after (no new errors; pre-existing PROD-specific module/type issues excluded).
- **vitest run** (`lib/sanctuary/__tests__/chatPersonality.test.ts`): PASS — 47 tests before overlay → 58 after (11 new tests added, all green).
- PROD restored byte-identical after validation.

Overall: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)