### PR TITLE
feat(sanctuary v2): polished companion action interactables [SWO_V2_COMPANION_INTERACTABLES_POLISH]

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3085,3 +3085,279 @@ a,
     opacity: 0.85;
   }
 }
+
+/* ============================================
+   Sanctuary v2 — Companion Action Interactables
+   (SWO_V2_COMPANION_INTERACTABLES_POLISH)
+   One language for the action grid. Variant classes are emitted by
+   `companionActionVariantClasses()` so the React tree only needs to drop
+   the resolved class onto the button.
+   ============================================ */
+
+.companion-action-button {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  min-height: 64px;
+  padding: 10px 8px 8px;
+  background-color: #14102a;
+  color: #ffd29c;
+  cursor: pointer;
+  /* Tactile: layered inset highlight + drop shadow gives buttons a real
+     "rest" depth before they're pressed. */
+  box-shadow:
+    inset 0 1px 0 rgba(255, 215, 152, 0.18),
+    inset 0 -2px 0 rgba(0, 0, 0, 0.45),
+    0 2px 0 rgba(0, 0, 0, 0.55);
+  transform: translateY(0);
+  transition:
+    transform 90ms cubic-bezier(0.4, 0, 0.2, 1),
+    box-shadow 90ms cubic-bezier(0.4, 0, 0.2, 1),
+    background-color 160ms ease,
+    color 160ms ease;
+}
+
+.companion-action-button__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: inherit;
+}
+
+.companion-action-button__label {
+  font-size: 8px;
+  letter-spacing: 0.06em;
+  color: #d8c8ff;
+  text-transform: uppercase;
+}
+
+.companion-action-button__badge {
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  min-width: 18px;
+  padding: 1px 4px;
+  font-size: 7px;
+  background: #2a1f4a;
+  color: #ffd700;
+  border: 1px solid #5a4a8e;
+  border-radius: 3px;
+  text-align: center;
+  letter-spacing: 0.04em;
+  pointer-events: none;
+  box-shadow: 0 2px 0 rgba(0, 0, 0, 0.55);
+}
+
+/* Hover lift — kept subtle so the chrome border still reads as the hero. */
+.companion-action-button.companion-action--idle:hover,
+.companion-action-button.companion-action--selected:hover {
+  background-color: #1c1640;
+  color: #ffe2b2;
+  transform: translateY(-1px);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 215, 152, 0.28),
+    inset 0 -2px 0 rgba(0, 0, 0, 0.45),
+    0 3px 0 rgba(0, 0, 0, 0.55),
+    0 0 12px rgba(187, 136, 255, 0.25);
+}
+
+/* Tactile press — both :active for pointer and the resolved `pressed`
+   state for in-flight requests. */
+.companion-action-button.companion-action--idle:active,
+.companion-action-button.companion-action--selected:active,
+.companion-action-button.companion-action--pressed {
+  transform: translateY(2px);
+  box-shadow:
+    inset 0 2px 4px rgba(0, 0, 0, 0.55),
+    inset 0 -1px 0 rgba(255, 215, 152, 0.05),
+    0 0 0 rgba(0, 0, 0, 0);
+  background-color: #2a1f55;
+  color: #ffd700;
+}
+
+.companion-action-button.companion-action--pressed {
+  /* Working state pulse — gentle so it reads as in-progress, not error. */
+  animation: companion-action-pulse 1100ms ease-in-out infinite;
+}
+
+@keyframes companion-action-pulse {
+  0%, 100% {
+    box-shadow:
+      inset 0 2px 4px rgba(0, 0, 0, 0.55),
+      0 0 8px rgba(255, 215, 0, 0.25);
+  }
+  50% {
+    box-shadow:
+      inset 0 2px 4px rgba(0, 0, 0, 0.55),
+      0 0 14px rgba(255, 215, 0, 0.45);
+  }
+}
+
+/* Selected — caller-driven highlight (not used by interact today, but
+   reserved so future "active action" affordances share the language). */
+.companion-action-button.companion-action--selected {
+  background-color: #1f173d;
+  color: #ffe2b2;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 215, 152, 0.32),
+    inset 0 -2px 0 rgba(0, 0, 0, 0.45),
+    0 0 0 2px rgba(255, 215, 0, 0.45),
+    0 2px 0 rgba(0, 0, 0, 0.55);
+}
+
+/* Disabled (another action in flight) — preserve cozy palette so the
+   button doesn't read as broken; just clearly unactionable. */
+.companion-action-button.companion-action--disabled {
+  cursor: not-allowed;
+  background-color: #14102a;
+  color: #6f6896;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 215, 152, 0.06),
+    inset 0 -2px 0 rgba(0, 0, 0, 0.45),
+    0 1px 0 rgba(0, 0, 0, 0.55);
+  opacity: 0.65;
+}
+.companion-action-button.companion-action--disabled .companion-action-button__label {
+  color: #6f6896;
+}
+
+/* Sleeping — warm dusk tint so "wait" reads as cozy, not "broken". */
+.companion-action-button.companion-action--sleeping {
+  cursor: not-allowed;
+  background-color: #1a1830;
+  color: #5e7ba8;
+  box-shadow:
+    inset 0 1px 0 rgba(102, 204, 255, 0.12),
+    inset 0 -2px 0 rgba(0, 0, 0, 0.45),
+    0 1px 0 rgba(0, 0, 0, 0.55);
+  opacity: 0.78;
+}
+.companion-action-button.companion-action--sleeping .companion-action-button__label {
+  color: #5e7ba8;
+}
+.companion-action-button.companion-action--sleeping .companion-action-button__badge {
+  background: #14182c;
+  color: #88ccff;
+  border-color: #3a4a7e;
+}
+
+/* Cooldown — same shape as sleeping, but warm rather than cool. */
+.companion-action-button.companion-action--cooldown {
+  cursor: not-allowed;
+  background-color: #1c1428;
+  color: #c79a72;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 153, 68, 0.16),
+    inset 0 -2px 0 rgba(0, 0, 0, 0.45),
+    0 1px 0 rgba(0, 0, 0, 0.55);
+  opacity: 0.82;
+}
+.companion-action-button.companion-action--cooldown .companion-action-button__label {
+  color: #c79a72;
+}
+.companion-action-button.companion-action--cooldown .companion-action-button__badge {
+  background: #2a1812;
+  color: #ff9944;
+  border-color: #6a3a1e;
+}
+
+/* Focus ring — relies on the existing chrome-button focus image, plus a
+   warm glow halo so keyboard nav stays visible on dark backgrounds. */
+.companion-action-button:focus-visible {
+  outline: none;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 215, 152, 0.28),
+    inset 0 -2px 0 rgba(0, 0, 0, 0.45),
+    0 0 0 2px rgba(255, 215, 0, 0.65),
+    0 0 16px rgba(255, 215, 0, 0.35);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .companion-action-button {
+    transition: none !important;
+  }
+  .companion-action-button.companion-action--pressed {
+    animation: none !important;
+  }
+}
+
+/* ============================================
+   Companion micro-badges / chips — one outline language for level,
+   training, bond, mood, and other inline pills on the companion surface.
+   ============================================ */
+
+.companion-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 6px;
+  font-size: 8px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  border: 1px solid;
+  border-radius: 3px;
+  background: #14102a;
+  color: #d8c8ff;
+  border-color: #3a2f5e;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 215, 152, 0.08),
+    0 1px 0 rgba(0, 0, 0, 0.45);
+  white-space: nowrap;
+}
+
+.companion-chip--compact {
+  padding: 2px 4px;
+  font-size: 7px;
+  gap: 3px;
+}
+
+.companion-chip__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.companion-chip__label {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 2px;
+}
+
+.companion-chip--neutral {
+  color: #d8c8ff;
+  border-color: #3a2f5e;
+  background: #14102a;
+}
+
+.companion-chip--gold {
+  color: #ffd700;
+  border-color: #6a5a1e;
+  background: #1c1610;
+}
+
+.companion-chip--pink {
+  color: #ff99cc;
+  border-color: #6a2a4a;
+  background: #1c0f1c;
+}
+
+.companion-chip--cyan {
+  color: #88ccff;
+  border-color: #2a4a7e;
+  background: #0f1c2a;
+}
+
+.companion-chip--purple {
+  color: #bb88ff;
+  border-color: #4a2a8e;
+  background: #1a0f2c;
+}
+
+.companion-chip--warm {
+  color: #ff9944;
+  border-color: #6a3a1e;
+  background: #1c1410;
+}

--- a/app/sanctuary/CompanionView.tsx
+++ b/app/sanctuary/CompanionView.tsx
@@ -13,6 +13,9 @@ import {
   type CozyMood,
 } from '@/lib/sanctuary/companionGreeting';
 import { MOOD_EMOJI } from '@/components/sanctuary/overlays/CompanionHUD';
+import CompanionActionButton from '@/components/sanctuary/CompanionActionButton';
+import CompanionChip from '@/components/sanctuary/CompanionChip';
+import { COMPANION_ACTIONS } from '@/lib/sanctuary/companionAction';
 import EventBus from '@/components/sanctuary/EventBus';
 import { emitCompanionVfx } from '@/lib/sanctuary/vfxEvents';
 import {
@@ -84,14 +87,6 @@ interface ChatLine {
 }
 
 type QuickAction = 'feed' | 'pet' | 'talk' | 'sleep' | 'play';
-
-const ACTIONS: { id: QuickAction; icon: string; label: string }[] = [
-  { id: 'feed', icon: '🍎', label: 'Feed' },
-  { id: 'pet', icon: '🐾', label: 'Pet' },
-  { id: 'talk', icon: '💬', label: 'Talk' },
-  { id: 'sleep', icon: '💤', label: 'Sleep' },
-  { id: 'play', icon: '🎾', label: 'Play' },
-];
 
 const NEED_LABEL: Record<'hunger' | 'happiness' | 'energy', string> = {
   hunger: 'Hungry — feed me!',
@@ -583,10 +578,17 @@ export default function CompanionView() {
         <p className="text-[#bb88ff] text-[10px] italic px-4 leading-snug">
           {greeting}
         </p>
-        <p className="text-gray-400 text-[10px]">
-          Lv.{companion.level} · Training {companion.companion_level} · Bond{' '}
-          {Math.round(companion.bond_score)}
-        </p>
+        <div className="flex flex-wrap items-center justify-center gap-2 pt-1">
+          <CompanionChip tone="gold" compact>
+            Lv {companion.level}
+          </CompanionChip>
+          <CompanionChip tone="purple" compact>
+            Training {companion.companion_level}
+          </CompanionChip>
+          <CompanionChip tone="pink" compact>
+            Bond {Math.round(companion.bond_score)}
+          </CompanionChip>
+        </div>
         {lastVisit && (
           <p className="text-gray-500 text-[8px]">
             {lastVisit}
@@ -791,35 +793,16 @@ export default function CompanionView() {
               QUICK ACTIONS
             </h2>
             <div className="grid grid-cols-3 gap-2">
-              {ACTIONS.map((a) => {
-                const muted = isSleeping && a.id !== 'sleep';
-                return (
-                  <button
-                    key={a.id}
-                    onClick={() => handleAction(a.id)}
-                    disabled={interacting !== null}
-                    aria-label={muted ? `${a.label} (sleeping)` : a.label}
-                    title={muted ? 'Companion is sleeping — wait until they wake' : a.label}
-                    className={`chrome-button flex flex-col items-center justify-center gap-1 py-3 transition-all
-                      ${
-                        interacting === a.id
-                          ? 'bg-[#ffd700]/10 shadow-[0_0_10px_rgba(255,215,0,0.3)]'
-                          : muted
-                            ? 'bg-[#0a0a15]/40 opacity-50'
-                            : 'bg-[#0a0a15] hover:bg-[#1a0f3a]/40'
-                      }
-                      disabled:opacity-50 disabled:cursor-not-allowed
-                    `}
-                  >
-                    <span className="text-xl leading-none">
-                      {interacting === a.id ? '⏳' : a.icon}
-                    </span>
-                    <span className="text-[7px] text-gray-300 font-['Press_Start_2P']">
-                      {a.label}
-                    </span>
-                  </button>
-                );
-              })}
+              {COMPANION_ACTIONS.map((a) => (
+                <CompanionActionButton
+                  key={a.id}
+                  action={a.id}
+                  label={a.label}
+                  busy={interacting}
+                  isSleeping={isSleeping}
+                  onActivate={handleAction}
+                />
+              ))}
             </div>
             {feedback && (
               <p

--- a/components/sanctuary/CompanionActionButton.tsx
+++ b/components/sanctuary/CompanionActionButton.tsx
@@ -1,0 +1,91 @@
+// [SWO_V2_COMPANION_INTERACTABLES_POLISH]
+// Shared interactable for the companion surface. One component renders
+// every variant (idle / hover / pressed / disabled / sleeping / cooldown /
+// selected) so the variant story lives in one place rather than scattered
+// across each call site.
+
+'use client';
+
+import type { CSSProperties, ReactNode } from 'react';
+import {
+  resolveCompanionActionState,
+  companionActionVariantClasses,
+  type CompanionActionId,
+} from '@/lib/sanctuary/companionAction';
+import { CompanionActionIcon } from './CompanionActionIcon';
+
+export interface CompanionActionButtonProps {
+  action: CompanionActionId;
+  label: string;
+  busy: CompanionActionId | null;
+  isSleeping: boolean;
+  cooldownSeconds?: number;
+  isSelected?: boolean;
+  onActivate: (action: CompanionActionId) => void;
+  /** Override the default pixel-art icon. Used by tests / future asset swaps. */
+  iconSlot?: ReactNode;
+  /** Override the default cooldown / sleeping badge. */
+  badgeSlot?: ReactNode;
+  className?: string;
+  style?: CSSProperties;
+}
+
+export default function CompanionActionButton({
+  action,
+  label,
+  busy,
+  isSleeping,
+  cooldownSeconds,
+  isSelected,
+  onActivate,
+  iconSlot,
+  badgeSlot,
+  className = '',
+  style,
+}: CompanionActionButtonProps) {
+  const resolved = resolveCompanionActionState({
+    action,
+    busy,
+    isSleeping,
+    cooldownSeconds,
+    isSelected,
+  });
+
+  const variantClass = companionActionVariantClasses(resolved.state);
+  const working = resolved.state === 'pressed';
+
+  return (
+    <button
+      type="button"
+      onClick={() => onActivate(action)}
+      disabled={resolved.disabled}
+      aria-label={resolved.ariaLabel}
+      title={resolved.title}
+      data-state={resolved.state}
+      data-action={action}
+      className={`companion-action-button chrome-button ${variantClass} ${className}`}
+      style={style}
+    >
+      <span className="companion-action-button__icon" aria-hidden="true">
+        {iconSlot ?? (
+          <CompanionActionIcon
+            action={action}
+            working={working}
+            size={24}
+          />
+        )}
+      </span>
+      <span className="companion-action-button__label font-['Press_Start_2P']">
+        {label}
+      </span>
+      {(badgeSlot ?? resolved.badge) ? (
+        <span
+          className="companion-action-button__badge font-['Press_Start_2P']"
+          aria-hidden="true"
+        >
+          {badgeSlot ?? resolved.badge}
+        </span>
+      ) : null}
+    </button>
+  );
+}

--- a/components/sanctuary/CompanionActionIcon.tsx
+++ b/components/sanctuary/CompanionActionIcon.tsx
@@ -1,0 +1,154 @@
+// [SWO_V2_COMPANION_INTERACTABLES_POLISH]
+// Pixel-art SVG icons for the companion action grid. Replaces the raw
+// emoji affordances we shipped pre-RD-Batch-1 — each icon renders at any
+// size while staying crisp via shape-rendering=crispEdges. Stroke colors
+// are inherited from `currentColor` so variant CSS can re-tint them.
+
+import type { ReactElement, SVGProps } from 'react';
+import type { CompanionActionId } from '@/lib/sanctuary/companionAction';
+
+type IconProps = SVGProps<SVGSVGElement> & { size?: number };
+
+function PixelSvg({ size = 24, children, ...rest }: IconProps & { children: React.ReactNode }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 16 16"
+      shapeRendering="crispEdges"
+      aria-hidden="true"
+      role="img"
+      {...rest}
+    >
+      {children}
+    </svg>
+  );
+}
+
+// 16x16 pixel apple — silhouette uses currentColor; bite + leaf use accent.
+export function FeedIcon(props: IconProps) {
+  return (
+    <PixelSvg {...props}>
+      <rect x="6" y="2" width="2" height="2" fill="#5fb15a" />
+      <rect x="8" y="3" width="2" height="2" fill="#5fb15a" />
+      <rect x="7" y="3" width="1" height="1" fill="#3a3a4e" />
+      <rect x="4" y="4" width="8" height="2" fill="currentColor" />
+      <rect x="3" y="5" width="10" height="1" fill="currentColor" />
+      <rect x="3" y="6" width="11" height="6" fill="currentColor" />
+      <rect x="4" y="12" width="9" height="1" fill="currentColor" />
+      <rect x="5" y="13" width="7" height="1" fill="currentColor" />
+      <rect x="6" y="6" width="2" height="2" fill="#fff5e0" opacity="0.55" />
+    </PixelSvg>
+  );
+}
+
+// 16x16 paw print — pad + 3 toe beans, all in currentColor.
+export function PetIcon(props: IconProps) {
+  return (
+    <PixelSvg {...props}>
+      {/* Toe beans */}
+      <rect x="3" y="4" width="2" height="3" fill="currentColor" />
+      <rect x="6" y="2" width="2" height="3" fill="currentColor" />
+      <rect x="9" y="2" width="2" height="3" fill="currentColor" />
+      <rect x="12" y="4" width="2" height="3" fill="currentColor" />
+      {/* Main pad */}
+      <rect x="5" y="8" width="6" height="4" fill="currentColor" />
+      <rect x="4" y="9" width="8" height="2" fill="currentColor" />
+      <rect x="6" y="12" width="4" height="1" fill="currentColor" />
+    </PixelSvg>
+  );
+}
+
+// 16x16 speech bubble.
+export function TalkIcon(props: IconProps) {
+  return (
+    <PixelSvg {...props}>
+      <rect x="2" y="3" width="12" height="8" fill="currentColor" />
+      <rect x="3" y="2" width="10" height="1" fill="currentColor" />
+      <rect x="3" y="11" width="10" height="1" fill="currentColor" />
+      <rect x="5" y="11" width="2" height="2" fill="currentColor" />
+      <rect x="5" y="13" width="1" height="1" fill="currentColor" />
+      {/* dots */}
+      <rect x="5" y="6" width="1" height="2" fill="#0a0a15" />
+      <rect x="8" y="6" width="1" height="2" fill="#0a0a15" />
+      <rect x="11" y="6" width="1" height="2" fill="#0a0a15" />
+    </PixelSvg>
+  );
+}
+
+// 16x16 crescent moon.
+export function SleepIcon(props: IconProps) {
+  return (
+    <PixelSvg {...props}>
+      <rect x="6" y="2" width="6" height="2" fill="currentColor" />
+      <rect x="4" y="3" width="2" height="2" fill="currentColor" />
+      <rect x="3" y="5" width="2" height="6" fill="currentColor" />
+      <rect x="4" y="11" width="2" height="2" fill="currentColor" />
+      <rect x="6" y="13" width="6" height="1" fill="currentColor" />
+      {/* Cut-out for crescent shape */}
+      <rect x="7" y="4" width="6" height="2" fill="#0a0a15" />
+      <rect x="6" y="6" width="6" height="6" fill="#0a0a15" />
+      <rect x="7" y="12" width="5" height="1" fill="#0a0a15" />
+      {/* zZz mark */}
+      <rect x="11" y="3" width="2" height="1" fill="#88ccff" />
+      <rect x="12" y="4" width="1" height="1" fill="#88ccff" />
+      <rect x="11" y="5" width="2" height="1" fill="#88ccff" />
+    </PixelSvg>
+  );
+}
+
+// 16x16 pixel ball — concentric panels suggesting a baseball/play orb.
+export function PlayIcon(props: IconProps) {
+  return (
+    <PixelSvg {...props}>
+      <rect x="5" y="2" width="6" height="1" fill="currentColor" />
+      <rect x="3" y="3" width="10" height="1" fill="currentColor" />
+      <rect x="2" y="4" width="12" height="8" fill="currentColor" />
+      <rect x="3" y="12" width="10" height="1" fill="currentColor" />
+      <rect x="5" y="13" width="6" height="1" fill="currentColor" />
+      {/* seams */}
+      <rect x="4" y="5" width="1" height="6" fill="#0a0a15" opacity="0.7" />
+      <rect x="11" y="5" width="1" height="6" fill="#0a0a15" opacity="0.7" />
+      <rect x="6" y="4" width="1" height="1" fill="#0a0a15" opacity="0.5" />
+      <rect x="9" y="4" width="1" height="1" fill="#0a0a15" opacity="0.5" />
+      <rect x="6" y="11" width="1" height="1" fill="#0a0a15" opacity="0.5" />
+      <rect x="9" y="11" width="1" height="1" fill="#0a0a15" opacity="0.5" />
+    </PixelSvg>
+  );
+}
+
+// 16x16 hourglass — used for the "pressed/working" state instead of ⏳.
+export function WorkingIcon(props: IconProps) {
+  return (
+    <PixelSvg {...props}>
+      <rect x="3" y="2" width="10" height="1" fill="currentColor" />
+      <rect x="3" y="13" width="10" height="1" fill="currentColor" />
+      <rect x="4" y="3" width="8" height="1" fill="currentColor" />
+      <rect x="5" y="4" width="6" height="1" fill="currentColor" />
+      <rect x="6" y="5" width="4" height="1" fill="currentColor" />
+      <rect x="7" y="6" width="2" height="2" fill="currentColor" />
+      <rect x="6" y="8" width="4" height="1" fill="currentColor" />
+      <rect x="5" y="9" width="6" height="1" fill="currentColor" />
+      <rect x="4" y="10" width="8" height="1" fill="currentColor" />
+      <rect x="3" y="11" width="10" height="2" fill="currentColor" />
+    </PixelSvg>
+  );
+}
+
+const ICON_BY_ACTION: Record<CompanionActionId, (p: IconProps) => ReactElement> = {
+  feed: FeedIcon,
+  pet: PetIcon,
+  talk: TalkIcon,
+  sleep: SleepIcon,
+  play: PlayIcon,
+};
+
+export function CompanionActionIcon({
+  action,
+  working,
+  size = 24,
+  ...rest
+}: IconProps & { action: CompanionActionId; working?: boolean }) {
+  const Icon = working ? WorkingIcon : ICON_BY_ACTION[action];
+  return <Icon size={size} {...rest} />;
+}

--- a/components/sanctuary/CompanionChip.tsx
+++ b/components/sanctuary/CompanionChip.tsx
@@ -1,0 +1,50 @@
+// [SWO_V2_COMPANION_INTERACTABLES_POLISH]
+// One outline-and-highlight language for the small text affordances on the
+// companion surface (level pill, training pill, bond pill, mood pill).
+// Centralises the cozy 1px border + warm-tinted background so individual
+// call sites can't drift into ad-hoc styling.
+
+import type { ReactNode } from 'react';
+
+export type CompanionChipTone = 'neutral' | 'gold' | 'pink' | 'cyan' | 'purple' | 'warm';
+
+const TONE_CLASS: Record<CompanionChipTone, string> = {
+  neutral: 'companion-chip--neutral',
+  gold: 'companion-chip--gold',
+  pink: 'companion-chip--pink',
+  cyan: 'companion-chip--cyan',
+  purple: 'companion-chip--purple',
+  warm: 'companion-chip--warm',
+};
+
+export interface CompanionChipProps {
+  tone?: CompanionChipTone;
+  icon?: ReactNode;
+  children: ReactNode;
+  /** Renders an extra-small hit-target pill for inline use. */
+  compact?: boolean;
+  className?: string;
+}
+
+export default function CompanionChip({
+  tone = 'neutral',
+  icon,
+  children,
+  compact = false,
+  className = '',
+}: CompanionChipProps) {
+  return (
+    <span
+      className={`companion-chip ${TONE_CLASS[tone]} ${
+        compact ? 'companion-chip--compact' : ''
+      } font-['Press_Start_2P'] ${className}`}
+    >
+      {icon ? (
+        <span className="companion-chip__icon" aria-hidden="true">
+          {icon}
+        </span>
+      ) : null}
+      <span className="companion-chip__label">{children}</span>
+    </span>
+  );
+}

--- a/lib/sanctuary/__tests__/companionAction.test.ts
+++ b/lib/sanctuary/__tests__/companionAction.test.ts
@@ -1,0 +1,187 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+
+import {
+  resolveCompanionActionState,
+  companionActionVariantClasses,
+  formatCooldownBadge,
+  COMPANION_ACTIONS,
+  type CompanionActionId,
+  type CompanionActionState,
+} from '../companionAction';
+
+const baseInput = (override: Partial<Parameters<typeof resolveCompanionActionState>[0]> = {}) => ({
+  action: 'feed' as CompanionActionId,
+  busy: null,
+  isSleeping: false,
+  ...override,
+});
+
+describe('COMPANION_ACTIONS metadata', () => {
+  it('exposes the canonical 5-action lineup with no raw-emoji labels', () => {
+    expect(COMPANION_ACTIONS.map((a) => a.id)).toEqual([
+      'feed',
+      'pet',
+      'talk',
+      'sleep',
+      'play',
+    ]);
+    // Labels must be plain text — emoji as the *primary* affordance lives
+    // in the SVG icon slot, not in the label string. This regression test
+    // protects the post-RD-Batch-1 invariant.
+    for (const a of COMPANION_ACTIONS) {
+      expect(a.label).toMatch(/^[A-Za-z][A-Za-z\s'-]*$/);
+      expect(a.blockedHint.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('resolveCompanionActionState — idle', () => {
+  it('returns idle/disabled=false when nothing else is happening', () => {
+    const r = resolveCompanionActionState(baseInput());
+    expect(r.state).toBe<CompanionActionState>('idle');
+    expect(r.disabled).toBe(false);
+    expect(r.badge).toBeNull();
+    expect(r.ariaLabel).toBe('Feed');
+    expect(r.title).toBe('Feed');
+  });
+});
+
+describe('resolveCompanionActionState — pressed', () => {
+  it('returns pressed/disabled=true when this action is the busy one', () => {
+    const r = resolveCompanionActionState(baseInput({ busy: 'feed' }));
+    expect(r.state).toBe<CompanionActionState>('pressed');
+    expect(r.disabled).toBe(true);
+    expect(r.title).toContain('working');
+  });
+});
+
+describe('resolveCompanionActionState — disabled by sibling', () => {
+  it('marks disabled when ANOTHER action is currently dispatching', () => {
+    const r = resolveCompanionActionState(baseInput({ busy: 'pet' }));
+    expect(r.state).toBe<CompanionActionState>('disabled');
+    expect(r.disabled).toBe(true);
+    expect(r.title.toLowerCase()).toContain('progress');
+  });
+});
+
+describe('resolveCompanionActionState — sleeping', () => {
+  it('marks non-sleep actions as sleeping when companion is asleep', () => {
+    const r = resolveCompanionActionState(
+      baseInput({ action: 'feed', isSleeping: true }),
+    );
+    expect(r.state).toBe<CompanionActionState>('sleeping');
+    expect(r.disabled).toBe(true);
+    // 💤 codepoint as the cozy status badge (not a CTA).
+    expect(r.badge).toBe('\u{1F4A4}');
+    expect(r.ariaLabel.toLowerCase()).toContain('sleeping');
+  });
+
+  it('does NOT block the sleep action while sleeping (still cozy idle)', () => {
+    const r = resolveCompanionActionState(
+      baseInput({ action: 'sleep', isSleeping: true }),
+    );
+    // Already-asleep edge: sleep button stays idle so the callsite can
+    // present a "they're already dreaming" hint via its own copy.
+    expect(r.state).toBe<CompanionActionState>('idle');
+    expect(r.disabled).toBe(false);
+  });
+});
+
+describe('resolveCompanionActionState — cooldown', () => {
+  it('renders cooldown variant + compact "12s" badge when cooldown > 0', () => {
+    const r = resolveCompanionActionState(
+      baseInput({ cooldownSeconds: 12 }),
+    );
+    expect(r.state).toBe<CompanionActionState>('cooldown');
+    expect(r.disabled).toBe(true);
+    expect(r.badge).toBe('12s');
+  });
+
+  it('clamps fractional / negative cooldowns and falls back to idle on 0', () => {
+    expect(
+      resolveCompanionActionState(baseInput({ cooldownSeconds: 0 })).state,
+    ).toBe('idle');
+    expect(
+      resolveCompanionActionState(baseInput({ cooldownSeconds: -3 })).state,
+    ).toBe('idle');
+    expect(
+      resolveCompanionActionState(baseInput({ cooldownSeconds: 12.7 })).badge,
+    ).toBe('12s');
+  });
+});
+
+describe('resolveCompanionActionState — selected', () => {
+  it('returns selected when caller asks AND nothing else is preempting', () => {
+    const r = resolveCompanionActionState(baseInput({ isSelected: true }));
+    expect(r.state).toBe<CompanionActionState>('selected');
+    expect(r.disabled).toBe(false);
+  });
+
+  it('selected loses to pressed/disabled/sleeping/cooldown precedence', () => {
+    expect(
+      resolveCompanionActionState(
+        baseInput({ isSelected: true, busy: 'feed' }),
+      ).state,
+    ).toBe('pressed');
+    expect(
+      resolveCompanionActionState(
+        baseInput({ isSelected: true, busy: 'pet' }),
+      ).state,
+    ).toBe('disabled');
+    expect(
+      resolveCompanionActionState(
+        baseInput({ isSelected: true, isSleeping: true }),
+      ).state,
+    ).toBe('sleeping');
+    expect(
+      resolveCompanionActionState(
+        baseInput({ isSelected: true, cooldownSeconds: 5 }),
+      ).state,
+    ).toBe('cooldown');
+  });
+});
+
+describe('companionActionVariantClasses', () => {
+  it('emits a unique class per variant so styling stays isolated', () => {
+    const states: CompanionActionState[] = [
+      'idle',
+      'hover',
+      'pressed',
+      'disabled',
+      'sleeping',
+      'cooldown',
+      'selected',
+    ];
+    const classes = states.map(companionActionVariantClasses);
+    expect(new Set(classes).size).toBe(states.length);
+    for (const c of classes) {
+      expect(c.startsWith('companion-action--')).toBe(true);
+    }
+  });
+});
+
+describe('formatCooldownBadge', () => {
+  it('formats seconds, minutes, and hours compactly', () => {
+    expect(formatCooldownBadge(0)).toBe('');
+    expect(formatCooldownBadge(7)).toBe('7s');
+    expect(formatCooldownBadge(59)).toBe('59s');
+    expect(formatCooldownBadge(60)).toBe('1m');
+    expect(formatCooldownBadge(3599)).toBe('59m');
+    expect(formatCooldownBadge(3600)).toBe('1h');
+    expect(formatCooldownBadge(7200)).toBe('2h');
+  });
+});
+
+describe('resolveCompanionActionState — error path', () => {
+  it('throws on an unknown action id (defensive — should never hit)', () => {
+    expect(() =>
+      resolveCompanionActionState({
+        // @ts-expect-error — intentional invalid id for the runtime guard.
+        action: 'nope',
+        busy: null,
+        isSleeping: false,
+      }),
+    ).toThrow(/Unknown companion action/);
+  });
+});

--- a/lib/sanctuary/companionAction.ts
+++ b/lib/sanctuary/companionAction.ts
@@ -1,0 +1,160 @@
+// [SWO_V2_COMPANION_INTERACTABLES_POLISH]
+// Pure helpers for companion action interactables. These are split out from
+// the React component so the variant matrix (idle / pressed / disabled /
+// sleeping / cooldown / selected) can be unit-tested in node without a DOM.
+
+export type CompanionActionId = 'feed' | 'pet' | 'talk' | 'sleep' | 'play';
+
+export type CompanionActionState =
+  | 'idle'
+  | 'hover'
+  | 'pressed'
+  | 'disabled'
+  | 'sleeping'
+  | 'cooldown'
+  | 'selected';
+
+export interface CompanionActionMeta {
+  id: CompanionActionId;
+  label: string;
+  // Cozy-tone status hint surfaced via aria-label / title when the action
+  // can't fire right now (used as the explanatory "Why can't I tap this?"
+  // line). Never user-triggered as a primary affordance.
+  blockedHint: string;
+}
+
+export const COMPANION_ACTIONS: readonly CompanionActionMeta[] = [
+  { id: 'feed', label: 'Feed', blockedHint: 'sleeping — try again on wake' },
+  { id: 'pet', label: 'Pet', blockedHint: 'sleeping — try again on wake' },
+  { id: 'talk', label: 'Talk', blockedHint: 'sleeping — try again on wake' },
+  { id: 'sleep', label: 'Sleep', blockedHint: 'already dreaming' },
+  { id: 'play', label: 'Play', blockedHint: 'sleeping — try again on wake' },
+];
+
+export interface CompanionActionInput {
+  action: CompanionActionId;
+  /** The action currently being dispatched, or `null` when idle. */
+  busy: CompanionActionId | null;
+  /** True when companion has `is_sleeping === 1`. */
+  isSleeping: boolean;
+  /** Per-action cooldown remaining, in seconds. 0 / undefined → no cooldown. */
+  cooldownSeconds?: number;
+  /** True when the consumer wants this button rendered as the selected one. */
+  isSelected?: boolean;
+}
+
+export interface CompanionActionResolved {
+  state: CompanionActionState;
+  disabled: boolean;
+  ariaLabel: string;
+  title: string;
+  /** Short text shown in the corner badge slot, e.g. "12s" or "💤". `null` → no badge. */
+  badge: string | null;
+}
+
+const ACTION_META = new Map<CompanionActionId, CompanionActionMeta>(
+  COMPANION_ACTIONS.map((m) => [m.id, m]),
+);
+
+/**
+ * Resolve the variant + a11y story for a single action button. Order of
+ * precedence (highest wins):
+ *
+ *   1. `pressed`   — this button is the one currently dispatching
+ *   2. `disabled`  — some OTHER action is currently dispatching
+ *   3. `cooldown`  — this action has a positive cooldown
+ *   4. `sleeping`  — companion is asleep and this action isn't `sleep`
+ *   5. `selected`  — caller wants this button highlighted (purely cosmetic)
+ *   6. `idle`      — default
+ *
+ * `hover` is reserved for CSS-only :hover and isn't returned here.
+ */
+export function resolveCompanionActionState(
+  input: CompanionActionInput,
+): CompanionActionResolved {
+  const meta = ACTION_META.get(input.action);
+  if (!meta) {
+    throw new Error(`Unknown companion action: ${input.action}`);
+  }
+  const cooldown = Math.max(0, Math.floor(input.cooldownSeconds ?? 0));
+  const isPressed = input.busy === input.action;
+  const isOtherBusy = input.busy !== null && input.busy !== input.action;
+  const sleepBlocks = input.isSleeping && input.action !== 'sleep';
+
+  let state: CompanionActionState;
+  let badge: string | null = null;
+  let title = meta.label;
+
+  if (isPressed) {
+    state = 'pressed';
+    title = `${meta.label} (working...)`;
+  } else if (isOtherBusy) {
+    state = 'disabled';
+    title = `${meta.label} (${input.busy} in progress)`;
+  } else if (cooldown > 0) {
+    state = 'cooldown';
+    badge = formatCooldownBadge(cooldown);
+    title = `${meta.label} (ready in ${badge})`;
+  } else if (sleepBlocks) {
+    state = 'sleeping';
+    badge = '\u{1F4A4}'; // 💤 — moon-Z, single status glyph (not a primary affordance)
+    title = `${meta.label} — ${meta.blockedHint}`;
+  } else if (input.isSelected) {
+    state = 'selected';
+  } else {
+    state = 'idle';
+  }
+
+  const disabled =
+    state === 'pressed' ||
+    state === 'disabled' ||
+    state === 'cooldown' ||
+    state === 'sleeping';
+
+  return {
+    state,
+    disabled,
+    ariaLabel: title,
+    title,
+    badge,
+  };
+}
+
+/**
+ * Compose Tailwind-ish class fragments for a button variant. Kept as a
+ * helper rather than inline ternaries so all six variants live in one
+ * legible place. Returned string never includes layout/spacing classes —
+ * those belong to the consuming component.
+ */
+export function companionActionVariantClasses(
+  state: CompanionActionState,
+): string {
+  switch (state) {
+    case 'pressed':
+      return 'companion-action--pressed';
+    case 'disabled':
+      return 'companion-action--disabled';
+    case 'cooldown':
+      return 'companion-action--cooldown';
+    case 'sleeping':
+      return 'companion-action--sleeping';
+    case 'selected':
+      return 'companion-action--selected';
+    case 'hover':
+      return 'companion-action--hover';
+    case 'idle':
+    default:
+      return 'companion-action--idle';
+  }
+}
+
+/** Round a cooldown to a compact label like "12s" / "1m" / "1h". */
+export function formatCooldownBadge(secondsRaw: number): string {
+  const seconds = Math.max(0, Math.floor(secondsRaw));
+  if (seconds <= 0) return '';
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h`;
+}


### PR DESCRIPTION
## Summary
- **Shared `CompanionActionButton`** owns every variant (idle / hover / pressed / disabled / sleeping / cooldown / selected) instead of each callsite re-implementing button states with ad-hoc Tailwind ternaries.
- **Pixel-art SVG icons** (feed / pet / talk / sleep / play / working) retire the raw-emoji affordances we shipped pre-RD-Batch-1, satisfying acceptance criterion (d): no action on the companion surface uses a raw emoji as its primary affordance.
- **Tactile feedback** — buttons now layer an inset highlight + drop shadow at rest, lift 1 px on hover, sink 2 px on `:active` and on the resolved `pressed` (in-flight) state, and gain a warm `focus-visible` glow ring.
- **Cozy disabled treatment** — disabled / sleeping / cooldown variants keep their warmth (dusk blue for sleeping, ember orange for cooldown, muted purple for sibling-busy) instead of washing out to gray.
- **`CompanionChip`** centralises one outline+highlight language for level / training / bond / mood pills.
- **13 unit tests** cover every variant, precedence ordering (pressed > disabled > cooldown > sleeping > selected > idle), the cooldown formatter (`7s` → `1m` → `1h`), and the metadata invariant that no action label contains emoji.

## Acceptance criteria
- (a) Shared component with pixel-art icon slot, label slot, optional cooldown / sleep badge, explicit pressed/hover/disabled/selected variants ✅
- (b) Tactile down-state + focus ring + readable cozy disabled treatment ✅
- (c) Stat chips / pills / micro-badges share one outline language via `CompanionChip` ✅
- (d) No raw emoji as primary affordance on the companion surface (icons are SVG; the 💤 status badge appears in a corner badge slot, not as the primary affordance) ✅
- (e) ≥6 UI tests covering all variants — **13 tests in `lib/sanctuary/__tests__/companionAction.test.ts`** ✅

## Test plan
- [x] `npm run type-check` — clean
- [x] `npx eslint` on changed files — clean
- [x] `npx vitest run` — 760 pass, 4 pre-existing api-e2e failures unchanged
- [ ] Manual smoke test of pressed / hover / disabled / sleeping states in dev server (deferred — no dev server in this environment)

## Mirror Validation (PROD)
- **tsc --noEmit (baseline)**: 459 errors (pre-existing, mostly missing `colyseus.js`/`howler` modules)
- **tsc --noEmit (after overlay)**: 460 errors → +1
  - The single new error is `'@/lib/sanctuary/companionGreeting' has no exported member 'timeOfDayPrefix'` because the PROD mirror is one PR behind on the time-of-day greeting work (already merged to workspace via PR #281). This isn't introduced by this PR — it's a baseline-lag artifact and disappears once PROD picks up #281.
- **vitest run**: PASS — 13/13 new tests green on PROD overlay
- Mirror restored byte-identical after validation.
- Overall: PASS (with the noted PROD-lag baseline drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)