### PR TITLE
ci(casino): add Forge build+test workflow for contracts/casino

### DIFF
--- a/.github/workflows/casino-forge.yml
+++ b/.github/workflows/casino-forge.yml
@@ -1,0 +1,53 @@
+name: Casino Forge CI
+
+# Runs Foundry build + test for the Cosmic Casino contracts on PRs that touch
+# the on-chain layer. Mirrors the local instructions in contracts/casino/README.md.
+# Solidity 0.8.24 is pinned via contracts/casino/foundry.toml.
+
+on:
+  pull_request:
+    paths:
+      - 'contracts/casino/**'
+      - 'lib/casino/**'
+      - '.github/workflows/casino-forge.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    working-directory: contracts/casino
+
+jobs:
+  forge:
+    name: forge build + test
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+
+      - name: Show Foundry versions
+        run: |
+          forge --version
+          cast --version
+
+      - name: Install Foundry dependencies
+        # lib/ is gitignored; restore deps per contracts/casino/README.md.
+        run: |
+          forge install foundry-rs/forge-std --no-commit
+          forge install OpenZeppelin/openzeppelin-contracts --no-commit
+          forge install radeksvarz/createx-forge --no-commit
+
+      - name: Forge build
+        run: forge build
+
+      - name: Forge test
+        run: forge test -vvv --skip 'script/**'


### PR DESCRIPTION
## Summary

Adds `.github/workflows/casino-forge.yml` — a Foundry CI workflow that runs `forge build` + `forge test -vvv` against `contracts/casino/`.

- **Trigger**: PRs touching `contracts/casino/**` or `lib/casino/**` (also `workflow_dispatch` for manual runs and self-changes).
- **Toolchain**: `foundry-rs/foundry-toolchain@v1` (stable). Solidity `0.8.24` is already pinned in `contracts/casino/foundry.toml`, so no separate version flag is needed.
- **Dep restore**: `lib/` is gitignored under `contracts/casino/`, so the workflow re-runs the three `forge install …` commands documented in `contracts/casino/README.md` (forge-std, OpenZeppelin, createx-forge).
- **Failure semantics**: `forge test -vvv` exits non-zero on a red test, which blocks the PR via the normal required-check flow. Intentionally-broken test would surface as a red Action run on the PR.
- **Out of scope**: Medusa fuzzing is excluded (campaigns are minutes-long; `contracts/casino/README.md` explicitly notes "Medusa is not wired to CI"). Foundry's `CasinoMedusaInvariant` shim still runs as part of `forge test`, so cross-game solvency stays covered.

Implements `[SWO_CASINO_CI_FORGE_TEST]`. Builds on the recently-ported Bankroll / Allowlist / Dice / Randomness / Deploy / Medusa Foundry suites (PRs #289–#295), so the green run is more than just a smoke test (164 tests on `dev` head locally).

## Test plan

- [x] Local: `PATH=/home/agent/.foundry/bin:$PATH forge test --skip 'script/**' --root contracts/casino` → 164/164 passing (13 test suites)
- [x] YAML lint: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/casino-forge.yml'))"` → valid
- [x] Path filters: only fires on `contracts/casino/**`, `lib/casino/**`, or this workflow file itself
- [ ] Verify the first PR run on `dev` is green end-to-end
- [ ] Verify a deliberately-broken test triggers PR-blocking red (smoke-test in a follow-up branch if needed)

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS — 459 errors unchanged (all pre-existing; this PR adds only a YAML file)
- **vitest run**: PASS — 794 passed / 4 failed unchanged (all pre-existing; this PR adds only a YAML file)
- Mirror restored byte-identical after overlay.
Overall: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)