### PR TITLE
feat(sanctuary v2): time-of-day greeting prefix [SWO_V2_COMPANION_TIME_OF_DAY_GREETING]

### DIFF
--- a/app/sanctuary/CompanionView.tsx
+++ b/app/sanctuary/CompanionView.tsx
@@ -9,6 +9,7 @@ import { describeNeeds, lowStats, type NeedStats } from '@/lib/sanctuary/needs';
 import {
   greetingForMood,
   lastVisitedPhrase,
+  timeOfDayPrefix,
   type CozyMood,
 } from '@/lib/sanctuary/companionGreeting';
 import { MOOD_EMOJI } from '@/components/sanctuary/overlays/CompanionHUD';
@@ -558,6 +559,7 @@ export default function CompanionView() {
     effectiveMood as CozyMood,
     isSleeping,
   );
+  const timePrefix = timeOfDayPrefix(new Date().getHours());
   // Prefer the local "page-open" marker over `stats_updated_at` whenever it
   // is fresher, so the cozy line refreshes on every open even when the
   // player just lurks without interacting.
@@ -575,6 +577,9 @@ export default function CompanionView() {
         >
           {displayName.toUpperCase()}
         </h1>
+        <p className="text-[#88ccff] text-[10px] italic px-4 leading-snug">
+          {timePrefix}
+        </p>
         <p className="text-[#bb88ff] text-[10px] italic px-4 leading-snug">
           {greeting}
         </p>

--- a/lib/sanctuary/__tests__/companionGreeting.test.ts
+++ b/lib/sanctuary/__tests__/companionGreeting.test.ts
@@ -5,6 +5,7 @@ import {
   greetingForMood,
   journalLineForAction,
   lastVisitedPhrase,
+  timeOfDayPrefix,
   type CozyAction,
   type CozyMood,
 } from '../companionGreeting';
@@ -134,6 +135,64 @@ describe('lastVisitedPhrase', () => {
     ];
     for (const s of samples) {
       expect(s).not.toMatch(/abandon|forgot|neglect|left/i);
+    }
+  });
+});
+
+describe('timeOfDayPrefix', () => {
+  it('returns the morning line for 5–11 (band: morning)', () => {
+    expect(timeOfDayPrefix(5)).toBe('Good morning.');
+    expect(timeOfDayPrefix(8)).toBe('Good morning.');
+    expect(timeOfDayPrefix(11)).toBe('Good morning.');
+  });
+
+  it('returns the afternoon line for 12–16 (band: afternoon)', () => {
+    expect(timeOfDayPrefix(12)).toBe('Good afternoon.');
+    expect(timeOfDayPrefix(14)).toBe('Good afternoon.');
+    expect(timeOfDayPrefix(16)).toBe('Good afternoon.');
+  });
+
+  it('returns the evening line for 17–21 (band: evening)', () => {
+    expect(timeOfDayPrefix(17)).toBe('Evening, friend.');
+    expect(timeOfDayPrefix(19)).toBe('Evening, friend.');
+    expect(timeOfDayPrefix(21)).toBe('Evening, friend.');
+  });
+
+  it('returns the late-night line for 22–04 (band: late-night), wrapping past midnight', () => {
+    expect(timeOfDayPrefix(22)).toBe('Up late?');
+    expect(timeOfDayPrefix(23)).toBe('Up late?');
+    expect(timeOfDayPrefix(0)).toBe('Up late?');
+    expect(timeOfDayPrefix(2)).toBe('Up late?');
+    expect(timeOfDayPrefix(4)).toBe('Up late?');
+  });
+
+  it('normalizes out-of-range or non-finite hours instead of throwing', () => {
+    expect(() => timeOfDayPrefix(-7)).not.toThrow();
+    expect(() => timeOfDayPrefix(99)).not.toThrow();
+    // -7 wraps to 17 → evening
+    expect(timeOfDayPrefix(-7)).toBe('Evening, friend.');
+    // 99 wraps to 3 → late-night
+    expect(timeOfDayPrefix(99)).toBe('Up late?');
+    // NaN coerces to 0 → late-night
+    expect(timeOfDayPrefix(Number.NaN)).toBe('Up late?');
+  });
+
+  it('never returns the empty string for any hour 0–23', () => {
+    for (let h = 0; h < 24; h++) {
+      const line = timeOfDayPrefix(h);
+      expect(line.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('partitions every hour 0–23 into one of the four band lines', () => {
+    const allowed = new Set([
+      'Good morning.',
+      'Good afternoon.',
+      'Evening, friend.',
+      'Up late?',
+    ]);
+    for (let h = 0; h < 24; h++) {
+      expect(allowed.has(timeOfDayPrefix(h))).toBe(true);
     }
   });
 });

--- a/lib/sanctuary/companionGreeting.ts
+++ b/lib/sanctuary/companionGreeting.ts
@@ -2,12 +2,15 @@
  * Cozy/tamagotchi-voice helpers for the dedicated Companion screen
  * (`[SWO_V2_COMPANION_COZY_POLISH]`).
  *
- * Three pure helpers, no DB / Phaser / React imports so they can be
- * unit-tested in isolation and reused by CompanionView, db.ts journal
- * messages, and any future cozy surface (mobile widget, push copy, etc.):
+ * Pure helpers, no DB / Phaser / React imports so they can be unit-tested
+ * in isolation and reused by CompanionView, db.ts journal messages, and
+ * any future cozy surface (mobile widget, push copy, etc.):
  *
  *   - greetingForMood(name, mood, isSleeping) → cozy one-liner the
  *     companion says back at you on screen-mount or mood-change.
+ *   - timeOfDayPrefix(hour) → short "Good morning." / "Evening, friend." /
+ *     "Up late?" framing line that the Companion header stacks above the
+ *     mood line. Operator-local hour from `Date#getHours()`.
  *   - lastVisitedPhrase(stats_updated_at, now) → soft, non-punishing
  *     time-since-last-tend phrase ("you just popped in" / "they missed
  *     you"). Always reassuring; never scolding.
@@ -96,6 +99,30 @@ export function greetingForMood(
   const pool = GREETINGS_BY_MOOD[effectiveMood] ?? GREETINGS_BY_MOOD.idle;
   const line = pool[Math.abs(hashString(name) + dayKey) % pool.length];
   return (line ?? GREETINGS_BY_MOOD.idle[0]).replace(/\{name\}/g, name);
+}
+
+/**
+ * Short time-of-day framing phrase the Companion header stacks ABOVE the
+ * mood greeting (it never replaces it). Operator-local: pass
+ * `new Date().getHours()` from a client component.
+ *
+ * Bands:
+ *   -   5 ≤ h < 12  → "Good morning."
+ *   -  12 ≤ h < 17  → "Good afternoon."
+ *   -  17 ≤ h < 22  → "Evening, friend."
+ *   -  22 ≤ h or h < 5 → "Up late?"
+ *
+ * Out-of-range or non-finite `hour` normalizes via `((h % 24) + 24) % 24`,
+ * matching journalLineForAction's wrap so callers can pass any number
+ * without throwing. Returns a non-empty string for every input.
+ */
+export function timeOfDayPrefix(hour: number): string {
+  const safe = Number.isFinite(hour) ? hour : 0;
+  const h = (((Math.trunc(safe) % 24) + 24) % 24);
+  if (h >= 5 && h < 12) return 'Good morning.';
+  if (h >= 12 && h < 17) return 'Good afternoon.';
+  if (h >= 17 && h < 22) return 'Evening, friend.';
+  return 'Up late?';
 }
 
 /**


### PR DESCRIPTION
## Summary
Adds a thin time-of-day framing line above the cozy mood greeting on the Companion header. Operator-local hour (from `Date#getHours()`), so it reflects the viewer's clock instead of UTC.

- New peer helper `timeOfDayPrefix(hour: number): string` in `lib/sanctuary/companionGreeting.ts`
  - `5–11` → `Good morning.`
  - `12–16` → `Good afternoon.`
  - `17–21` → `Evening, friend.`
  - `22–04` → `Up late?` (wraps past midnight)
  - Out-of-range / non-finite hours normalize via `((h % 24) + 24) % 24` instead of throwing.
- `CompanionView` renders the prefix as its own `<p>` directly above the existing mood line. The mood greeting is **never replaced** — it just stacks under the new line, satisfying acceptance (b).
- 7 new vitest cases (≥1 per band, plus normalization, non-empty, and partition checks) — total 32 cases across the file.
- No API change to `greetingForMood` / `lastVisitedPhrase` / `journalLineForAction`. Pure additive.

## Acceptance mapping
- (a) peer helper accepts an `hour` parameter and prepends a short time-of-day line — `timeOfDayPrefix(hour)` ✅
- (b) prefix never replaces the mood line, only stacks above — separate `<p>` element above the existing one ✅
- (c) ≥4 vitest cases covering each time-of-day band — morning / afternoon / evening / late-night each have an explicit case, plus 3 robustness cases ✅
- (d) no API change — only additions; existing exports unchanged ✅

## Test plan
- [x] `npm run type-check` — clean
- [x] `npx eslint` on changed files — clean
- [x] `npx vitest run lib/sanctuary/__tests__/companionGreeting.test.ts` — 32/32 passing
- [x] Full `npx vitest run` — 747 passed, 4 pre-existing api-e2e failures unchanged

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS (459 pre-existing errors, 459 after overlay → 0 new)
- **vitest run**: PASS (4 pre-existing failures, 4 after overlay → 0 new; 729 → 736 passing reflects the +7 new tests)
Overall: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)