### PR TITLE
test(casino): port DeployDeterministic + cast-based predict_addresses helper [SWO_CASINO_TEST_PORT_DEPLOY_DETERMINISTIC]

### DIFF
--- a/contracts/casino/README.md
+++ b/contracts/casino/README.md
@@ -66,6 +66,29 @@ The deploy script uses CREATE3 via the CreateX singleton at
 testnet. Same `(deployer, salt)` ⇒ same address on mainnet, so the testnet
 addresses are the predicted mainnet addresses for the same deployer.
 
+### Predicting addresses (cast-based dry-run)
+
+`scripts/casino/predict_addresses.sh <chainId>` prints the CREATE3 addresses
+that `Deploy.s.sol` will produce on a target chain, without sending any tx.
+It calls `computeCreate3Address` on the live CreateX singleton via `cast` and
+also sanity-checks that CreateX actually has code on that chain.
+
+```bash
+bash scripts/casino/predict_addresses.sh 10143    # Monad testnet
+bash scripts/casino/predict_addresses.sh 143      # Monad mainnet
+bash scripts/casino/predict_addresses.sh 31337    # local anvil
+```
+
+Defaults match the production deployer (`0xb29e…fD7B`) and the salts in
+`Deploy.s.sol`. Override via `CASINO_DEPLOYER`, `CASINO_BANKROLL_SALT`,
+`CASINO_FLIP_SALT`, `CASINO_DICE_SALT`, `CASINO_CLIMB_SALT`, or per-chain
+RPCs (`MONAD_TESTNET_RPC`, `MONAD_MAINNET_RPC`, `ANVIL_RPC`,
+`CASINO_RPC_<chainId>`). For chain `10143` the output should match
+`contracts/casino/deployments/10143.json` byte-for-byte; the Foundry test
+`DeployDeterministic.t.sol::test_predictionsMatchDeployments10143Json` pins
+the same invariant so the prediction can never silently drift away from the
+deployed address book.
+
 ## Heritage
 
 The 8-contract BunnyBagz suite (Foundry, Halmos, Medusa, OpenZeppelin Defender

--- a/contracts/casino/test/DeployDeterministic.t.sol
+++ b/contracts/casino/test/DeployDeterministic.t.sol
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {CreateXScript} from "createx-forge/script/CreateXScript.sol";
+
+import {Deploy} from "../script/Deploy.s.sol";
+import {CasinoBankroll} from "../src/CasinoBankroll.sol";
+import {CosmicFlip} from "../src/CosmicFlip.sol";
+import {GravityDice} from "../src/GravityDice.sol";
+import {ConstellationClimb} from "../src/ConstellationClimb.sol";
+
+/// @title DeployDeterministicTest
+/// @notice Acceptance harness for the createx-forge cutover on Monad: the
+///         same `(deployer, salt)` pair must produce the same contract
+///         addresses no matter which chain we deploy on. Without that,
+///         "wrong address on chain X" is the next mainnet footgun.
+contract DeployDeterministicTest is Test, CreateXScript {
+    /// @dev Use a real private key so the test can drive `Deploy.run()` via
+    ///      `vm.startBroadcast(pk)` (which is broadcast-compatible) instead of
+    ///      `vm.prank` (which isn't).
+    uint256 internal constant DEPLOYER_PK = 0xA11CE;
+    address internal deployer = vm.addr(DEPLOYER_PK);
+
+    /// @dev Distinct from any real chainId so the end-to-end test writes to
+    ///      `deployments/9999999.json` instead of clobbering the real
+    ///      anvil/testnet artifacts.
+    uint256 internal constant _TEST_CHAIN_ID = 9999999;
+
+    /// @dev Salt entropy values must match `Deploy.s.sol`'s defaults.
+    uint88 internal constant BANKROLL_ENTROPY = 0xBB01;
+    uint88 internal constant FLIP_ENTROPY     = 0xBBC1;
+    uint88 internal constant DICE_ENTROPY     = 0xBBD1;
+    uint88 internal constant CLIMB_ENTROPY    = 0xBBA1;
+
+    /// @dev The live production deployer for `deployments/10143.json`. The
+    ///      address book test below pins CREATE3 predictions for this deployer
+    ///      against the Monad-testnet artifact so we notice the moment salt
+    ///      encoding or default entropy drifts.
+    address internal constant PROD_DEPLOYER =
+        0xb29e6735629539cEd64F0d6f0c476Fe92539fD7B;
+
+    function setUp() public withCreateX {
+        vm.deal(deployer, 100 ether);
+    }
+
+    /// @notice Cleans up the per-chain deployment JSON the end-to-end test
+    ///         writes so we don't leave drift in the workspace.
+    function _cleanupTestDeploymentJson() internal {
+        string memory path = string.concat("deployments/", vm.toString(_TEST_CHAIN_ID), ".json");
+        try vm.removeFile(path) {} catch {}
+    }
+
+    /// @notice Same deployer + same salt entropy = same CREATE3 address,
+    ///         independent of `block.chainid`. This is the central guarantee
+    ///         that the createx-forge switch is supposed to give us. We span
+    ///         all four casino contracts so we don't ship a "wrong address on
+    ///         chain X" footgun for any of the games.
+    function test_sameSaltYieldsSameAddressAcrossChains() public {
+        bytes32 bankrollSalt = _packSalt(deployer, BANKROLL_ENTROPY);
+        bytes32 flipSalt     = _packSalt(deployer, FLIP_ENTROPY);
+        bytes32 diceSalt     = _packSalt(deployer, DICE_ENTROPY);
+        bytes32 climbSalt    = _packSalt(deployer, CLIMB_ENTROPY);
+
+        // anvil
+        vm.chainId(31337);
+        address bankrollOnAnvil = computeCreate3Address(bankrollSalt, deployer);
+        address flipOnAnvil     = computeCreate3Address(flipSalt,     deployer);
+        address diceOnAnvil     = computeCreate3Address(diceSalt,     deployer);
+        address climbOnAnvil    = computeCreate3Address(climbSalt,    deployer);
+
+        // Monad testnet
+        vm.chainId(10143);
+        address bankrollOnTestnet = computeCreate3Address(bankrollSalt, deployer);
+        address flipOnTestnet     = computeCreate3Address(flipSalt,     deployer);
+        address diceOnTestnet     = computeCreate3Address(diceSalt,     deployer);
+        address climbOnTestnet    = computeCreate3Address(climbSalt,    deployer);
+
+        // Monad mainnet
+        vm.chainId(143);
+        address bankrollOnMainnet = computeCreate3Address(bankrollSalt, deployer);
+        address flipOnMainnet     = computeCreate3Address(flipSalt,     deployer);
+        address diceOnMainnet     = computeCreate3Address(diceSalt,     deployer);
+        address climbOnMainnet    = computeCreate3Address(climbSalt,    deployer);
+
+        assertEq(bankrollOnAnvil, bankrollOnTestnet, "bankroll drifts anvil->testnet");
+        assertEq(bankrollOnAnvil, bankrollOnMainnet, "bankroll drifts anvil->mainnet");
+        assertEq(flipOnAnvil,     flipOnTestnet,     "flip drifts anvil->testnet");
+        assertEq(flipOnAnvil,     flipOnMainnet,     "flip drifts anvil->mainnet");
+        assertEq(diceOnAnvil,     diceOnTestnet,     "dice drifts anvil->testnet");
+        assertEq(diceOnAnvil,     diceOnMainnet,     "dice drifts anvil->mainnet");
+        assertEq(climbOnAnvil,    climbOnTestnet,    "climb drifts anvil->testnet");
+        assertEq(climbOnAnvil,    climbOnMainnet,    "climb drifts anvil->mainnet");
+
+        // Distinct entropy => distinct addresses for every contract pair.
+        assertTrue(bankrollOnAnvil != flipOnAnvil,  "bankroll/flip share addr");
+        assertTrue(bankrollOnAnvil != diceOnAnvil,  "bankroll/dice share addr");
+        assertTrue(bankrollOnAnvil != climbOnAnvil, "bankroll/climb share addr");
+        assertTrue(flipOnAnvil     != diceOnAnvil,  "flip/dice share addr");
+        assertTrue(flipOnAnvil     != climbOnAnvil, "flip/climb share addr");
+        assertTrue(diceOnAnvil     != climbOnAnvil, "dice/climb share addr");
+    }
+
+    /// @notice Different deployers -> different addresses for the same salt.
+    ///         This is the permissioned-deploy guard from CreateX (first 20
+    ///         bytes of the salt are the deployer's address).
+    function test_differentDeployerYieldsDifferentAddress() public view {
+        uint88 entropy = BANKROLL_ENTROPY;
+        address addrA = computeCreate3Address(_packSalt(address(0xA11CE), entropy), address(0xA11CE));
+        address addrB = computeCreate3Address(_packSalt(address(0xB0B),   entropy), address(0xB0B));
+        assertTrue(addrA != addrB, "permissioned-deploy guard broken");
+    }
+
+    /// @notice End-to-end: run the actual `Deploy` script against a local
+    ///         anvil VM and assert the deployed addresses match the
+    ///         pre-computed addresses from `computeCreate3Address`. Catches
+    ///         any drift between the script's salt encoding and the test's,
+    ///         and verifies all 4 contracts (bankroll + cosmic-flip +
+    ///         gravity-dice + constellation-climb) are deployed and
+    ///         registered.
+    function test_deployScriptYieldsPredictedAddresses() public {
+        bytes32 bankrollSalt = _packSalt(deployer, BANKROLL_ENTROPY);
+        bytes32 flipSalt     = _packSalt(deployer, FLIP_ENTROPY);
+        bytes32 diceSalt     = _packSalt(deployer, DICE_ENTROPY);
+        bytes32 climbSalt    = _packSalt(deployer, CLIMB_ENTROPY);
+        address expectedBankroll = computeCreate3Address(bankrollSalt, deployer);
+        address expectedFlip     = computeCreate3Address(flipSalt,     deployer);
+        address expectedDice     = computeCreate3Address(diceSalt,     deployer);
+        address expectedClimb    = computeCreate3Address(climbSalt,    deployer);
+
+        // Use a unique chainId so the script's `deployments/<chainId>.json`
+        // writeup lands in a test-only artifact instead of clobbering the
+        // real `deployments/31337.json`. We then remove it on teardown.
+        vm.chainId(_TEST_CHAIN_ID);
+
+        Deploy script = new Deploy();
+        // CreateX is already etched by this test's own setUp(); the script's
+        // setUp re-checks and is a no-op.
+        script.setUp();
+
+        // Inject a real PRIVATE_KEY so the script takes the
+        // `vm.startBroadcast(pk)` branch — that path is broadcast-compatible
+        // and doesn't fight a vm.prank like the implicit-broadcaster branch
+        // would.
+        vm.setEnv("PRIVATE_KEY", vm.toString(bytes32(DEPLOYER_PK)));
+        (address bankrollAddr, address flipAddr, address diceAddr, address climbAddr) =
+            script.run();
+
+        assertEq(bankrollAddr, expectedBankroll, "deploy bankroll != predicted");
+        assertEq(flipAddr,     expectedFlip,     "deploy flip != predicted");
+        assertEq(diceAddr,     expectedDice,     "deploy dice != predicted");
+        assertEq(climbAddr,    expectedClimb,    "deploy climb != predicted");
+
+        // Sanity: deployed bytecode is non-empty.
+        assertGt(bankrollAddr.code.length, 0, "bankroll has no code");
+        assertGt(flipAddr.code.length,     0, "flip has no code");
+        assertGt(diceAddr.code.length,     0, "dice has no code");
+        assertGt(climbAddr.code.length,    0, "climb has no code");
+
+        // Wiring sanity: every game is registered against the bankroll.
+        CasinoBankroll bankroll = CasinoBankroll(payable(bankrollAddr));
+        assertTrue(bankroll.isGame(flipAddr),  "flip not registered as game");
+        assertTrue(bankroll.isGame(diceAddr),  "dice not registered as game");
+        assertTrue(bankroll.isGame(climbAddr), "climb not registered as game");
+
+        _cleanupTestDeploymentJson();
+    }
+
+    /// @notice Pins the CREATE3 prediction for the live production deployer
+    ///         against the addresses recorded in `deployments/10143.json`.
+    ///         If anyone changes salt encoding or rotates default entropy
+    ///         without rotating the artifact, this test trips immediately —
+    ///         well before anyone tries to deploy to mainnet against a stale
+    ///         address book.
+    function test_predictionsMatchDeployments10143Json() public view {
+        bytes32 bankrollSalt = _packSalt(PROD_DEPLOYER, BANKROLL_ENTROPY);
+        bytes32 flipSalt     = _packSalt(PROD_DEPLOYER, FLIP_ENTROPY);
+        bytes32 diceSalt     = _packSalt(PROD_DEPLOYER, DICE_ENTROPY);
+        bytes32 climbSalt    = _packSalt(PROD_DEPLOYER, CLIMB_ENTROPY);
+
+        address predictedBankroll = computeCreate3Address(bankrollSalt, PROD_DEPLOYER);
+        address predictedFlip     = computeCreate3Address(flipSalt,     PROD_DEPLOYER);
+        address predictedDice     = computeCreate3Address(diceSalt,     PROD_DEPLOYER);
+        address predictedClimb    = computeCreate3Address(climbSalt,    PROD_DEPLOYER);
+
+        // Pinned from contracts/casino/deployments/10143.json (Monad testnet).
+        // Update this test in lock-step if the deployer or default entropy
+        // ever rotates.
+        assertEq(
+            predictedBankroll,
+            0x33C5B6a95e71611F5dC821A74DDAD0F746fF2dFf,
+            "bankroll prediction != deployments/10143.json"
+        );
+        assertEq(
+            predictedFlip,
+            0x064b8bfc03b23D2b525deD9d3969090347A21983,
+            "cosmicFlip prediction != deployments/10143.json"
+        );
+        assertEq(
+            predictedDice,
+            0xAC023542A8168465EE4A1b3e8Ae0f58F36A6d84B,
+            "gravityDice prediction != deployments/10143.json"
+        );
+        assertEq(
+            predictedClimb,
+            0xd9B9b6c37ad4f3D5b07ae76dE261c5C865600d6e,
+            "constellationClimb prediction != deployments/10143.json"
+        );
+    }
+
+    function _packSalt(address d, uint88 entropy) internal pure returns (bytes32) {
+        return bytes32(abi.encodePacked(d, hex"00", bytes11(entropy)));
+    }
+}

--- a/scripts/casino/predict_addresses.sh
+++ b/scripts/casino/predict_addresses.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# predict_addresses.sh — cast-based dry-run helper that prints the CREATE3
+# addresses the Cosmic Casino `Deploy.s.sol` script will produce for a given
+# chain, without sending any tx.
+#
+# CREATE3 addresses depend only on (deployer, salt) — the chainId picks the
+# RPC endpoint and lets the helper sanity-check that CreateX is actually
+# present at `0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed` on that chain.
+#
+# Usage:
+#   bash scripts/casino/predict_addresses.sh <chainId>
+#
+# Examples:
+#   bash scripts/casino/predict_addresses.sh 10143    # Monad testnet
+#   bash scripts/casino/predict_addresses.sh 143      # Monad mainnet
+#   bash scripts/casino/predict_addresses.sh 31337    # local anvil
+#
+# Env overrides:
+#   CASINO_DEPLOYER          deployer addr (default: prod 0xb29e…fD7B)
+#   CASINO_BANKROLL_SALT     uint88 entropy (default 0xBB01)
+#   CASINO_FLIP_SALT         uint88 entropy (default 0xBBC1)
+#   CASINO_DICE_SALT         uint88 entropy (default 0xBBD1)
+#   CASINO_CLIMB_SALT        uint88 entropy (default 0xBBA1)
+#   CASINO_RPC_<chainId>     RPC URL for the chain (per-chain overrides)
+#   MONAD_TESTNET_RPC        Monad testnet RPC (default https://testnet-rpc.monad.xyz)
+#   MONAD_MAINNET_RPC        Monad mainnet RPC (default https://rpc.monad.xyz)
+#   ANVIL_RPC                local anvil (default http://127.0.0.1:8545)
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+    echo "usage: $0 <chainId>" >&2
+    echo "see header comment for env overrides." >&2
+    exit 2
+fi
+
+CHAIN_ID="$1"
+DEPLOYER="${CASINO_DEPLOYER:-0xb29e6735629539cEd64F0d6f0c476Fe92539fD7B}"
+BANKROLL_ENTROPY="${CASINO_BANKROLL_SALT:-0xBB01}"
+FLIP_ENTROPY="${CASINO_FLIP_SALT:-0xBBC1}"
+DICE_ENTROPY="${CASINO_DICE_SALT:-0xBBD1}"
+CLIMB_ENTROPY="${CASINO_CLIMB_SALT:-0xBBA1}"
+
+CREATEX="0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed"
+
+# Pick RPC for the requested chain.
+case "$CHAIN_ID" in
+    10143) DEFAULT_RPC="${MONAD_TESTNET_RPC:-https://testnet-rpc.monad.xyz}" ;;
+    143)   DEFAULT_RPC="${MONAD_MAINNET_RPC:-https://rpc.monad.xyz}" ;;
+    31337) DEFAULT_RPC="${ANVIL_RPC:-http://127.0.0.1:8545}" ;;
+    *)     DEFAULT_RPC="" ;;
+esac
+
+# Per-chain override always wins.
+PER_CHAIN_VAR="CASINO_RPC_${CHAIN_ID}"
+RPC_URL="${!PER_CHAIN_VAR:-$DEFAULT_RPC}"
+
+if [[ -z "$RPC_URL" ]]; then
+    echo "predict_addresses: no RPC URL configured for chain $CHAIN_ID." >&2
+    echo "Set $PER_CHAIN_VAR=https://... and re-run." >&2
+    exit 2
+fi
+
+if ! command -v cast >/dev/null 2>&1; then
+    echo "predict_addresses: 'cast' (foundry) not on PATH." >&2
+    echo "Install: https://book.getfoundry.sh/getting-started/installation" >&2
+    exit 2
+fi
+
+# Strip 0x and lowercase the deployer for salt packing.
+DEPLOYER_LC=$(echo "$DEPLOYER" | tr 'A-Z' 'a-z')
+DEPLOYER_HEX="${DEPLOYER_LC#0x}"
+
+# Pack the salt: 20-byte deployer || 0x00 || 11-byte entropy.
+# Each entropy literal is 0x???? (2..4 nibbles); left-pad to 22 nibbles.
+pack_salt() {
+    local entropy_hex="${1#0x}"
+    entropy_hex=$(echo "$entropy_hex" | tr 'A-Z' 'a-z')
+    # 11 bytes = 22 nibbles. Left-pad with zeros.
+    local padded
+    padded=$(printf "%022s" "$entropy_hex" | tr ' ' '0')
+    echo "0x${DEPLOYER_HEX}00${padded}"
+}
+
+BANKROLL_SALT=$(pack_salt "$BANKROLL_ENTROPY")
+FLIP_SALT=$(pack_salt "$FLIP_ENTROPY")
+DICE_SALT=$(pack_salt "$DICE_ENTROPY")
+CLIMB_SALT=$(pack_salt "$CLIMB_ENTROPY")
+
+# Sanity-check CreateX is deployed on the target chain.
+CREATEX_CODE_SIZE=$(cast codesize "$CREATEX" --rpc-url "$RPC_URL" 2>/dev/null || echo "0")
+if [[ "$CREATEX_CODE_SIZE" == "0" ]]; then
+    echo "predict_addresses: CreateX singleton has no code at $CREATEX on chain $CHAIN_ID." >&2
+    echo "Either the RPC is wrong, or CreateX has not been deployed to this chain yet." >&2
+    exit 1
+fi
+
+predict() {
+    local salt="$1"
+    cast call "$CREATEX" \
+        "computeCreate3Address(bytes32,address)(address)" \
+        "$salt" "$DEPLOYER" \
+        --rpc-url "$RPC_URL"
+}
+
+BANKROLL_ADDR=$(predict "$BANKROLL_SALT")
+FLIP_ADDR=$(predict "$FLIP_SALT")
+DICE_ADDR=$(predict "$DICE_SALT")
+CLIMB_ADDR=$(predict "$CLIMB_SALT")
+
+echo "chainId:              $CHAIN_ID"
+echo "rpc:                  $RPC_URL"
+echo "deployer:             $DEPLOYER"
+echo "createx:              $CREATEX (codesize=$CREATEX_CODE_SIZE)"
+echo "CasinoBankroll:       $BANKROLL_ADDR   (salt $BANKROLL_SALT)"
+echo "CosmicFlip:           $FLIP_ADDR   (salt $FLIP_SALT)"
+echo "GravityDice:          $DICE_ADDR   (salt $DICE_SALT)"
+echo "ConstellationClimb:   $CLIMB_ADDR   (salt $CLIMB_SALT)"


### PR DESCRIPTION
## Summary
- Ports `BunnyBagzDeployDeterministic.t.sol` → `contracts/casino/test/DeployDeterministic.t.sol` (same filename, mechanical contract/salt rename pass), and **adds a new pin test** `test_predictionsMatchDeployments10143Json` that asserts the CREATE3 predictions for the live prod deployer (`0xb29e…fD7B`) match the four addresses in `contracts/casino/deployments/10143.json` byte-for-byte. Tripping it means salt encoding or default entropy has drifted out of sync with the Monad-testnet address book.
- Adds `scripts/casino/predict_addresses.sh <chainId>` — a `cast`-based dry-run helper that calls `computeCreate3Address` on the live CreateX singleton (`0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed`) and prints the four casino-contract predictions. Sanity-checks that CreateX actually has code on the target chain; supports per-chain RPC overrides (`MONAD_TESTNET_RPC`, `MONAD_MAINNET_RPC`, `ANVIL_RPC`, `CASINO_RPC_<chainId>`) plus per-salt overrides.
- Documents the helper in `contracts/casino/README.md` under a new "Predicting addresses (cast-based dry-run)" subsection.

## Acceptance
- (a) **File exists** — `contracts/casino/test/DeployDeterministic.t.sol` checked in.
- (b) **CREATE3 prediction = actual on local anvil** for all 4 contracts using salts from `Deploy.s.sol` — verified by `test_deployScriptYieldsPredictedAddresses` (runs `Deploy.run()` on anvil with a broadcast PK, asserts deployed addrs match `computeCreate3Address`, plus wiring sanity checks).
- (c) **Prediction matches `deployments/10143.json`** — verified by `test_predictionsMatchDeployments10143Json` for the prod deployer `0xb29e…fD7B` and the four addresses in the artifact.
- (d) **`scripts/casino/predict_addresses.sh <chainId>`** documented in `contracts/casino/README.md`.

## Test plan
- [x] `PATH=/home/agent/.foundry/bin:$PATH forge test --match-contract DeployDeterministic --skip 'script/**'` → 4/4 PASS
- [x] Full casino suite: `forge test --skip 'script/**'` → 148/148 PASS, 0 regressions
- [x] `bash -n scripts/casino/predict_addresses.sh` syntax check passes
- [x] Salt-packing logic spot-checked against `deployments/10143.json`'s `bankrollSalt` (matches exactly)

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS (459 errors, unchanged vs baseline — no new errors introduced)
- **vitest run**: PASS (4 failed / 794 passed, unchanged vs baseline — no new failures introduced)
- Mirror restored byte-identical after the diff (overlay → measure → restore README + delete new test + remove new `scripts/casino/` dir)
- Overall: PASS

Depends on: B1 (already merged — Casino* renames + `deployments/10143.json` are in place).

[SWO_CASINO_TEST_PORT_DEPLOY_DETERMINISTIC]

🤖 Generated with [Claude Code](https://claude.com/claude-code)