### PR TITLE
feat(sanctuary v2): cozy pixel-art chrome for companion shell

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2987,3 +2987,101 @@ a,
     linear-gradient(0deg, rgba(153, 102, 255, 0.4) 1px, transparent 1px);
   background-size: 25% 33.33%;
 }
+
+/* ============================================
+   Sanctuary v2 — Companion Chrome (SWO_V2_RD_COMPANION_CHROME_BATCH_2)
+   Hand-authored 9-slice frame set + decorative ornaments living at
+   /public/sanctuary/ui/chrome/. See manifest.json there for prompt/seed
+   traceability so RD-generated PNG drop-ins can replace these later.
+   ============================================ */
+
+.chrome-panel,
+.chrome-panel--active,
+.chrome-panel--muted {
+  position: relative;
+  border-style: solid;
+  border-width: 8px;
+  border-color: transparent;
+  border-image-slice: 8 fill;
+  border-image-width: 8px;
+  border-image-repeat: repeat;
+  background-clip: padding-box;
+  /* The SVG's middle slice is opaque #0d0a1c, so it serves as the panel
+     background once `border-image-slice: 8 fill` is applied. */
+}
+
+.chrome-panel {
+  border-image-source: url('/sanctuary/ui/chrome/panel_frame.svg');
+}
+.chrome-panel--active {
+  border-image-source: url('/sanctuary/ui/chrome/panel_frame_active.svg');
+}
+.chrome-panel--muted {
+  border-image-source: url('/sanctuary/ui/chrome/panel_frame_muted.svg');
+}
+
+.chrome-button {
+  position: relative;
+  border-style: solid;
+  border-width: 4px;
+  border-color: transparent;
+  border-image-source: url('/sanctuary/ui/chrome/button_outline.svg');
+  border-image-slice: 4;
+  border-image-width: 4px;
+  border-image-repeat: stretch;
+  background-clip: padding-box;
+}
+
+.chrome-button:focus-visible {
+  outline: none;
+  border-image-source: url('/sanctuary/ui/chrome/focus_ring.svg');
+  border-image-slice: 6;
+  border-image-width: 6px;
+  border-width: 6px;
+}
+
+/* Decorative corner ornaments — purely cosmetic, pointer-events: none.
+   Use as siblings inside a chromed panel (e.g. <span className="chrome-flourish-a"/>). */
+.chrome-flourish-a,
+.chrome-flourish-b {
+  position: absolute;
+  width: 16px;
+  height: 16px;
+  pointer-events: none;
+  background-repeat: no-repeat;
+  background-size: contain;
+  image-rendering: pixelated;
+}
+.chrome-flourish-a {
+  top: 2px;
+  left: 2px;
+  background-image: url('/sanctuary/ui/chrome/corner_flourish_a.svg');
+}
+.chrome-flourish-b {
+  bottom: 2px;
+  right: 2px;
+  background-image: url('/sanctuary/ui/chrome/corner_flourish_b.svg');
+}
+
+/* Tileable horizontal dust strip — used as a soft divider above headings. */
+.chrome-dust {
+  display: block;
+  height: 8px;
+  background-image: url('/sanctuary/ui/chrome/dust_motif.svg');
+  background-repeat: repeat-x;
+  background-size: 32px 8px;
+  image-rendering: pixelated;
+  opacity: 0.85;
+  pointer-events: none;
+}
+
+/* Reduced-motion fallback: the chrome itself has no animation, but make
+   sure decorative pieces stay visible (not faded out by other rules). */
+@media (prefers-reduced-motion: reduce) {
+  .chrome-flourish-a,
+  .chrome-flourish-b,
+  .chrome-dust {
+    animation: none !important;
+    opacity: 0.85;
+  }
+}

--- a/app/sanctuary/CompanionView.tsx
+++ b/app/sanctuary/CompanionView.tsx
@@ -591,7 +591,11 @@ export default function CompanionView() {
 
       <div className="grid md:grid-cols-2 gap-6">
         {/* Sprite + needs */}
-        <div className="pixel-card p-6 space-y-4">
+        <div className="chrome-panel p-6 space-y-4 relative">
+          {/* Cozy pixel-art corner flourishes (decorative). See
+              public/sanctuary/ui/chrome/manifest.json. */}
+          <span className="chrome-flourish-a" aria-hidden="true" />
+          <span className="chrome-flourish-b" aria-hidden="true" />
           <div className="flex justify-center">
             <div className="relative">
               {/* Cozy ambient: a few twinkling stars behind the sprite. Pure
@@ -777,6 +781,7 @@ export default function CompanionView() {
         {/* Actions + Journal */}
         <div className="space-y-4">
           <div className="pixel-card p-4 space-y-3">
+            <span className="chrome-dust" aria-hidden="true" />
             <h2 className="text-[#ffd700] text-[10px] tracking-wider font-['Press_Start_2P']">
               QUICK ACTIONS
             </h2>
@@ -790,13 +795,13 @@ export default function CompanionView() {
                     disabled={interacting !== null}
                     aria-label={muted ? `${a.label} (sleeping)` : a.label}
                     title={muted ? 'Companion is sleeping — wait until they wake' : a.label}
-                    className={`flex flex-col items-center justify-center gap-1 py-3 rounded-lg border-2 transition-all
+                    className={`chrome-button flex flex-col items-center justify-center gap-1 py-3 transition-all
                       ${
                         interacting === a.id
-                          ? 'border-[#ffd700] bg-[#ffd700]/10 shadow-[0_0_10px_rgba(255,215,0,0.3)]'
+                          ? 'bg-[#ffd700]/10 shadow-[0_0_10px_rgba(255,215,0,0.3)]'
                           : muted
-                            ? 'border-[#2a2a4e]/40 bg-[#0a0a15]/40 opacity-50'
-                            : 'border-[#2a2a4e] bg-[#0a0a15] hover:border-[#9966ff]/60 hover:bg-[#1a0f3a]/40'
+                            ? 'bg-[#0a0a15]/40 opacity-50'
+                            : 'bg-[#0a0a15] hover:bg-[#1a0f3a]/40'
                       }
                       disabled:opacity-50 disabled:cursor-not-allowed
                     `}

--- a/public/sanctuary/ui/chrome/button_outline.svg
+++ b/public/sanctuary/ui/chrome/button_outline.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" shape-rendering="crispEdges" image-rendering="pixelated">
+  <!--
+    Action button outline (9-slice). Slice=4, width=4.
+    Cozy purple hairline with chamfered corners.
+  -->
+  <rect width="16" height="16" fill="none"/>
+  <!-- chamfered corners -->
+  <rect x="1" y="0" width="14" height="1" fill="#5a4a8e"/>
+  <rect x="1" y="15" width="14" height="1" fill="#5a4a8e"/>
+  <rect x="0" y="1" width="1" height="14" fill="#5a4a8e"/>
+  <rect x="15" y="1" width="1" height="14" fill="#5a4a8e"/>
+  <!-- inner soft shadow -->
+  <rect x="1" y="1" width="14" height="1" fill="#7e6ab8"/>
+  <rect x="1" y="14" width="14" height="1" fill="#2a1f4a"/>
+  <rect x="1" y="2" width="1" height="12" fill="#7e6ab8"/>
+  <rect x="14" y="2" width="1" height="12" fill="#2a1f4a"/>
+  <!-- corner accents -->
+  <rect x="1" y="1" width="1" height="1" fill="#bb88ff"/>
+  <rect x="14" y="14" width="1" height="1" fill="#bb88ff"/>
+  <!-- transparent core -->
+  <rect x="2" y="2" width="12" height="12" fill="none"/>
+</svg>

--- a/public/sanctuary/ui/chrome/corner_flourish_a.svg
+++ b/public/sanctuary/ui/chrome/corner_flourish_a.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" shape-rendering="crispEdges" image-rendering="pixelated">
+  <!--
+    Decorative top-left corner flourish: small star with a curl tail.
+    Use as ::before/::after on chromed panels. Mirror via transform: scaleX(-1).
+  -->
+  <rect width="16" height="16" fill="none"/>
+  <!-- star core -->
+  <g fill="#ffd070">
+    <rect x="3" y="2" width="2" height="2"/>
+    <rect x="2" y="3" width="1" height="1"/>
+    <rect x="5" y="3" width="1" height="1"/>
+    <rect x="3" y="5" width="2" height="1"/>
+  </g>
+  <!-- bright star center -->
+  <rect x="3" y="3" width="2" height="2" fill="#fff2c0"/>
+  <!-- curl tail toward inside -->
+  <g fill="#9966ff">
+    <rect x="6" y="4" width="1" height="1"/>
+    <rect x="7" y="5" width="1" height="1"/>
+    <rect x="8" y="6" width="1" height="1"/>
+    <rect x="9" y="7" width="1" height="1"/>
+  </g>
+  <!-- soft dust pixels -->
+  <g fill="#bb88ff" opacity="0.7">
+    <rect x="11" y="9" width="1" height="1"/>
+    <rect x="13" y="11" width="1" height="1"/>
+    <rect x="10" y="12" width="1" height="1"/>
+  </g>
+</svg>

--- a/public/sanctuary/ui/chrome/corner_flourish_b.svg
+++ b/public/sanctuary/ui/chrome/corner_flourish_b.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" shape-rendering="crispEdges" image-rendering="pixelated">
+  <!--
+    Decorative bottom-right flourish: pink heart-spark with crescent.
+    Pairs with corner_flourish_a.svg. Use ::after on chromed panels.
+  -->
+  <rect width="16" height="16" fill="none"/>
+  <!-- crescent moon (cozy) -->
+  <g fill="#bb88ff">
+    <rect x="9" y="9" width="3" height="1"/>
+    <rect x="8" y="10" width="1" height="3"/>
+    <rect x="9" y="13" width="3" height="1"/>
+    <rect x="12" y="10" width="1" height="3"/>
+  </g>
+  <rect x="11" y="11" width="1" height="1" fill="#ffd070"/>
+  <!-- spark cluster -->
+  <g fill="#ffd070">
+    <rect x="3" y="11" width="1" height="1"/>
+    <rect x="2" y="12" width="1" height="1"/>
+    <rect x="4" y="12" width="1" height="1"/>
+    <rect x="3" y="13" width="1" height="1"/>
+  </g>
+  <!-- dust pixels -->
+  <g fill="#88e0ff" opacity="0.7">
+    <rect x="6" y="6" width="1" height="1"/>
+    <rect x="2" y="8" width="1" height="1"/>
+    <rect x="6" y="13" width="1" height="1"/>
+  </g>
+</svg>

--- a/public/sanctuary/ui/chrome/dust_motif.svg
+++ b/public/sanctuary/ui/chrome/dust_motif.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="8" viewBox="0 0 32 8" shape-rendering="crispEdges" image-rendering="pixelated">
+  <!--
+    Horizontal dust/star motif. Used as a decorative divider strip
+    (background-image, repeat-x) inside or above a chromed panel.
+  -->
+  <rect width="32" height="8" fill="none"/>
+  <g fill="#ffd070">
+    <rect x="2" y="3" width="1" height="1"/>
+    <rect x="1" y="4" width="3" height="1"/>
+    <rect x="2" y="5" width="1" height="1"/>
+  </g>
+  <g fill="#bb88ff">
+    <rect x="9" y="2" width="1" height="1"/>
+    <rect x="8" y="3" width="3" height="1"/>
+    <rect x="9" y="4" width="1" height="1"/>
+  </g>
+  <rect x="15" y="3" width="2" height="2" fill="#fff2c0"/>
+  <g fill="#88e0ff">
+    <rect x="22" y="3" width="1" height="1"/>
+    <rect x="21" y="4" width="3" height="1"/>
+    <rect x="22" y="5" width="1" height="1"/>
+  </g>
+  <g fill="#ff99cc">
+    <rect x="28" y="2" width="1" height="1"/>
+    <rect x="27" y="3" width="3" height="1"/>
+    <rect x="28" y="4" width="1" height="1"/>
+  </g>
+</svg>

--- a/public/sanctuary/ui/chrome/focus_ring.svg
+++ b/public/sanctuary/ui/chrome/focus_ring.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" shape-rendering="crispEdges" image-rendering="pixelated">
+  <!--
+    Focus ring ornament. Drawn around a focused button via background-image
+    on a wrapper or :focus-visible pseudo. 9-slice with corner star ornaments.
+    Slice=6, width=6.
+  -->
+  <rect width="20" height="20" fill="none"/>
+  <!-- ring outline (gold) -->
+  <rect x="2" y="0" width="16" height="1" fill="#ffd070"/>
+  <rect x="2" y="19" width="16" height="1" fill="#ffd070"/>
+  <rect x="0" y="2" width="1" height="16" fill="#ffd070"/>
+  <rect x="19" y="2" width="1" height="16" fill="#ffd070"/>
+  <!-- corner stars (4-pixel cross) -->
+  <g fill="#fff2c0">
+    <!-- top-left star -->
+    <rect x="1" y="0" width="1" height="1"/>
+    <rect x="0" y="1" width="1" height="1"/>
+    <rect x="2" y="1" width="1" height="1"/>
+    <rect x="1" y="2" width="1" height="1"/>
+    <!-- top-right star -->
+    <rect x="18" y="0" width="1" height="1"/>
+    <rect x="17" y="1" width="1" height="1"/>
+    <rect x="19" y="1" width="1" height="1"/>
+    <rect x="18" y="2" width="1" height="1"/>
+    <!-- bottom-left -->
+    <rect x="1" y="17" width="1" height="1"/>
+    <rect x="0" y="18" width="1" height="1"/>
+    <rect x="2" y="18" width="1" height="1"/>
+    <rect x="1" y="19" width="1" height="1"/>
+    <!-- bottom-right -->
+    <rect x="18" y="17" width="1" height="1"/>
+    <rect x="17" y="18" width="1" height="1"/>
+    <rect x="19" y="18" width="1" height="1"/>
+    <rect x="18" y="19" width="1" height="1"/>
+  </g>
+</svg>

--- a/public/sanctuary/ui/chrome/manifest.json
+++ b/public/sanctuary/ui/chrome/manifest.json
@@ -1,0 +1,124 @@
+{
+  "$schema": "./manifest.schema.json",
+  "version": 1,
+  "scope": "sanctuary-v2",
+  "task": "SWO_V2_RD_COMPANION_CHROME_BATCH_2",
+  "generated_at": "2026-05-08",
+  "notes": [
+    "Cozy pixel-art interface chrome for the Sanctuary companion shell.",
+    "Assets are hand-authored SVGs (palette- and grid-compliant) so the chrome ships without an RD_API_KEY in CI.",
+    "Each entry below preserves the prompt + seed intent so future RD regenerations can produce a matching PNG/Aseprite drop-in without code changes — swap the file path on the same logical name and retain dimensions.",
+    "Palette anchors: deep #0d0a1c / #1a1430 backgrounds; warm #4a3a7e / #ffd070 frames; pink #ff99cc + cyan #88e0ff dust accents. Matches docs/SANCTUARY_STYLE_DOCTRINE.md."
+  ],
+  "rd_style": {
+    "model": "RD_FAST",
+    "prompt_style": "retro",
+    "size": 256,
+    "n": 1,
+    "negative_prompt": "blurry, photorealistic, smooth gradient, banding, text, watermark"
+  },
+  "assets": [
+    {
+      "name": "panel_frame",
+      "path": "panel_frame.svg",
+      "kind": "9-slice",
+      "dimensions": { "w": 24, "h": 24 },
+      "border_image_slice": 8,
+      "border_image_width": 8,
+      "intent": "Base panel frame — neutral cozy purple with gold corner studs.",
+      "prompt": "A cozy pixel-art ornate panel frame, warm purple stone with tiny gold corner gemstones, soft inner shadow, transparent center, dungeon-fantasy UI, Stardew/Tamagotchi aesthetic, perfectly tileable edges.",
+      "seed": 4711201,
+      "palette": ["#0d0a1c", "#1a1430", "#2a1f4a", "#3a2a6a", "#4a3a7e", "#7e6ab8", "#ffd070", "#fff2c0"]
+    },
+    {
+      "name": "panel_frame_active",
+      "path": "panel_frame_active.svg",
+      "kind": "9-slice",
+      "dimensions": { "w": 24, "h": 24 },
+      "border_image_slice": 8,
+      "border_image_width": 8,
+      "intent": "Active/selected panel — warm gold tones, used when a panel is the player's focus.",
+      "prompt": "Same cozy pixel-art panel frame as panel_frame, but glowing brighter gold-amber, like lantern-lit oak; transparent center; tileable.",
+      "seed": 4711202,
+      "palette": ["#0d0a1c", "#2a1d10", "#4a3018", "#7a5a2a", "#b88940", "#ffd070", "#fff2a0", "#ffe080"]
+    },
+    {
+      "name": "panel_frame_muted",
+      "path": "panel_frame_muted.svg",
+      "kind": "9-slice",
+      "dimensions": { "w": 24, "h": 24 },
+      "border_image_slice": 8,
+      "border_image_width": 8,
+      "intent": "Muted/disabled panel — desaturated indigo, low contrast.",
+      "prompt": "Same panel geometry as panel_frame but desaturated cool indigo, dim corner studs, soft and quiet, transparent center, tileable.",
+      "seed": 4711203,
+      "palette": ["#0d0a1c", "#10131e", "#1a1d2e", "#252a3e", "#3a4060", "#5a6080"]
+    },
+    {
+      "name": "button_outline",
+      "path": "button_outline.svg",
+      "kind": "9-slice",
+      "dimensions": { "w": 16, "h": 16 },
+      "border_image_slice": 4,
+      "border_image_width": 4,
+      "intent": "Outline for action buttons (feed/pet/talk/sleep/play). Replaces flat 2px border.",
+      "prompt": "A cozy pixel-art button outline, chamfered corners, faint highlight on top-left and shadow on bottom-right, lavender accent pixels in opposite corners, tileable, transparent center.",
+      "seed": 4711204,
+      "palette": ["#2a1f4a", "#5a4a8e", "#7e6ab8", "#bb88ff"]
+    },
+    {
+      "name": "focus_ring",
+      "path": "focus_ring.svg",
+      "kind": "9-slice",
+      "dimensions": { "w": 20, "h": 20 },
+      "border_image_slice": 6,
+      "border_image_width": 6,
+      "intent": ":focus-visible ornament for buttons — gold rim with 4-pixel corner stars.",
+      "prompt": "A cozy pixel-art focus ring, slim warm-gold rim, four 4-pixel cross stars at the corners, tileable, transparent center.",
+      "seed": 4711205,
+      "palette": ["#ffd070", "#fff2c0"]
+    },
+    {
+      "name": "corner_flourish_a",
+      "path": "corner_flourish_a.svg",
+      "kind": "decoration",
+      "dimensions": { "w": 16, "h": 16 },
+      "intent": "Top-left flourish: small gold star with a purple curl tail and dust pixels.",
+      "prompt": "Tiny pixel-art ornament, golden 4-point star with a soft lavender ribbon curling inward, faint dust sparkles, transparent background, sized for a 16x16 corner accent.",
+      "seed": 4711206,
+      "palette": ["#9966ff", "#bb88ff", "#ffd070", "#fff2c0"]
+    },
+    {
+      "name": "corner_flourish_b",
+      "path": "corner_flourish_b.svg",
+      "kind": "decoration",
+      "dimensions": { "w": 16, "h": 16 },
+      "intent": "Bottom-right flourish: lavender crescent with gold sparkle and cyan dust. Pairs with corner_flourish_a.",
+      "prompt": "Tiny pixel-art ornament, lavender crescent moon with a single gold sparkle and faint cyan dust pixels, transparent, sized for a 16x16 corner accent.",
+      "seed": 4711207,
+      "palette": ["#88e0ff", "#bb88ff", "#ffd070"]
+    },
+    {
+      "name": "dust_motif",
+      "path": "dust_motif.svg",
+      "kind": "decoration",
+      "dimensions": { "w": 32, "h": 8 },
+      "intent": "Tileable horizontal dust strip — used as a divider above panel headings.",
+      "prompt": "A horizontal pixel-art dust strip with five tiny stars in gold, lavender, white, cyan, and pink, evenly spaced, repeats seamlessly, transparent background.",
+      "seed": 4711208,
+      "palette": ["#88e0ff", "#bb88ff", "#ffd070", "#fff2c0", "#ff99cc"]
+    }
+  ],
+  "integration": {
+    "css_classes": [
+      ".chrome-panel — applies panel_frame.svg via border-image",
+      ".chrome-panel--active — applies panel_frame_active.svg",
+      ".chrome-panel--muted — applies panel_frame_muted.svg",
+      ".chrome-button — applies button_outline.svg via border-image; focus_ring.svg shown on :focus-visible",
+      ".chrome-flourish-a / .chrome-flourish-b — corner ornaments",
+      ".chrome-dust — repeating horizontal dust divider"
+    ],
+    "consumed_by": ["app/sanctuary/CompanionView.tsx"],
+    "reduced_motion": "Decorative ornaments are static; no chrome class introduces motion. The existing prefers-reduced-motion rule in app/globals.css already neutralizes residual animation. Frames remain readable when motion is disabled."
+  }
+}

--- a/public/sanctuary/ui/chrome/panel_frame.svg
+++ b/public/sanctuary/ui/chrome/panel_frame.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" shape-rendering="crispEdges" image-rendering="pixelated">
+  <!--
+    Sanctuary cozy panel frame (base, 9-slice).
+    Designed for CSS border-image with slice=8 width=8.
+    Corners (8x8) are fixed; edges (8x4 strips) tile.
+    Palette: pixel doctrine (warm purple, gold spark, soft inner shade).
+  -->
+  <!-- transparent middle so content shows through -->
+  <rect width="24" height="24" fill="none"/>
+
+  <!-- outer dark rim -->
+  <rect x="0" y="1" width="24" height="22" fill="#1a1430"/>
+  <rect x="1" y="0" width="22" height="24" fill="#1a1430"/>
+
+  <!-- main frame body -->
+  <rect x="1" y="1" width="22" height="22" fill="#2a1f4a"/>
+  <rect x="2" y="2" width="20" height="20" fill="#3a2a6a"/>
+  <rect x="3" y="3" width="18" height="18" fill="#4a3a7e"/>
+
+  <!-- inner shadow line -->
+  <rect x="4" y="4" width="16" height="16" fill="#2a1f4a"/>
+  <!-- inner content cutout (so border-image edges remain hollow) -->
+  <rect x="5" y="5" width="14" height="14" fill="#0d0a1c"/>
+
+  <!-- gold corner studs (cozy lantern feel) -->
+  <rect x="2" y="2" width="2" height="2" fill="#ffd070"/>
+  <rect x="20" y="2" width="2" height="2" fill="#ffd070"/>
+  <rect x="2" y="20" width="2" height="2" fill="#ffd070"/>
+  <rect x="20" y="20" width="2" height="2" fill="#ffd070"/>
+
+  <!-- subtle highlight pixels on top/left for hand-painted lift -->
+  <rect x="3" y="2" width="1" height="1" fill="#7e6ab8"/>
+  <rect x="2" y="3" width="1" height="1" fill="#7e6ab8"/>
+  <rect x="20" y="2" width="1" height="1" fill="#fff2c0"/>
+  <rect x="2" y="20" width="1" height="1" fill="#fff2c0"/>
+</svg>

--- a/public/sanctuary/ui/chrome/panel_frame_active.svg
+++ b/public/sanctuary/ui/chrome/panel_frame_active.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" shape-rendering="crispEdges" image-rendering="pixelated">
+  <!--
+    Active variant: brighter gold tones for selected/focused panels.
+    Same 9-slice geometry as panel_frame.svg.
+  -->
+  <rect width="24" height="24" fill="none"/>
+  <rect x="0" y="1" width="24" height="22" fill="#2a1d10"/>
+  <rect x="1" y="0" width="22" height="24" fill="#2a1d10"/>
+  <rect x="1" y="1" width="22" height="22" fill="#4a3018"/>
+  <rect x="2" y="2" width="20" height="20" fill="#7a5a2a"/>
+  <rect x="3" y="3" width="18" height="18" fill="#b88940"/>
+  <rect x="4" y="4" width="16" height="16" fill="#5a3a18"/>
+  <rect x="5" y="5" width="14" height="14" fill="#0d0a1c"/>
+  <!-- bright gold corner studs -->
+  <rect x="2" y="2" width="2" height="2" fill="#fff2a0"/>
+  <rect x="20" y="2" width="2" height="2" fill="#fff2a0"/>
+  <rect x="2" y="20" width="2" height="2" fill="#fff2a0"/>
+  <rect x="20" y="20" width="2" height="2" fill="#fff2a0"/>
+  <!-- highlight pixels -->
+  <rect x="3" y="2" width="1" height="1" fill="#ffe080"/>
+  <rect x="2" y="3" width="1" height="1" fill="#ffe080"/>
+</svg>

--- a/public/sanctuary/ui/chrome/panel_frame_muted.svg
+++ b/public/sanctuary/ui/chrome/panel_frame_muted.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" shape-rendering="crispEdges" image-rendering="pixelated">
+  <!--
+    Muted variant: cooler, low-contrast for disabled/quiet panels.
+    Same 9-slice geometry as panel_frame.svg.
+  -->
+  <rect width="24" height="24" fill="none"/>
+  <rect x="0" y="1" width="24" height="22" fill="#10131e"/>
+  <rect x="1" y="0" width="22" height="24" fill="#10131e"/>
+  <rect x="1" y="1" width="22" height="22" fill="#1a1d2e"/>
+  <rect x="2" y="2" width="20" height="20" fill="#252a3e"/>
+  <rect x="3" y="3" width="18" height="18" fill="#3a4060"/>
+  <rect x="4" y="4" width="16" height="16" fill="#1a1d2e"/>
+  <rect x="5" y="5" width="14" height="14" fill="#0d0a1c"/>
+  <!-- dim corner studs -->
+  <rect x="2" y="2" width="2" height="2" fill="#5a6080"/>
+  <rect x="20" y="2" width="2" height="2" fill="#5a6080"/>
+  <rect x="2" y="20" width="2" height="2" fill="#5a6080"/>
+  <rect x="20" y="20" width="2" height="2" fill="#5a6080"/>
+</svg>


### PR DESCRIPTION
## Summary
- Adds a reusable cozy pixel-art chrome system under `public/sanctuary/ui/chrome/`: `panel_frame`/`_active`/`_muted` (9-slice), `button_outline`, `focus_ring`, two corner flourishes and a tileable dust motif — all hand-authored SVGs, palette-compliant with `docs/SANCTUARY_STYLE_DOCTRINE.md`.
- `manifest.json` carries prompt + seed + dimensions for every asset, so an RD-rendered PNG drop-in can replace any SVG later without code changes (RD_API_KEY isn't present in this CI environment, so the SVGs ship as the cozy baseline).
- `CompanionView.tsx` now consumes the chrome: the sprite/needs panel uses `.chrome-panel` with paired corner flourishes, action buttons use `.chrome-button` (gold `focus_ring` ornament on `:focus-visible`) instead of flat 2px borders, and a `.chrome-dust` divider sits above `QUICK ACTIONS`. Other panels keep `pixel-card` so the visual change is targeted to the focal areas.

## Acceptance criteria
- (a) Reusable 9-slice frame set + button outline + focus ring + 2 corner flourishes + dust motif: ✅
- (b) Assets at `public/sanctuary/ui/chrome/` with manifest + prompt/seed traceability: ✅ (`manifest.json`)
- (c) `CompanionView.tsx` consumes chrome instead of pure CSS borders where appropriate: ✅ (sprite panel + action buttons + dust divider)
- (d) Reduced-motion / low-clutter fallback remains readable: ✅ — chrome itself has zero animation; existing `@media (prefers-reduced-motion: reduce)` rule continues to work; an explicit rule in `globals.css` keeps decorative pieces visible (no fade-out) under reduced motion
- (e) Visual calmness vs baseline: replacing flat `border-[#2a2a4e]` borders with hand-painted purple+gold studs and adding cozy corner flourishes/dust gives the shell a tamagotchi/storybook feel rather than dev-UI flatness. Manual screenshot review still recommended.

## RD note
`RD_API_KEY` was not available in this run, so the chrome ships as palette-compliant SVGs rather than RD-rendered PNGs. The manifest preserves the prompt, seed, palette, and slice geometry for each asset, so a future regeneration via `scripts/v3/generate.mjs` (or similar) can drop PNGs into the same paths and the CSS picks them up unchanged.

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS — 459 errors before overlay, 459 errors after overlay → 0 NEW errors (pre-existing errors are unrelated: missing `colyseus.js`/`howler` modules, PlayerSpriteV3 type drift, etc.)
- **vitest run**: PASS — 740 tests pass; 4 pre-existing api-e2e failures unchanged (same as recent merged PRs #280/#281/#282)

Overall: PASS

## Test plan
- [ ] Open `/sanctuary` with a connected wallet & active companion: the sprite/needs card now has the painted purple+gold frame with star/curl flourishes in the top-left and a crescent in the bottom-right.
- [ ] Hover/focus an action button: outline tightens; tab-focus shows the gold focus-ring ornament with corner stars.
- [ ] Toggle `prefers-reduced-motion` (e.g. via DevTools): chrome remains crisp and readable; no animations introduced.
- [ ] Verify other Sanctuary cards (Journal/Chat/Quick Actions header) still render with `pixel-card` styling — no regression to unrelated panels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)