### PR TITLE
ci(casino): add forge fmt --check job [SWO_CASINO_CI_FOUNDRY_FMT]

### DIFF
--- a/.github/workflows/casino-forge.yml
+++ b/.github/workflows/casino-forge.yml
@@ -1,0 +1,109 @@
+name: Casino Forge CI
+
+# Runs Foundry build + test for the Cosmic Casino contracts on PRs that touch
+# the on-chain layer. Mirrors the local instructions in contracts/casino/README.md.
+# Solidity 0.8.24 is pinned via contracts/casino/foundry.toml.
+
+on:
+  pull_request:
+    paths:
+      - 'contracts/casino/**'
+      - 'lib/casino/**'
+      - '.github/workflows/casino-forge.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    working-directory: contracts/casino
+
+jobs:
+  forge:
+    name: forge build + test
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+
+      - name: Show Foundry versions
+        run: |
+          forge --version
+          cast --version
+
+      - name: Install Foundry dependencies
+        # lib/ is gitignored; restore deps per contracts/casino/README.md.
+        run: |
+          forge install foundry-rs/forge-std --no-commit
+          forge install OpenZeppelin/openzeppelin-contracts --no-commit
+          forge install radeksvarz/createx-forge --no-commit
+
+      - name: Forge build
+        run: forge build
+
+      - name: Forge test
+        run: forge test -vvv --skip 'script/**'
+
+  coverage:
+    name: forge coverage (lcov + gate)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # Run in parallel with the build/test job. The gate is the source of truth
+    # for PR-blocking — `forge coverage` re-runs the suite under instrumentation,
+    # so a green here implies a green build + test too.
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+
+      - name: Show Foundry versions
+        run: |
+          forge --version
+          cast --version
+
+      - name: Install Foundry dependencies
+        run: |
+          forge install foundry-rs/forge-std --no-commit
+          forge install OpenZeppelin/openzeppelin-contracts --no-commit
+          forge install radeksvarz/createx-forge --no-commit
+
+      - name: Forge coverage (LCOV)
+        # --ir-minimum keeps source maps accurate without "stack too deep"
+        # failures. The summary report streams to the job log for humans.
+        run: |
+          forge coverage \
+            --report lcov \
+            --report-file lcov.info \
+            --report summary \
+            --ir-minimum
+
+      - name: Upload LCOV artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: casino-forge-lcov
+          path: contracts/casino/lcov.info
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Enforce per-contract coverage thresholds
+        # PR-blocking gate: 90% line / 80% branch per src/ contract.
+        # Tests, scripts, and libraries are excluded — only production sources
+        # under src/ are gated. Configurable via --line / --branch / --include.
+        run: |
+          python3 script/check_coverage.py lcov.info \
+            --line 90 \
+            --branch 80 \
+            --include src/

--- a/.github/workflows/casino-forge.yml
+++ b/.github/workflows/casino-forge.yml
@@ -20,6 +20,30 @@ defaults:
     working-directory: contracts/casino
 
 jobs:
+  fmt:
+    name: forge fmt --check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Style-only gate. Runs in parallel with build/test so a whitespace
+    # regression turns the PR red without waiting on the heavier suite.
+    # `[fmt]` block in contracts/casino/foundry.toml is the source of truth
+    # (line_length=100, tab_width=4, bracket_spacing=false, int_types=long).
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+
+      - name: Show Foundry versions
+        run: forge --version
+
+      - name: Forge fmt (check)
+        run: forge fmt --check
+
   forge:
     name: forge build + test
     runs-on: ubuntu-latest

--- a/contracts/casino/script/Deploy.s.sol
+++ b/contracts/casino/script/Deploy.s.sol
@@ -39,10 +39,10 @@ import {CasinoAllowlist} from "../src/CasinoAllowlist.sol";
 ///           CASINO_ALLOWLIST_SEED     CSV of addresses (default empty)
 ///           PRIVATE_KEY               deployer key (forge default if unset)
 contract Deploy is CreateXScript {
-    uint88 internal constant DEFAULT_BANKROLL_SALT  = 0xBB01;
-    uint88 internal constant DEFAULT_FLIP_SALT      = 0xBBC1;
-    uint88 internal constant DEFAULT_DICE_SALT      = 0xBBD1;
-    uint88 internal constant DEFAULT_CLIMB_SALT     = 0xBBA1;
+    uint88 internal constant DEFAULT_BANKROLL_SALT = 0xBB01;
+    uint88 internal constant DEFAULT_FLIP_SALT = 0xBBC1;
+    uint88 internal constant DEFAULT_DICE_SALT = 0xBBD1;
+    uint88 internal constant DEFAULT_CLIMB_SALT = 0xBBA1;
     uint88 internal constant DEFAULT_ALLOWLIST_SALT = 0xBBAA;
 
     function setUp() public withCreateX {}
@@ -60,8 +60,8 @@ contract Deploy is CreateXScript {
         bytes32 diceSalt;
         bytes32 climbSalt;
         bytes32 allowlistSalt;
-        bool    deployAllowlist;
-        bool    allowlistEnabled;
+        bool deployAllowlist;
+        bool allowlistEnabled;
     }
 
     struct DeployedAddresses {
@@ -86,9 +86,9 @@ contract Deploy is CreateXScript {
 
         DeployedAddresses memory a;
         a.bankroll = computeCreate3Address(p.bankrollSalt, p.deployer);
-        a.flip     = computeCreate3Address(p.flipSalt,     p.deployer);
-        a.dice     = computeCreate3Address(p.diceSalt,     p.deployer);
-        a.climb    = computeCreate3Address(p.climbSalt,    p.deployer);
+        a.flip = computeCreate3Address(p.flipSalt, p.deployer);
+        a.dice = computeCreate3Address(p.diceSalt, p.deployer);
+        a.climb = computeCreate3Address(p.climbSalt, p.deployer);
 
         _create3IfMissing(
             a.bankroll,
@@ -125,8 +125,8 @@ contract Deploy is CreateXScript {
         );
 
         CasinoBankroll bankroll = CasinoBankroll(payable(a.bankroll));
-        _registerIfMissing(bankroll, a.flip,  p.initialAllowance);
-        _registerIfMissing(bankroll, a.dice,  p.initialAllowance);
+        _registerIfMissing(bankroll, a.flip, p.initialAllowance);
+        _registerIfMissing(bankroll, a.dice, p.initialAllowance);
         _registerIfMissing(bankroll, a.climb, p.initialAllowance);
         if (p.initialDeposit > 0) {
             bankroll.deposit{value: p.initialDeposit}();
@@ -145,15 +145,14 @@ contract Deploy is CreateXScript {
                 a.allowlist,
                 p.allowlistSalt,
                 abi.encodePacked(
-                    type(CasinoAllowlist).creationCode,
-                    abi.encode(p.deployer, p.allowlistEnabled)
+                    type(CasinoAllowlist).creationCode, abi.encode(p.deployer, p.allowlistEnabled)
                 ),
                 "allowlist"
             );
 
-            CosmicFlip          cf = CosmicFlip(payable(a.flip));
-            GravityDice         dc = GravityDice(payable(a.dice));
-            ConstellationClimb  hl = ConstellationClimb(payable(a.climb));
+            CosmicFlip cf = CosmicFlip(payable(a.flip));
+            GravityDice dc = GravityDice(payable(a.dice));
+            ConstellationClimb hl = ConstellationClimb(payable(a.climb));
             if (address(cf.allowlist()) != a.allowlist && cf.owner() == p.deployer) {
                 cf.setAllowlist(a.allowlist);
             }
@@ -187,34 +186,34 @@ contract Deploy is CreateXScript {
         _writeDeploymentJson(a, p);
 
         bankrollAddr = a.bankroll;
-        flipAddr     = a.flip;
-        diceAddr     = a.dice;
-        climbAddr    = a.climb;
+        flipAddr = a.flip;
+        diceAddr = a.dice;
+        climbAddr = a.climb;
     }
 
     function _loadParams() internal view returns (DeployParams memory p) {
         p.initialAllowance = vm.envOr("CASINO_INITIAL_ALLOWANCE", uint256(10 ether));
-        p.initialDeposit   = vm.envOr("CASINO_INITIAL_DEPOSIT",   p.initialAllowance);
-        p.minBet           = vm.envOr("CASINO_MIN_BET",           uint256(0.001 ether));
-        p.maxBet           = vm.envOr("CASINO_MAX_BET",           uint256(0.1 ether));
-        p.climbMaxPayout   = vm.envOr("CASINO_CLIMB_MAX_PAYOUT",  uint256(1 ether));
+        p.initialDeposit = vm.envOr("CASINO_INITIAL_DEPOSIT", p.initialAllowance);
+        p.minBet = vm.envOr("CASINO_MIN_BET", uint256(0.001 ether));
+        p.maxBet = vm.envOr("CASINO_MAX_BET", uint256(0.1 ether));
+        p.climbMaxPayout = vm.envOr("CASINO_CLIMB_MAX_PAYOUT", uint256(1 ether));
         p.maxDrawdown24hWei = vm.envOr("CASINO_MAX_DRAWDOWN_24H", p.initialDeposit / 2);
 
         uint256 pk = vm.envOr("PRIVATE_KEY", uint256(0));
         p.deployer = pk != 0 ? vm.addr(pk) : msg.sender;
 
         uint88 bEntropy = uint88(vm.envOr("CASINO_BANKROLL_SALT", uint256(DEFAULT_BANKROLL_SALT)));
-        uint88 cEntropy = uint88(vm.envOr("CASINO_FLIP_SALT",     uint256(DEFAULT_FLIP_SALT)));
-        uint88 dEntropy = uint88(vm.envOr("CASINO_DICE_SALT",     uint256(DEFAULT_DICE_SALT)));
-        uint88 hEntropy = uint88(vm.envOr("CASINO_CLIMB_SALT",    uint256(DEFAULT_CLIMB_SALT)));
+        uint88 cEntropy = uint88(vm.envOr("CASINO_FLIP_SALT", uint256(DEFAULT_FLIP_SALT)));
+        uint88 dEntropy = uint88(vm.envOr("CASINO_DICE_SALT", uint256(DEFAULT_DICE_SALT)));
+        uint88 hEntropy = uint88(vm.envOr("CASINO_CLIMB_SALT", uint256(DEFAULT_CLIMB_SALT)));
         uint88 aEntropy = uint88(vm.envOr("CASINO_ALLOWLIST_SALT", uint256(DEFAULT_ALLOWLIST_SALT)));
-        p.bankrollSalt  = _packSalt(p.deployer, bEntropy);
-        p.flipSalt      = _packSalt(p.deployer, cEntropy);
-        p.diceSalt      = _packSalt(p.deployer, dEntropy);
-        p.climbSalt     = _packSalt(p.deployer, hEntropy);
+        p.bankrollSalt = _packSalt(p.deployer, bEntropy);
+        p.flipSalt = _packSalt(p.deployer, cEntropy);
+        p.diceSalt = _packSalt(p.deployer, dEntropy);
+        p.climbSalt = _packSalt(p.deployer, hEntropy);
         p.allowlistSalt = _packSalt(p.deployer, aEntropy);
 
-        p.deployAllowlist  = vm.envOr("CASINO_DEPLOY_ALLOWLIST", false);
+        p.deployAllowlist = vm.envOr("CASINO_DEPLOY_ALLOWLIST", false);
         p.allowlistEnabled = vm.envOr("CASINO_ALLOWLIST_ENABLED", true);
     }
 
@@ -266,13 +265,13 @@ contract Deploy is CreateXScript {
 
     function _writeDeploymentJson(DeployedAddresses memory a, DeployParams memory p) internal {
         string memory key = "casino_deployment";
-        vm.serializeAddress(key, "bankroll",      a.bankroll);
-        vm.serializeAddress(key, "cosmicFlip",    a.flip);
-        vm.serializeAddress(key, "gravityDice",   a.dice);
+        vm.serializeAddress(key, "bankroll", a.bankroll);
+        vm.serializeAddress(key, "cosmicFlip", a.flip);
+        vm.serializeAddress(key, "gravityDice", a.dice);
         vm.serializeAddress(key, "constellationClimb", a.climb);
-        vm.serializeAddress(key, "allowlist",     a.allowlist);
-        vm.serializeAddress(key, "deployer",      p.deployer);
-        vm.serializeBytes32(key, "bankrollSalt",  p.bankrollSalt);
+        vm.serializeAddress(key, "allowlist", a.allowlist);
+        vm.serializeAddress(key, "deployer", p.deployer);
+        vm.serializeBytes32(key, "bankrollSalt", p.bankrollSalt);
         vm.serializeBytes32(key, "cosmicFlipSalt", p.flipSalt);
         vm.serializeBytes32(key, "gravityDiceSalt", p.diceSalt);
         vm.serializeBytes32(key, "constellationClimbSalt", p.climbSalt);
@@ -281,11 +280,7 @@ contract Deploy is CreateXScript {
         vm.serializeUint(key, "maxDrawdown24hWei", p.maxDrawdown24hWei);
         string memory json = vm.serializeUint(key, "chainId", block.chainid);
 
-        string memory path = string.concat(
-            "deployments/",
-            vm.toString(block.chainid),
-            ".json"
-        );
+        string memory path = string.concat("deployments/", vm.toString(block.chainid), ".json");
         vm.writeJson(json, path);
         console2.log("Wrote deployment JSON to:", path);
     }

--- a/contracts/casino/script/check_coverage.py
+++ b/contracts/casino/script/check_coverage.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Enforce per-contract LCOV coverage thresholds for the Cosmic Casino suite.
+
+Parses an LCOV tracefile and verifies that every Solidity source file matching
+``--include`` (default: ``src/``) meets the line and branch coverage minimums.
+
+Usage:
+    python3 check_coverage.py <lcov.info> [--line N] [--branch N] [--include PREFIX]
+
+Exit codes:
+    0 — every gated contract meets both thresholds.
+    1 — at least one contract is below threshold (CI gate failure).
+    2 — usage / parse error.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class Record:
+    source: str
+    lines_found: int = 0
+    lines_hit: int = 0
+    branches_found: int = 0
+    branches_hit: int = 0
+
+    @property
+    def line_pct(self) -> float:
+        return 100.0 if self.lines_found == 0 else 100.0 * self.lines_hit / self.lines_found
+
+    @property
+    def branch_pct(self) -> float:
+        return 100.0 if self.branches_found == 0 else 100.0 * self.branches_hit / self.branches_found
+
+
+def parse_lcov(path: Path) -> list[Record]:
+    records: list[Record] = []
+    current: Record | None = None
+    with path.open("r", encoding="utf-8") as fh:
+        for raw in fh:
+            line = raw.strip()
+            if line.startswith("SF:"):
+                current = Record(source=line[3:])
+            elif current is None:
+                continue
+            elif line.startswith("LF:"):
+                current.lines_found = int(line[3:])
+            elif line.startswith("LH:"):
+                current.lines_hit = int(line[3:])
+            elif line.startswith("BRF:"):
+                current.branches_found = int(line[4:])
+            elif line.startswith("BRH:"):
+                current.branches_hit = int(line[4:])
+            elif line == "end_of_record":
+                records.append(current)
+                current = None
+    return records
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("lcov", type=Path, help="Path to lcov.info tracefile.")
+    parser.add_argument("--line", type=float, default=90.0, help="Min line coverage %% (default: 90).")
+    parser.add_argument("--branch", type=float, default=80.0, help="Min branch coverage %% (default: 80).")
+    parser.add_argument(
+        "--include",
+        action="append",
+        default=None,
+        help="Source-path prefix to gate (repeatable). Default: src/",
+    )
+    args = parser.parse_args()
+
+    if not args.lcov.is_file():
+        print(f"check_coverage: lcov file not found: {args.lcov}", file=sys.stderr)
+        return 2
+
+    includes = args.include if args.include else ["src/"]
+    records = [r for r in parse_lcov(args.lcov) if any(r.source.startswith(p) for p in includes)]
+
+    if not records:
+        print(
+            f"check_coverage: no source files in lcov match prefixes {includes}",
+            file=sys.stderr,
+        )
+        return 2
+
+    failures: list[str] = []
+    header = f"{'Contract':<40} {'Lines':>14} {'Line %':>8} {'Branches':>14} {'Branch %':>9}  Gate"
+    print(header)
+    print("-" * len(header))
+    for r in sorted(records, key=lambda r: r.source):
+        line_ok = r.line_pct + 1e-9 >= args.line
+        # Treat contracts with zero recorded branches as branch-passing — there
+        # is nothing to gate. This avoids false negatives on simple libraries.
+        branch_ok = r.branches_found == 0 or r.branch_pct + 1e-9 >= args.branch
+        status = "PASS" if (line_ok and branch_ok) else "FAIL"
+        print(
+            f"{r.source:<40} "
+            f"{r.lines_hit:>6}/{r.lines_found:<7} {r.line_pct:>7.2f}% "
+            f"{r.branches_hit:>6}/{r.branches_found:<7} {r.branch_pct:>8.2f}%  {status}"
+        )
+        if not line_ok:
+            failures.append(f"{r.source}: line {r.line_pct:.2f}% < {args.line:.2f}%")
+        if not branch_ok:
+            failures.append(f"{r.source}: branch {r.branch_pct:.2f}% < {args.branch:.2f}%")
+
+    print()
+    print(f"Thresholds: line >= {args.line:.2f}%, branch >= {args.branch:.2f}% (per contract)")
+    if failures:
+        print(f"FAIL — {len(failures)} threshold violation(s):", file=sys.stderr)
+        for f in failures:
+            print(f"  - {f}", file=sys.stderr)
+        return 1
+    print(f"PASS — all {len(records)} contract(s) meet thresholds")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/contracts/casino/src/CasinoBankroll.sol
+++ b/contracts/casino/src/CasinoBankroll.sol
@@ -58,7 +58,10 @@ contract CasinoBankroll is Ownable, Pausable, ReentrancyGuard {
 
     /// @notice Circuit-breaker tripped (manually or by drawdown threshold).
     event CircuitBreakerTripped(
-        uint256 windowStartBalance, uint256 currentBalance, uint256 maxDrawdown24hWei, uint256 timestamp
+        uint256 windowStartBalance,
+        uint256 currentBalance,
+        uint256 maxDrawdown24hWei,
+        uint256 timestamp
     );
     /// @notice Circuit-breaker reset (cooldown elapsed or owner-driven).
     event CircuitBreakerReset(uint256 currentBalance, uint256 timestamp);

--- a/contracts/casino/src/ConstellationClimb.sol
+++ b/contracts/casino/src/ConstellationClimb.sol
@@ -40,29 +40,29 @@ interface ICasinoAllowlist {
 contract ConstellationClimb is Ownable, Pausable, ReentrancyGuard {
     enum Direction {
         Higher, // 0 — bet that next card > currentCard
-        Lower   // 1 — bet that next card < currentCard
+        Lower // 1 — bet that next card < currentCard
     }
 
     enum Status {
-        None,        // 0 — slot empty
-        Open,        // 1 — accepting playStep / cashOut
-        CashedOut,   // 2 — player cashed out for `bet * multiplier`
-        Lost,        // 3 — settled, player forfeited stake (lose path)
-        Refunded,    // 4 — expired without resolution; stake returned
-        Pushed       // 5 — tie on a playStep; stake returned, session ended
+        None, // 0 — slot empty
+        Open, // 1 — accepting playStep / cashOut
+        CashedOut, // 2 — player cashed out for `bet * multiplier`
+        Lost, // 3 — settled, player forfeited stake (lose path)
+        Refunded, // 4 — expired without resolution; stake returned
+        Pushed // 5 — tie on a playStep; stake returned, session ended
     }
 
     struct Session {
         address player;
-        uint96  bet;                // wei locked at open
+        uint96 bet; // wei locked at open
         bytes32 clientSeed;
-        bytes32 serverCommit;       // rotates per playStep — points at NEXT step's reveal
-        uint64  lastBlock;          // last action block (open or step) — basis for expiry
-        uint8   currentCard;        // 1..13
-        Status  status;
-        uint8   stepCount;          // # of completed playSteps
-        uint256 currentMultiplier;  // wad-scaled cumulative multiplier (1e18 = 1.0x)
-        uint256 nonce;              // per-session nonce mixed into rollOutcome
+        bytes32 serverCommit; // rotates per playStep — points at NEXT step's reveal
+        uint64 lastBlock; // last action block (open or step) — basis for expiry
+        uint8 currentCard; // 1..13
+        Status status;
+        uint8 stepCount; // # of completed playSteps
+        uint256 currentMultiplier; // wad-scaled cumulative multiplier (1e18 = 1.0x)
+        uint256 nonce; // per-session nonce mixed into rollOutcome
     }
 
     /// @notice Number of blocks after which an idle Open session can be refunded.
@@ -112,33 +112,30 @@ contract ConstellationClimb is Ownable, Pausable, ReentrancyGuard {
         uint256 stake,
         bytes32 clientSeed,
         bytes32 serverCommit,
-        uint8   initialCard,
+        uint8 initialCard,
         uint256 nonce,
-        uint64  blockOpened
+        uint64 blockOpened
     );
     event StepPlayed(
         uint256 indexed sessionId,
         address indexed player,
         Direction direction,
-        uint8   prevCard,
-        uint8   newCard,
-        bool    won,
+        uint8 prevCard,
+        uint8 newCard,
+        bool won,
         uint256 newMultiplier,
         bytes32 serverReveal,
         bytes32 nextCommit
     );
     event SessionCashedOut(
-        uint256 indexed sessionId,
-        address indexed player,
-        uint256 payout,
-        uint256 finalMultiplier
+        uint256 indexed sessionId, address indexed player, uint256 payout, uint256 finalMultiplier
     );
     event SessionRefunded(uint256 indexed sessionId, address indexed player, uint256 stake);
     event SessionPushed(
         uint256 indexed sessionId,
         address indexed player,
         uint256 stake,
-        uint8   card,
+        uint8 card,
         uint256 multiplier
     );
 
@@ -191,8 +188,13 @@ contract ConstellationClimb is Ownable, Pausable, ReentrancyGuard {
         maxPayout = newMax;
     }
 
-    function pause() external onlyOwner { _pause(); }
-    function unpause() external onlyOwner { _unpause(); }
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    function unpause() external onlyOwner {
+        _unpause();
+    }
 
     function setAllowlist(address newAllowlist) external onlyOwner {
         allowlist = ICasinoAllowlist(newAllowlist);
@@ -210,7 +212,8 @@ contract ConstellationClimb is Ownable, Pausable, ReentrancyGuard {
     {
         ICasinoAllowlist al = allowlist;
         if (address(al) != address(0)) {
-            try al.enforceAccess(msg.sender) {} catch {
+            try al.enforceAccess(msg.sender) {}
+            catch {
                 revert NotAllowed();
             }
         }
@@ -227,21 +230,27 @@ contract ConstellationClimb is Ownable, Pausable, ReentrancyGuard {
             uint8(uint256(keccak256(abi.encodePacked(clientSeed, INIT_TAG))) % CARD_MOD) + 1;
 
         sessions[sessionId] = Session({
-            player:             msg.sender,
-            bet:                uint96(msg.value),
-            clientSeed:         clientSeed,
-            serverCommit:       serverCommit,
-            lastBlock:          uint64(block.number),
-            currentCard:        initialCard,
-            status:             Status.Open,
-            stepCount:          0,
-            currentMultiplier:  WAD,
-            nonce:              nonce
+            player: msg.sender,
+            bet: uint96(msg.value),
+            clientSeed: clientSeed,
+            serverCommit: serverCommit,
+            lastBlock: uint64(block.number),
+            currentCard: initialCard,
+            status: Status.Open,
+            stepCount: 0,
+            currentMultiplier: WAD,
+            nonce: nonce
         });
 
         emit SessionOpened(
-            sessionId, msg.sender, msg.value, clientSeed, serverCommit,
-            initialCard, nonce, uint64(block.number)
+            sessionId,
+            msg.sender,
+            msg.value,
+            clientSeed,
+            serverCommit,
+            initialCard,
+            nonce,
+            uint64(block.number)
         );
     }
 
@@ -254,7 +263,9 @@ contract ConstellationClimb is Ownable, Pausable, ReentrancyGuard {
         Session storage s = sessions[sessionId];
         if (s.status == Status.None) revert SessionNotFound();
         if (s.status != Status.Open) revert SessionNotOpen();
-        if (!CommitRevealRandomness.verifyCommit(serverReveal, s.serverCommit)) revert InvalidReveal();
+        if (!CommitRevealRandomness.verifyCommit(serverReveal, s.serverCommit)) {
+            revert InvalidReveal();
+        }
         if (nextCommit == bytes32(0)) revert ZeroCommit();
         if (commitUsed[nextCommit]) revert CommitAlreadyUsed();
         commitUsed[nextCommit] = true;
@@ -301,12 +312,7 @@ contract ConstellationClimb is Ownable, Pausable, ReentrancyGuard {
         }
     }
 
-    function _settlePush(
-        Session storage s,
-        uint256 sessionId,
-        uint8 card,
-        uint256 mult
-    ) internal {
+    function _settlePush(Session storage s, uint256 sessionId, uint8 card, uint256 mult) internal {
         s.status = Status.Pushed;
         uint256 stake = uint256(s.bet);
         address payable player = payable(s.player);

--- a/contracts/casino/src/CosmicFlip.sol
+++ b/contracts/casino/src/CosmicFlip.sol
@@ -32,26 +32,29 @@ interface ICasinoAllowlist {
 contract CosmicFlip is Ownable, Pausable, ReentrancyGuard {
     using CommitRevealRandomness for bytes32;
 
-    enum Side { Heads, Tails }
+    enum Side {
+        Heads,
+        Tails
+    }
 
     enum Status {
-        None,    // 0 — slot empty
+        None, // 0 — slot empty
         Pending, // 1 — placed, not yet settled
-        Won,     // 2 — settled, player won
-        Lost,    // 3 — settled, house won
+        Won, // 2 — settled, player won
+        Lost, // 3 — settled, house won
         Refunded // 4 — expired, player refunded
     }
 
     struct Bet {
         address player;
-        uint96  stake;        // wei, fits 79+ bn tokens; plenty
+        uint96 stake; // wei, fits 79+ bn tokens; plenty
         bytes32 clientSeed;
         bytes32 serverCommit;
-        uint64  blockPlaced;
-        Side    side;
-        Status  status;
+        uint64 blockPlaced;
+        Side side;
+        Status status;
         bytes32 serverReveal; // populated on settle
-        uint256 nonce;        // matches per-bet nonce in randomness scheme
+        uint256 nonce; // matches per-bet nonce in randomness scheme
     }
 
     /// @notice Number of blocks after which an unsettled bet can be refunded.
@@ -95,18 +98,18 @@ contract CosmicFlip is Ownable, Pausable, ReentrancyGuard {
     event BetPlaced(
         uint256 indexed betId,
         address indexed player,
-        Side    side,
+        Side side,
         uint256 stake,
         bytes32 clientSeed,
         bytes32 serverCommit,
         uint256 nonce,
-        uint64  blockPlaced
+        uint64 blockPlaced
     );
     event BetSettled(
         uint256 indexed betId,
         address indexed player,
-        Side    outcome,
-        bool    won,
+        Side outcome,
+        bool won,
         uint256 payout,
         bytes32 serverReveal
     );
@@ -158,8 +161,13 @@ contract CosmicFlip is Ownable, Pausable, ReentrancyGuard {
         maxBet = newMax;
     }
 
-    function pause() external onlyOwner { _pause(); }
-    function unpause() external onlyOwner { _unpause(); }
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    function unpause() external onlyOwner {
+        _unpause();
+    }
 
     /// @notice Owner-set the soft-launch allowlist contract. Pass address(0)
     ///         to fully detach (open house). Mainnet ships with this set; the
@@ -181,7 +189,8 @@ contract CosmicFlip is Ownable, Pausable, ReentrancyGuard {
     {
         ICasinoAllowlist al = allowlist;
         if (address(al) != address(0)) {
-            try al.enforceAccess(msg.sender) {} catch {
+            try al.enforceAccess(msg.sender) {}
+            catch {
                 revert NotAllowed();
             }
         }
@@ -194,19 +203,26 @@ contract CosmicFlip is Ownable, Pausable, ReentrancyGuard {
         uint256 nonce = playerNonce[msg.sender]++;
 
         bets[betId] = Bet({
-            player:       msg.sender,
-            stake:        uint96(msg.value),
-            clientSeed:   clientSeed,
+            player: msg.sender,
+            stake: uint96(msg.value),
+            clientSeed: clientSeed,
             serverCommit: serverCommit,
-            blockPlaced:  uint64(block.number),
-            side:         side,
-            status:       Status.Pending,
+            blockPlaced: uint64(block.number),
+            side: side,
+            status: Status.Pending,
             serverReveal: bytes32(0),
-            nonce:        nonce
+            nonce: nonce
         });
 
         emit BetPlaced(
-            betId, msg.sender, side, msg.value, clientSeed, serverCommit, nonce, uint64(block.number)
+            betId,
+            msg.sender,
+            side,
+            msg.value,
+            clientSeed,
+            serverCommit,
+            nonce,
+            uint64(block.number)
         );
     }
 
@@ -215,7 +231,9 @@ contract CosmicFlip is Ownable, Pausable, ReentrancyGuard {
         Bet storage b = bets[betId];
         if (b.status == Status.None) revert BetNotFound();
         if (b.status != Status.Pending) revert BetNotPending();
-        if (!CommitRevealRandomness.verifyCommit(serverReveal, b.serverCommit)) revert InvalidReveal();
+        if (!CommitRevealRandomness.verifyCommit(serverReveal, b.serverCommit)) {
+            revert InvalidReveal();
+        }
 
         uint256 outcome = CommitRevealRandomness.rollOutcome(serverReveal, b.clientSeed, b.nonce, 2);
         Side rolled = outcome == 0 ? Side.Heads : Side.Tails;

--- a/contracts/casino/src/GravityDice.sol
+++ b/contracts/casino/src/GravityDice.sol
@@ -38,24 +38,24 @@ contract GravityDice is Ownable, Pausable, ReentrancyGuard {
     using CommitRevealRandomness for bytes32;
 
     enum Status {
-        None,    // 0 — slot empty
+        None, // 0 — slot empty
         Pending, // 1 — placed, not yet settled
-        Won,     // 2 — settled, player won
-        Lost,    // 3 — settled, house won
+        Won, // 2 — settled, player won
+        Lost, // 3 — settled, house won
         Refunded // 4 — expired, player refunded
     }
 
     struct Bet {
         address player;
-        uint96  stake;        // wei, fits 79+ bn tokens; plenty
+        uint96 stake; // wei, fits 79+ bn tokens; plenty
         bytes32 clientSeed;
         bytes32 serverCommit;
-        uint64  blockPlaced;
-        uint8   rollUnder;    // target threshold in [MIN_ROLL_UNDER, MAX_ROLL_UNDER]
-        Status  status;
-        uint8   roll;         // populated on settle, in [1, 100]
+        uint64 blockPlaced;
+        uint8 rollUnder; // target threshold in [MIN_ROLL_UNDER, MAX_ROLL_UNDER]
+        Status status;
+        uint8 roll; // populated on settle, in [1, 100]
         bytes32 serverReveal; // populated on settle
-        uint256 nonce;        // matches per-bet nonce in randomness scheme
+        uint256 nonce; // matches per-bet nonce in randomness scheme
     }
 
     /// @notice Number of blocks after which an unsettled bet can be refunded.
@@ -100,19 +100,19 @@ contract GravityDice is Ownable, Pausable, ReentrancyGuard {
     event BetPlaced(
         uint256 indexed betId,
         address indexed player,
-        uint8   rollUnder,
+        uint8 rollUnder,
         uint256 stake,
         bytes32 clientSeed,
         bytes32 serverCommit,
         uint256 nonce,
-        uint64  blockPlaced
+        uint64 blockPlaced
     );
     event BetSettled(
         uint256 indexed betId,
         address indexed player,
-        uint8   rollUnder,
-        uint8   roll,
-        bool    won,
+        uint8 rollUnder,
+        uint8 roll,
+        bool won,
         uint256 payout,
         bytes32 serverReveal
     );
@@ -155,8 +155,13 @@ contract GravityDice is Ownable, Pausable, ReentrancyGuard {
         maxBet = newMax;
     }
 
-    function pause() external onlyOwner { _pause(); }
-    function unpause() external onlyOwner { _unpause(); }
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    function unpause() external onlyOwner {
+        _unpause();
+    }
 
     function setAllowlist(address newAllowlist) external onlyOwner {
         allowlist = ICasinoAllowlist(newAllowlist);
@@ -174,7 +179,8 @@ contract GravityDice is Ownable, Pausable, ReentrancyGuard {
     {
         ICasinoAllowlist al = allowlist;
         if (address(al) != address(0)) {
-            try al.enforceAccess(msg.sender) {} catch {
+            try al.enforceAccess(msg.sender) {}
+            catch {
                 revert NotAllowed();
             }
         }
@@ -190,20 +196,27 @@ contract GravityDice is Ownable, Pausable, ReentrancyGuard {
         uint256 nonce = playerNonce[msg.sender]++;
 
         bets[betId] = Bet({
-            player:       msg.sender,
-            stake:        uint96(msg.value),
-            clientSeed:   clientSeed,
+            player: msg.sender,
+            stake: uint96(msg.value),
+            clientSeed: clientSeed,
             serverCommit: serverCommit,
-            blockPlaced:  uint64(block.number),
-            rollUnder:    rollUnder,
-            status:       Status.Pending,
-            roll:         0,
+            blockPlaced: uint64(block.number),
+            rollUnder: rollUnder,
+            status: Status.Pending,
+            roll: 0,
             serverReveal: bytes32(0),
-            nonce:        nonce
+            nonce: nonce
         });
 
         emit BetPlaced(
-            betId, msg.sender, rollUnder, msg.value, clientSeed, serverCommit, nonce, uint64(block.number)
+            betId,
+            msg.sender,
+            rollUnder,
+            msg.value,
+            clientSeed,
+            serverCommit,
+            nonce,
+            uint64(block.number)
         );
     }
 
@@ -211,9 +224,12 @@ contract GravityDice is Ownable, Pausable, ReentrancyGuard {
         Bet storage b = bets[betId];
         if (b.status == Status.None) revert BetNotFound();
         if (b.status != Status.Pending) revert BetNotPending();
-        if (!CommitRevealRandomness.verifyCommit(serverReveal, b.serverCommit)) revert InvalidReveal();
+        if (!CommitRevealRandomness.verifyCommit(serverReveal, b.serverCommit)) {
+            revert InvalidReveal();
+        }
 
-        uint256 raw = CommitRevealRandomness.rollOutcome(serverReveal, b.clientSeed, b.nonce, ROLL_MOD);
+        uint256 raw =
+            CommitRevealRandomness.rollOutcome(serverReveal, b.clientSeed, b.nonce, ROLL_MOD);
         // forge-lint: disable-next-line(unsafe-typecast)
         uint8 roll = uint8(raw + 1);
         b.serverReveal = serverReveal;

--- a/contracts/casino/test/CasinoAllowlistUnit.t.sol
+++ b/contracts/casino/test/CasinoAllowlistUnit.t.sol
@@ -31,10 +31,10 @@ contract CasinoAllowlistUnitTest is Test {
     GravityDice dice;
     ConstellationClimb hilo;
 
-    address owner   = address(0xB055);
+    address owner = address(0xB055);
     address allowed = address(0xA11);
     address blocked = address(0xB10C);
-    address other   = address(0xC0FFEE);
+    address other = address(0xC0FFEE);
 
     bytes32 constant SERVER_SEED = bytes32(uint256(0xA11CE));
     bytes32 constant CLIENT_SEED = bytes32(uint256(0xC11ABC));
@@ -47,17 +47,17 @@ contract CasinoAllowlistUnitTest is Test {
         vm.deal(owner, 100 ether);
         vm.deal(allowed, 10 ether);
         vm.deal(blocked, 10 ether);
-        vm.deal(other,   10 ether);
+        vm.deal(other, 10 ether);
 
         vm.startPrank(owner);
         allowlist = new CasinoAllowlist(owner, true);
         bankroll = new CasinoBankroll(owner);
         coinflip = new CosmicFlip(owner, address(bankroll), MIN_BET, MAX_BET);
-        dice     = new GravityDice(owner, address(bankroll), MIN_BET, MAX_BET);
-        hilo     = new ConstellationClimb(owner, address(bankroll), MIN_BET, MAX_BET, 1 ether);
+        dice = new GravityDice(owner, address(bankroll), MIN_BET, MAX_BET);
+        hilo = new ConstellationClimb(owner, address(bankroll), MIN_BET, MAX_BET, 1 ether);
         bankroll.registerGame(address(coinflip), SEED_AMT);
-        bankroll.registerGame(address(dice),     SEED_AMT);
-        bankroll.registerGame(address(hilo),     SEED_AMT);
+        bankroll.registerGame(address(dice), SEED_AMT);
+        bankroll.registerGame(address(hilo), SEED_AMT);
         bankroll.deposit{value: SEED_AMT}();
 
         coinflip.setAllowlist(address(allowlist));
@@ -131,7 +131,7 @@ contract CasinoAllowlistUnitTest is Test {
     }
 
     function test_allowlist_enforceAccessPasses() public view {
-        allowlist.enforceAccess(allowed);  // does not revert
+        allowlist.enforceAccess(allowed); // does not revert
     }
 
     // ---- Game wiring (the criterion-(b) tests) ----

--- a/contracts/casino/test/CasinoBankrollBreaker.t.sol
+++ b/contracts/casino/test/CasinoBankrollBreaker.t.sol
@@ -15,9 +15,9 @@ import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
 contract CasinoBankrollBreakerTest is Test {
     CasinoBankroll bankroll;
 
-    address owner     = address(0xB055);
-    address game      = address(0xCAFE);
-    address other     = address(0xBEEF);
+    address owner = address(0xB055);
+    address game = address(0xCAFE);
+    address other = address(0xBEEF);
     address recipient = address(0xD00D);
 
     uint256 constant SEED = 10 ether;

--- a/contracts/casino/test/CasinoBankrollInvariant.t.sol
+++ b/contracts/casino/test/CasinoBankrollInvariant.t.sol
@@ -43,10 +43,11 @@ contract CoinflipHandler is Test {
         }
     }
 
-    function place(uint256 playerIdx, uint256 sideIdx, uint256 stakeSeed, uint256 seedSeed) external {
+    function place(uint256 playerIdx, uint256 sideIdx, uint256 stakeSeed, uint256 seedSeed)
+        external
+    {
         address p = players[playerIdx % players.length];
-        CosmicFlip.Side side =
-            (sideIdx % 2) == 0 ? CosmicFlip.Side.Heads : CosmicFlip.Side.Tails;
+        CosmicFlip.Side side = (sideIdx % 2) == 0 ? CosmicFlip.Side.Heads : CosmicFlip.Side.Tails;
         uint256 stake = bound(stakeSeed, MIN_BET, MAX_BET);
         bytes32 server = keccak256(abi.encodePacked(seedSeed, "server"));
         bytes32 client = keccak256(abi.encodePacked(seedSeed, "client"));
@@ -68,7 +69,7 @@ contract CoinflipHandler is Test {
         if (openBets.length == 0) return;
         uint256 i = idx % openBets.length;
         uint256 betId = openBets[i];
-        ( , uint96 stake, , , , , CosmicFlip.Status status, , ) = game.bets(betId);
+        (, uint96 stake,,,,, CosmicFlip.Status status,,) = game.bets(betId);
         if (status != CosmicFlip.Status.Pending) {
             _swapPop(i);
             return;
@@ -76,7 +77,7 @@ contract CoinflipHandler is Test {
         bytes32 server = seedOf[betId];
         try game.settleBet(betId, server) {
             // Re-read post-state to score outcome.
-            ( address player, , , , , , CosmicFlip.Status newStatus, , ) = game.bets(betId);
+            (address player,,,,,, CosmicFlip.Status newStatus,,) = game.bets(betId);
             if (newStatus == CosmicFlip.Status.Won) {
                 totalPaid += (uint256(stake) * 198) / 100;
                 _trackPlayer(player);
@@ -91,7 +92,7 @@ contract CoinflipHandler is Test {
         if (openBets.length == 0) return;
         uint256 i = idx % openBets.length;
         uint256 betId = openBets[i];
-        ( address p, uint96 stake, , , uint64 placed, , CosmicFlip.Status status, , ) = game.bets(betId);
+        (address p, uint96 stake,,, uint64 placed,, CosmicFlip.Status status,,) = game.bets(betId);
         if (status != CosmicFlip.Status.Pending) {
             _swapPop(i);
             return;
@@ -130,7 +131,7 @@ contract CoinflipHandler is Test {
 contract CasinoBankrollInvariant is StdInvariant, Test {
     CasinoBankroll bankroll;
     CosmicFlip game;
-    CoinflipHandler  handler;
+    CoinflipHandler handler;
     address owner = address(0xB055);
 
     uint256 constant SEED = 50 ether;
@@ -181,7 +182,7 @@ contract CasinoBankrollInvariant is StdInvariant, Test {
     function _sumPendingStakes() internal view returns (uint256 total) {
         uint256 next = game.nextBetId();
         for (uint256 i = 0; i < next; i++) {
-            ( , uint96 stake, , , , , CosmicFlip.Status status, , ) = game.bets(i);
+            (, uint96 stake,,,,, CosmicFlip.Status status,,) = game.bets(i);
             if (status == CosmicFlip.Status.Pending) total += stake;
         }
     }

--- a/contracts/casino/test/CasinoBankrollUnit.t.sol
+++ b/contracts/casino/test/CasinoBankrollUnit.t.sol
@@ -13,9 +13,9 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 contract CasinoBankrollUnitTest is Test {
     CasinoBankroll bankroll;
 
-    address owner    = address(0xB055);
-    address game     = address(0xCAFE);
-    address other    = address(0xBEEF);
+    address owner = address(0xB055);
+    address game = address(0xCAFE);
+    address other = address(0xBEEF);
     address recipient = address(0xD00D);
 
     function setUp() public {

--- a/contracts/casino/test/CasinoIntegration.t.sol
+++ b/contracts/casino/test/CasinoIntegration.t.sol
@@ -34,12 +34,12 @@ contract CasinoIntegrationTest is Test {
 
         vm.startPrank(owner);
         bankroll = new CasinoBankroll(owner);
-        flip     = new CosmicFlip(owner, address(bankroll), 0.001 ether, 0.1 ether);
-        dice     = new GravityDice(owner, address(bankroll), 0.001 ether, 0.1 ether);
-        climb    = new ConstellationClimb(owner, address(bankroll), 0.001 ether, 0.1 ether, 1 ether);
+        flip = new CosmicFlip(owner, address(bankroll), 0.001 ether, 0.1 ether);
+        dice = new GravityDice(owner, address(bankroll), 0.001 ether, 0.1 ether);
+        climb = new ConstellationClimb(owner, address(bankroll), 0.001 ether, 0.1 ether, 1 ether);
 
-        bankroll.registerGame(address(flip),  1 ether);
-        bankroll.registerGame(address(dice),  1 ether);
+        bankroll.registerGame(address(flip), 1 ether);
+        bankroll.registerGame(address(dice), 1 ether);
         bankroll.registerGame(address(climb), 1 ether);
         vm.stopPrank();
 
@@ -65,7 +65,9 @@ contract CasinoIntegrationTest is Test {
         flip.settleBet(betId, serverSeed);
 
         // Won → +0.98× = +0.0098 ether net (received 0.0198 ether on a 0.01 stake).
-        assertEq(player.balance, playerBalBefore + 0.0198 ether, "player should receive 1.98x stake");
+        assertEq(
+            player.balance, playerBalBefore + 0.0198 ether, "player should receive 1.98x stake"
+        );
     }
 
     function test_CosmicFlip_loseRoute() public {
@@ -81,7 +83,9 @@ contract CasinoIntegrationTest is Test {
         flip.settleBet(betId, serverSeed);
 
         assertEq(player.balance, playerBalBefore - 0.01 ether, "player loses full stake");
-        assertEq(address(bankroll).balance, bankrollBalBefore + 0.01 ether, "bankroll grows by stake");
+        assertEq(
+            address(bankroll).balance, bankrollBalBefore + 0.01 ether, "bankroll grows by stake"
+        );
     }
 
     function test_GravityDice_winRoute() public {
@@ -126,7 +130,11 @@ contract CasinoIntegrationTest is Test {
         // Stake was already inside the contract; cashOut routes stake → bankroll
         // then bankroll → player at 1x.
         assertEq(player.balance, playerBalBefore + 0.01 ether, "player gets stake back at 1.0x");
-        assertEq(address(bankroll).balance, bankrollBalBefore, "bankroll net-zero (settle + payout cancel)");
+        assertEq(
+            address(bankroll).balance,
+            bankrollBalBefore,
+            "bankroll net-zero (settle + payout cancel)"
+        );
     }
 
     function test_CasinoAllowlist_gating() public {

--- a/contracts/casino/test/CasinoMedusaInvariants.t.sol
+++ b/contracts/casino/test/CasinoMedusaInvariants.t.sol
@@ -107,11 +107,12 @@ contract CasinoMedusaTester {
     // Coinflip handlers
     // ---------------------------------------------------------------------
 
-    function placeCoinflip(uint256 playerIdx, uint256 sideIdx, uint256 stakeSeed, uint256 seedSeed) public {
+    function placeCoinflip(uint256 playerIdx, uint256 sideIdx, uint256 stakeSeed, uint256 seedSeed)
+        public
+    {
         if (players.length == 0) return;
         address p = players[playerIdx % players.length];
-        CosmicFlip.Side side =
-            (sideIdx % 2) == 0 ? CosmicFlip.Side.Heads : CosmicFlip.Side.Tails;
+        CosmicFlip.Side side = (sideIdx % 2) == 0 ? CosmicFlip.Side.Heads : CosmicFlip.Side.Tails;
         uint256 stake = _bound(stakeSeed, MIN_BET, MAX_BET);
         bytes32 server = keccak256(abi.encodePacked(seedSeed, "cf-server"));
         bytes32 client = keccak256(abi.encodePacked(seedSeed, "cf-client"));
@@ -129,13 +130,13 @@ contract CasinoMedusaTester {
         if (openCoinflipBets.length == 0) return;
         uint256 i = idx % openCoinflipBets.length;
         uint256 betId = openCoinflipBets[i];
-        ( , uint96 stake, , , , , CosmicFlip.Status status, , ) = coinflip.bets(betId);
+        (, uint96 stake,,,,, CosmicFlip.Status status,,) = coinflip.bets(betId);
         if (status != CosmicFlip.Status.Pending) {
             _swapPopCF(i);
             return;
         }
         try coinflip.settleBet(betId, coinflipSeed[betId]) {
-            ( , , , , , , CosmicFlip.Status newStatus, , ) = coinflip.bets(betId);
+            (,,,,,, CosmicFlip.Status newStatus,,) = coinflip.bets(betId);
             if (newStatus == CosmicFlip.Status.Won) {
                 totalPaid += (uint256(stake) * 198) / 100;
             }
@@ -147,7 +148,8 @@ contract CasinoMedusaTester {
         if (openCoinflipBets.length == 0) return;
         uint256 i = idx % openCoinflipBets.length;
         uint256 betId = openCoinflipBets[i];
-        ( address player, uint96 stake, , , uint64 placed, , CosmicFlip.Status status, , ) = coinflip.bets(betId);
+        (address player, uint96 stake,,, uint64 placed,, CosmicFlip.Status status,,) =
+            coinflip.bets(betId);
         if (status != CosmicFlip.Status.Pending) {
             _swapPopCF(i);
             return;
@@ -175,7 +177,12 @@ contract CasinoMedusaTester {
     // Dice handlers
     // ---------------------------------------------------------------------
 
-    function placeDice(uint256 playerIdx, uint256 rollUnderSeed, uint256 stakeSeed, uint256 seedSeed) public {
+    function placeDice(
+        uint256 playerIdx,
+        uint256 rollUnderSeed,
+        uint256 stakeSeed,
+        uint256 seedSeed
+    ) public {
         if (players.length == 0) return;
         address p = players[playerIdx % players.length];
         uint8 rollUnder = uint8(_bound(rollUnderSeed, 2, 98));
@@ -196,13 +203,13 @@ contract CasinoMedusaTester {
         if (openDiceBets.length == 0) return;
         uint256 i = idx % openDiceBets.length;
         uint256 betId = openDiceBets[i];
-        ( , uint96 stake, , , , , GravityDice.Status status, , , ) = dice.bets(betId);
+        (, uint96 stake,,,,, GravityDice.Status status,,,) = dice.bets(betId);
         if (status != GravityDice.Status.Pending) {
             _swapPopDice(i);
             return;
         }
         try dice.settleBet(betId, diceSeed[betId]) {
-            ( , , , , , uint8 rollUnder, GravityDice.Status newStatus, , , ) = dice.bets(betId);
+            (,,,,, uint8 rollUnder, GravityDice.Status newStatus,,,) = dice.bets(betId);
             if (newStatus == GravityDice.Status.Won) {
                 // Payout = stake * 99 / (rollUnder - 1).
                 uint256 payoutAmt = (uint256(stake) * 99) / (uint256(rollUnder) - 1);
@@ -216,7 +223,8 @@ contract CasinoMedusaTester {
         if (openDiceBets.length == 0) return;
         uint256 i = idx % openDiceBets.length;
         uint256 betId = openDiceBets[i];
-        ( address player, uint96 stake, , , uint64 placed, , GravityDice.Status status, , , ) = dice.bets(betId);
+        (address player, uint96 stake,,, uint64 placed,, GravityDice.Status status,,,) =
+            dice.bets(betId);
         if (status != GravityDice.Status.Pending) {
             _swapPopDice(i);
             return;
@@ -265,7 +273,7 @@ contract CasinoMedusaTester {
         if (openHiLoSessions.length == 0) return;
         uint256 i = idx % openHiLoSessions.length;
         uint256 sid = openHiLoSessions[i];
-        ( address player, uint96 bet, , , , , ConstellationClimb.Status status, , , ) = hilo.sessions(sid);
+        (address player, uint96 bet,,,,, ConstellationClimb.Status status,,,) = hilo.sessions(sid);
         if (status != ConstellationClimb.Status.Open) {
             _swapPopHL(i);
             return;
@@ -284,7 +292,8 @@ contract CasinoMedusaTester {
         if (openHiLoSessions.length == 0) return;
         uint256 i = idx % openHiLoSessions.length;
         uint256 sid = openHiLoSessions[i];
-        ( address player, uint96 bet, , , uint64 lastBlock, , ConstellationClimb.Status status, , , ) = hilo.sessions(sid);
+        (address player, uint96 bet,,, uint64 lastBlock,, ConstellationClimb.Status status,,,) =
+            hilo.sessions(sid);
         if (status != ConstellationClimb.Status.Open) {
             _swapPopHL(i);
             return;
@@ -317,28 +326,25 @@ contract CasinoMedusaTester {
     ///         True for every reachable state under any sequence of the
     ///         handlers above.
     function property_systemNeverInsolvent() public view returns (bool) {
-        uint256 ethHeld =
-            address(bankroll).balance +
-            address(coinflip).balance +
-            address(dice).balance +
-            address(hilo).balance;
+        uint256 ethHeld = address(bankroll).balance + address(coinflip).balance
+            + address(dice).balance + address(hilo).balance;
         return ethHeld >= _sumPendingStakes();
     }
 
     function _sumPendingStakes() internal view returns (uint256 total) {
         uint256 cfNext = coinflip.nextBetId();
         for (uint256 i = 0; i < cfNext; i++) {
-            ( , uint96 stake, , , , , CosmicFlip.Status status, , ) = coinflip.bets(i);
+            (, uint96 stake,,,,, CosmicFlip.Status status,,) = coinflip.bets(i);
             if (status == CosmicFlip.Status.Pending) total += stake;
         }
         uint256 dNext = dice.nextBetId();
         for (uint256 i = 0; i < dNext; i++) {
-            ( , uint96 stake, , , , , GravityDice.Status status, , , ) = dice.bets(i);
+            (, uint96 stake,,,,, GravityDice.Status status,,,) = dice.bets(i);
             if (status == GravityDice.Status.Pending) total += stake;
         }
         uint256 hNext = hilo.nextSessionId();
         for (uint256 i = 0; i < hNext; i++) {
-            ( , uint96 bet, , , , , ConstellationClimb.Status status, , , ) = hilo.sessions(i);
+            (, uint96 bet,,,,, ConstellationClimb.Status status,,,) = hilo.sessions(i);
             if (status == ConstellationClimb.Status.Open) total += bet;
         }
     }

--- a/contracts/casino/test/CommitRevealRandomnessUnit.t.sol
+++ b/contracts/casino/test/CommitRevealRandomnessUnit.t.sol
@@ -73,8 +73,9 @@ contract CommitRevealRandomnessUnitTest is Test {
         uint256 modSeed
     ) public pure {
         uint256 mod = bound(modSeed, 1, type(uint128).max);
-        uint256 viaPipeline =
-            CommitRevealRandomness.outcomeFromHash(CommitRevealRandomness.outcomeHash(server, client, nonce), mod);
+        uint256 viaPipeline = CommitRevealRandomness.outcomeFromHash(
+            CommitRevealRandomness.outcomeHash(server, client, nonce), mod
+        );
         uint256 viaHelper = CommitRevealRandomness.rollOutcome(server, client, nonce, mod);
         assertEq(viaPipeline, viaHelper);
     }
@@ -98,11 +99,12 @@ contract CommitRevealRandomnessUnitTest is Test {
     // ────────────────────────────────────────────────────────────────────────
 
     function test_parityVector1_coinflip() public pure {
-        bytes32 server = bytes32(uint256(0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa));
-        bytes32 client = bytes32(uint256(0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb));
+        bytes32 server =
+            bytes32(uint256(0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa));
+        bytes32 client =
+            bytes32(uint256(0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb));
         uint256 nonce = 0;
-        bytes32 expectedCommit =
-            0x20ee8f1366f06926e9e8771d8fb9007a8537c8dfdb6a3f8c2cfd64db19d2ec90;
+        bytes32 expectedCommit = 0x20ee8f1366f06926e9e8771d8fb9007a8537c8dfdb6a3f8c2cfd64db19d2ec90;
         bytes32 expectedOutcomeHash =
             0x4bcf8d6c0234f488ad0c0be6d04c4dab44d1dad9c162020f8d1f1bb91e6f3314;
         uint256 expectedCoinflip = 0;
@@ -118,15 +120,18 @@ contract CommitRevealRandomnessUnitTest is Test {
             expectedCoinflip,
             "v1: coinflip drift"
         );
-        assertTrue(CommitRevealRandomness.verifyCommit(server, expectedCommit), "v1: verifyCommit drift");
+        assertTrue(
+            CommitRevealRandomness.verifyCommit(server, expectedCommit), "v1: verifyCommit drift"
+        );
     }
 
     function test_parityVector2_coinflip() public pure {
-        bytes32 server = bytes32(uint256(0x1212121212121212121212121212121212121212121212121212121212121212));
-        bytes32 client = bytes32(uint256(0xfefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe));
+        bytes32 server =
+            bytes32(uint256(0x1212121212121212121212121212121212121212121212121212121212121212));
+        bytes32 client =
+            bytes32(uint256(0xfefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe));
         uint256 nonce = 42;
-        bytes32 expectedCommit =
-            0x1ade9f553ac636b4081983b175c3bbe991dd726b1cdbdb2588588cf5442bf50b;
+        bytes32 expectedCommit = 0x1ade9f553ac636b4081983b175c3bbe991dd726b1cdbdb2588588cf5442bf50b;
         bytes32 expectedOutcomeHash =
             0x93aa6cb4454b7a54b69f5718f5317374d38fac4713e58f048e70d92d20ae3b0c;
         uint256 expectedCoinflip = 0;
@@ -142,15 +147,17 @@ contract CommitRevealRandomnessUnitTest is Test {
             expectedCoinflip,
             "v2: coinflip drift"
         );
-        assertTrue(CommitRevealRandomness.verifyCommit(server, expectedCommit), "v2: verifyCommit drift");
+        assertTrue(
+            CommitRevealRandomness.verifyCommit(server, expectedCommit), "v2: verifyCommit drift"
+        );
     }
 
     function test_parityVector3_coinflip() public pure {
         bytes32 server = bytes32(uint256(0));
-        bytes32 client = bytes32(uint256(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff));
+        bytes32 client =
+            bytes32(uint256(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff));
         uint256 nonce = 999;
-        bytes32 expectedCommit =
-            0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563;
+        bytes32 expectedCommit = 0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563;
         bytes32 expectedOutcomeHash =
             0x728e65425523a8aba2498c23edc5b81dcccf9e2bba654e5b97fb88f6a9442e61;
         uint256 expectedCoinflip = 1;
@@ -166,7 +173,9 @@ contract CommitRevealRandomnessUnitTest is Test {
             expectedCoinflip,
             "v3: coinflip drift"
         );
-        assertTrue(CommitRevealRandomness.verifyCommit(server, expectedCommit), "v3: verifyCommit drift");
+        assertTrue(
+            CommitRevealRandomness.verifyCommit(server, expectedCommit), "v3: verifyCommit drift"
+        );
     }
 
     /// @notice Vector 4 — small integer seeds, dice (`mod=6`) and roll-under
@@ -176,8 +185,7 @@ contract CommitRevealRandomnessUnitTest is Test {
         bytes32 server = bytes32(uint256(1));
         bytes32 client = bytes32(uint256(2));
         uint256 nonce = 100;
-        bytes32 expectedCommit =
-            0xb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6;
+        bytes32 expectedCommit = 0xb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6;
         bytes32 expectedOutcomeHash =
             0x53fcaf77478d19cc564165ef5e0f22cbf2a347d03fce0828441d0f87ed5fde27;
         uint256 expectedMod6 = 1;
@@ -199,7 +207,9 @@ contract CommitRevealRandomnessUnitTest is Test {
             expectedMod100,
             "v4: roll-under drift"
         );
-        assertTrue(CommitRevealRandomness.verifyCommit(server, expectedCommit), "v4: verifyCommit drift");
+        assertTrue(
+            CommitRevealRandomness.verifyCommit(server, expectedCommit), "v4: verifyCommit drift"
+        );
     }
 
     /// @notice Vector 5 — keccak-derived seeds (typical production shape) with
@@ -211,8 +221,7 @@ contract CommitRevealRandomnessUnitTest is Test {
         // client = keccak256("client-v5")
         bytes32 client = 0x0a2a52793f8b0227b319e751a2079c406dddfcaac539ee4fc77326da39a8893b;
         uint256 nonce = 7;
-        bytes32 expectedCommit =
-            0x0d3bca55222e713c1577d7ad235266f7eabd6f14bfe2fa0497ee3b5ace87826a;
+        bytes32 expectedCommit = 0x0d3bca55222e713c1577d7ad235266f7eabd6f14bfe2fa0497ee3b5ace87826a;
         bytes32 expectedOutcomeHash =
             0x614dc4e9f30f5499a27fb7db75442b12fda175d363f6364afe9301a31851e8fd;
         uint256 expectedCoinflip = 1;
@@ -244,7 +253,9 @@ contract CommitRevealRandomnessUnitTest is Test {
             expectedRollUnder,
             "v5: roll-under drift"
         );
-        assertTrue(CommitRevealRandomness.verifyCommit(server, expectedCommit), "v5: verifyCommit drift");
+        assertTrue(
+            CommitRevealRandomness.verifyCommit(server, expectedCommit), "v5: verifyCommit drift"
+        );
     }
 
     // ────────────────────────────────────────────────────────────────────────
@@ -261,8 +272,8 @@ contract CommitRevealRandomnessUnitTest is Test {
         bytes32 client = keccak256("dist-test-client");
         uint256 totalRuns = 256;
         uint256 mod = 2;
-        uint256 expected = totalRuns / mod;       // 128
-        uint256 tolerance = expected / 10;        // 12 → ±10%
+        uint256 expected = totalRuns / mod; // 128
+        uint256 tolerance = expected / 10; // 12 → ±10%
 
         uint256[2] memory buckets;
         for (uint256 i = 0; i < totalRuns; i++) {

--- a/contracts/casino/test/ConstellationClimbUnit.t.sol
+++ b/contracts/casino/test/ConstellationClimbUnit.t.sol
@@ -25,20 +25,20 @@ contract ConstellationClimbUnitTest is Test {
     CasinoBankroll bankroll;
     ConstellationClimb game;
 
-    address owner   = address(0xB055);
-    address player  = address(0xCAFE);
-    address keeper  = address(0xBEEF);
+    address owner = address(0xB055);
+    address player = address(0xCAFE);
+    address keeper = address(0xBEEF);
 
-    bytes32 constant SERVER_SEED  = bytes32(uint256(0xA11CE));
+    bytes32 constant SERVER_SEED = bytes32(uint256(0xA11CE));
     bytes32 constant SERVER_SEED2 = bytes32(uint256(0xA11CE2));
-    bytes32 constant CLIENT_SEED  = bytes32(uint256(0xC11ABC));
+    bytes32 constant CLIENT_SEED = bytes32(uint256(0xC11ABC));
 
-    uint256 constant MIN_BET    = 0.001 ether;
-    uint256 constant MAX_BET    = 0.1 ether;
+    uint256 constant MIN_BET = 0.001 ether;
+    uint256 constant MAX_BET = 0.1 ether;
     uint256 constant MAX_PAYOUT = 5 ether;
-    uint256 constant SEED_AMT   = 200 ether; // generous to absorb compounded payouts
+    uint256 constant SEED_AMT = 200 ether; // generous to absorb compounded payouts
 
-    uint256 constant WAD      = 1e18;
+    uint256 constant WAD = 1e18;
     uint256 constant STEP_NUM = 12 * 99;
     uint256 constant STEP_DEN = 100;
 
@@ -70,7 +70,9 @@ contract ConstellationClimbUnitTest is Test {
     }
 
     function _initialCardFor(bytes32 client) internal pure returns (uint8) {
-        return uint8(uint256(keccak256(abi.encodePacked(client, bytes32(uint256(0xC0DECAFE))))) % 13) + 1;
+        return
+            uint8(uint256(keccak256(abi.encodePacked(client, bytes32(uint256(0xC0DECAFE))))) % 13)
+                + 1;
     }
 
     function _expectedHigherMult(uint256 oldMult, uint8 cur) internal pure returns (uint256) {
@@ -82,32 +84,32 @@ contract ConstellationClimbUnitTest is Test {
     }
 
     function _readCard(uint256 sessionId) internal view returns (uint8) {
-        ( , , , , , uint8 c, , , , ) = game.sessions(sessionId);
+        (,,,,, uint8 c,,,,) = game.sessions(sessionId);
         return c;
     }
 
     function _readMult(uint256 sessionId) internal view returns (uint256) {
-        ( , , , , , , , , uint256 m, ) = game.sessions(sessionId);
+        (,,,,,,,, uint256 m,) = game.sessions(sessionId);
         return m;
     }
 
     function _readStatus(uint256 sessionId) internal view returns (ConstellationClimb.Status) {
-        ( , , , , , , ConstellationClimb.Status st, , , ) = game.sessions(sessionId);
+        (,,,,,, ConstellationClimb.Status st,,,) = game.sessions(sessionId);
         return st;
     }
 
     function _readBet(uint256 sessionId) internal view returns (uint96) {
-        ( , uint96 b, , , , , , , , ) = game.sessions(sessionId);
+        (, uint96 b,,,,,,,,) = game.sessions(sessionId);
         return b;
     }
 
     function _readStepCount(uint256 sessionId) internal view returns (uint8) {
-        ( , , , , , , , uint8 sc, , ) = game.sessions(sessionId);
+        (,,,,,,, uint8 sc,,) = game.sessions(sessionId);
         return sc;
     }
 
     function _readNonce(uint256 sessionId) internal view returns (uint256) {
-        ( , , , , , , , , , uint256 n) = game.sessions(sessionId);
+        (,,,,,,,,, uint256 n) = game.sessions(sessionId);
         return n;
     }
 
@@ -180,14 +182,22 @@ contract ConstellationClimbUnitTest is Test {
     function test_quoteStepMultiplier_higherFormula() public view {
         for (uint8 c = 1; c <= 12; c++) {
             uint256 expected = (WAD * STEP_NUM) / ((13 - uint256(c)) * STEP_DEN);
-            assertEq(game.quoteStepMultiplier(c, ConstellationClimb.Direction.Higher), expected, "higher quote drift");
+            assertEq(
+                game.quoteStepMultiplier(c, ConstellationClimb.Direction.Higher),
+                expected,
+                "higher quote drift"
+            );
         }
     }
 
     function test_quoteStepMultiplier_lowerFormula() public view {
         for (uint8 c = 2; c <= 13; c++) {
             uint256 expected = (WAD * STEP_NUM) / ((uint256(c) - 1) * STEP_DEN);
-            assertEq(game.quoteStepMultiplier(c, ConstellationClimb.Direction.Lower), expected, "lower quote drift");
+            assertEq(
+                game.quoteStepMultiplier(c, ConstellationClimb.Direction.Lower),
+                expected,
+                "lower quote drift"
+            );
         }
     }
 
@@ -242,7 +252,9 @@ contract ConstellationClimbUnitTest is Test {
         uint256 expected = _expectedHigherMult(oldMult, cur);
         assertEq(_readMult(sid), expected, "higher compounding mismatch");
         assertEq(_readCard(sid), newCard, "currentCard advance");
-        assertEq(uint8(_readStatus(sid)), uint8(ConstellationClimb.Status.Open), "stays open after win");
+        assertEq(
+            uint8(_readStatus(sid)), uint8(ConstellationClimb.Status.Open), "stays open after win"
+        );
         assertEq(_readStepCount(sid), 1);
     }
 
@@ -317,7 +329,12 @@ contract ConstellationClimbUnitTest is Test {
         uint256 sid = _open(0.01 ether, CLIENT_SEED, _commit(SERVER_SEED));
         vm.prank(keeper);
         vm.expectRevert(ConstellationClimb.InvalidReveal.selector);
-        game.playStep(sid, ConstellationClimb.Direction.Higher, bytes32(uint256(0xDEAD)), _commit(SERVER_SEED2));
+        game.playStep(
+            sid,
+            ConstellationClimb.Direction.Higher,
+            bytes32(uint256(0xDEAD)),
+            _commit(SERVER_SEED2)
+        );
     }
 
     function test_playStep_revertsHigherAt13() public {
@@ -482,7 +499,9 @@ contract ConstellationClimbUnitTest is Test {
             uint8 cur = _readCard(sid);
             vm.prank(keeper);
             game.playStep(sid, ConstellationClimb.Direction.Higher, server, _commit(SERVER_SEED2));
-            assertEq(uint8(_readStatus(sid)), uint8(ConstellationClimb.Status.Open), "WIN stays Open");
+            assertEq(
+                uint8(_readStatus(sid)), uint8(ConstellationClimb.Status.Open), "WIN stays Open"
+            );
             assertEq(_readMult(sid), _expectedHigherMult(oldMult, cur));
         }
 
@@ -594,16 +613,20 @@ contract ConstellationClimbUnitTest is Test {
     // ---- Cross-layer parity (mirrors verify package hiloCard vectors) ----
 
     function test_parityHilo_v1() public pure {
-        bytes32 server = bytes32(uint256(0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa));
-        bytes32 client = bytes32(uint256(0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb));
+        bytes32 server =
+            bytes32(uint256(0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa));
+        bytes32 client =
+            bytes32(uint256(0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb));
         uint256 nonce = 0;
         uint256 raw = CommitRevealRandomness.rollOutcome(server, client, nonce, 13);
         assertEq(raw + 1, _expectedHiloV1(), "v1 hilo drift");
     }
 
     function test_parityHilo_v2() public pure {
-        bytes32 server = bytes32(uint256(0x1212121212121212121212121212121212121212121212121212121212121212));
-        bytes32 client = bytes32(uint256(0xfefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe));
+        bytes32 server =
+            bytes32(uint256(0x1212121212121212121212121212121212121212121212121212121212121212));
+        bytes32 client =
+            bytes32(uint256(0xfefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe));
         uint256 nonce = 42;
         uint256 raw = CommitRevealRandomness.rollOutcome(server, client, nonce, 13);
         assertEq(raw + 1, _expectedHiloV2(), "v2 hilo drift");
@@ -611,27 +634,33 @@ contract ConstellationClimbUnitTest is Test {
 
     function test_parityHilo_v3() public pure {
         bytes32 server = bytes32(uint256(0));
-        bytes32 client = bytes32(uint256(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff));
+        bytes32 client =
+            bytes32(uint256(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff));
         uint256 nonce = 999;
         uint256 raw = CommitRevealRandomness.rollOutcome(server, client, nonce, 13);
         assertEq(raw + 1, _expectedHiloV3(), "v3 hilo drift");
     }
 
     function _expectedHiloV1() internal pure returns (uint256) {
-        bytes32 server = bytes32(uint256(0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa));
-        bytes32 client = bytes32(uint256(0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb));
+        bytes32 server =
+            bytes32(uint256(0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa));
+        bytes32 client =
+            bytes32(uint256(0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb));
         return (uint256(keccak256(abi.encodePacked(server, client, uint256(0)))) % 13) + 1;
     }
 
     function _expectedHiloV2() internal pure returns (uint256) {
-        bytes32 server = bytes32(uint256(0x1212121212121212121212121212121212121212121212121212121212121212));
-        bytes32 client = bytes32(uint256(0xfefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe));
+        bytes32 server =
+            bytes32(uint256(0x1212121212121212121212121212121212121212121212121212121212121212));
+        bytes32 client =
+            bytes32(uint256(0xfefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe));
         return (uint256(keccak256(abi.encodePacked(server, client, uint256(42)))) % 13) + 1;
     }
 
     function _expectedHiloV3() internal pure returns (uint256) {
         bytes32 server = bytes32(uint256(0));
-        bytes32 client = bytes32(uint256(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff));
+        bytes32 client =
+            bytes32(uint256(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff));
         return (uint256(keccak256(abi.encodePacked(server, client, uint256(999)))) % 13) + 1;
     }
 
@@ -655,9 +684,8 @@ contract ConstellationClimbUnitTest is Test {
         vm.assume(!game.commitUsed(openCommit));
 
         vm.prank(player);
-        uint256 sid = game.openSession{value: bound(uint256(fStake), MIN_BET, MAX_BET)}(
-            fClient, openCommit
-        );
+        uint256 sid =
+            game.openSession{value: bound(uint256(fStake), MIN_BET, MAX_BET)}(fClient, openCommit);
 
         _runFuzzStep(sid, dir, fSeed, fClient);
     }
@@ -692,7 +720,9 @@ contract ConstellationClimbUnitTest is Test {
         }
     }
 
-    function testFuzz_sessionLength_compoundsCorrectly(uint8 fK, bytes32 fClient, bytes32 fSeed0) public {
+    function testFuzz_sessionLength_compoundsCorrectly(uint8 fK, bytes32 fClient, bytes32 fSeed0)
+        public
+    {
         uint256 K = bound(uint256(fK), 1, 6);
         uint8 initial = _initialCardFor(fClient);
         if (initial == 13 || initial == 1) return;
@@ -712,9 +742,8 @@ contract ConstellationClimbUnitTest is Test {
             if (st != ConstellationClimb.Status.Open) break;
 
             uint8 cur = _readCard(sid);
-            ConstellationClimb.Direction dir = cur < 13
-                ? ConstellationClimb.Direction.Higher
-                : ConstellationClimb.Direction.Lower;
+            ConstellationClimb.Direction dir =
+                cur < 13 ? ConstellationClimb.Direction.Higher : ConstellationClimb.Direction.Lower;
 
             uint256 stepNonceVal = _stepNonce(sid, uint8(i));
             uint8 newCard = _cardFor(seeds[i], fClient, stepNonceVal);
@@ -802,22 +831,28 @@ contract ClimbHandler is Test {
         if (openSessions.length == 0) return;
         uint256 i = idx % openSessions.length;
         uint256 sid = openSessions[i];
-        ( , uint96 stk, , , , uint8 cur, ConstellationClimb.Status status, , , ) = game.sessions(sid);
+        (, uint96 stk,,,, uint8 cur, ConstellationClimb.Status status,,,) = game.sessions(sid);
         if (status != ConstellationClimb.Status.Open) {
             _swapPop(i);
             return;
         }
 
         ConstellationClimb.Direction dir;
-        if (cur >= 13) dir = ConstellationClimb.Direction.Lower;
-        else if (cur <= 1) dir = ConstellationClimb.Direction.Higher;
-        else dir = (dirSeed % 2) == 0 ? ConstellationClimb.Direction.Higher : ConstellationClimb.Direction.Lower;
+        if (cur >= 13) {
+            dir = ConstellationClimb.Direction.Lower;
+        } else if (cur <= 1) {
+            dir = ConstellationClimb.Direction.Higher;
+        } else {
+            dir = (dirSeed % 2) == 0
+                ? ConstellationClimb.Direction.Higher
+                : ConstellationClimb.Direction.Lower;
+        }
 
         bytes32 reveal = openSeedOf[sid];
         bytes32 nextCommit = keccak256(abi.encodePacked("climb-handler-step", sid, dirSeed));
 
         try game.playStep(sid, dir, reveal, nextCommit) {
-            ( , , , , , , ConstellationClimb.Status nst, , , ) = game.sessions(sid);
+            (,,,,,, ConstellationClimb.Status nst,,,) = game.sessions(sid);
             if (nst == ConstellationClimb.Status.Lost) {
                 _swapPop(i);
             } else if (nst == ConstellationClimb.Status.Pushed) {
@@ -838,7 +873,8 @@ contract ClimbHandler is Test {
         if (_pendingCashOuts.length == 0) return;
         uint256 i = idx % _pendingCashOuts.length;
         uint256 sid = _pendingCashOuts[i];
-        ( address p, uint96 stake, , , , , ConstellationClimb.Status status, , uint256 mult, ) = game.sessions(sid);
+        (address p, uint96 stake,,,,, ConstellationClimb.Status status,, uint256 mult,) =
+            game.sessions(sid);
         if (status != ConstellationClimb.Status.Open) {
             _swapPopPending(i);
             return;
@@ -857,7 +893,8 @@ contract ClimbHandler is Test {
         if (openSessions.length == 0) return;
         uint256 i = idx % openSessions.length;
         uint256 sid = openSessions[i];
-        ( address p, uint96 stake, , , uint64 last, , ConstellationClimb.Status status, , , ) = game.sessions(sid);
+        (address p, uint96 stake,,, uint64 last,, ConstellationClimb.Status status,,,) =
+            game.sessions(sid);
         if (status != ConstellationClimb.Status.Open) {
             _swapPop(i);
             return;
@@ -931,7 +968,7 @@ contract ConstellationClimbInvariant is StdInvariant, Test {
     function _sumPendingStakes() internal view returns (uint256 total) {
         uint256 next = game.nextSessionId();
         for (uint256 i = 0; i < next; i++) {
-            ( , uint96 stake, , , , , ConstellationClimb.Status status, , , ) = game.sessions(i);
+            (, uint96 stake,,,,, ConstellationClimb.Status status,,,) = game.sessions(i);
             if (status == ConstellationClimb.Status.Open) total += stake;
         }
     }

--- a/contracts/casino/test/CosmicFlipCommitReplay.t.sol
+++ b/contracts/casino/test/CosmicFlipCommitReplay.t.sol
@@ -15,15 +15,15 @@ contract CosmicFlipCommitReplayTest is Test {
     CasinoBankroll bankroll;
     CosmicFlip game;
 
-    address owner   = address(0xB055);
-    address player  = address(0xCAFE);
-    address keeper  = address(0xBEEF);
+    address owner = address(0xB055);
+    address player = address(0xCAFE);
+    address keeper = address(0xBEEF);
 
     bytes32 constant SERVER_SEED = bytes32(uint256(0xA11CE));
     bytes32 constant CLIENT_SEED = bytes32(uint256(0xC11ABC));
 
-    uint256 constant MIN_BET  = 0.001 ether;
-    uint256 constant MAX_BET  = 0.1 ether;
+    uint256 constant MIN_BET = 0.001 ether;
+    uint256 constant MAX_BET = 0.1 ether;
     uint256 constant SEED_AMT = 10 ether;
 
     function setUp() public {
@@ -59,10 +59,8 @@ contract CosmicFlipCommitReplayTest is Test {
         //    computes the deterministic outcome for their NEXT nonce and
         //    bets the winning side.
         uint256 nextNonce = game.playerNonce(player);
-        uint256 outcome =
-            CommitRevealRandomness.rollOutcome(SERVER_SEED, CLIENT_SEED, nextNonce, 2);
-        CosmicFlip.Side guaranteedWin =
-            outcome == 0 ? CosmicFlip.Side.Heads : CosmicFlip.Side.Tails;
+        uint256 outcome = CommitRevealRandomness.rollOutcome(SERVER_SEED, CLIENT_SEED, nextNonce, 2);
+        CosmicFlip.Side guaranteedWin = outcome == 0 ? CosmicFlip.Side.Heads : CosmicFlip.Side.Tails;
 
         // 3) The contract MUST reject the replay. The expected behaviour is a
         //    revert with the dedicated `CommitAlreadyUsed` selector once the

--- a/contracts/casino/test/CosmicFlipHalmos.t.sol
+++ b/contracts/casino/test/CosmicFlipHalmos.t.sol
@@ -28,8 +28,8 @@ contract CosmicFlipHalmosTest is Test {
 
     address constant OWNER = address(0xB055);
 
-    uint256 constant MIN_BET  = 0.001 ether;
-    uint256 constant MAX_BET  = 0.1 ether;
+    uint256 constant MIN_BET = 0.001 ether;
+    uint256 constant MAX_BET = 0.1 ether;
     uint256 constant SEED_AMT = 10 ether;
 
     function setUp() public {
@@ -49,8 +49,8 @@ contract CosmicFlipHalmosTest is Test {
     function check_commitReplay_directReverts(
         address player1,
         address player2,
-        uint8   side1Raw,
-        uint8   side2Raw,
+        uint8 side1Raw,
+        uint8 side2Raw,
         bytes32 clientSeed1,
         bytes32 clientSeed2,
         bytes32 commit,
@@ -113,8 +113,8 @@ contract CosmicFlipHalmosTest is Test {
         address player1,
         address player2,
         address keeper,
-        uint8   side1Raw,
-        uint8   side2Raw,
+        uint8 side1Raw,
+        uint8 side2Raw,
         bytes32 clientSeed1,
         bytes32 clientSeed2,
         bytes32 commit,
@@ -124,10 +124,10 @@ contract CosmicFlipHalmosTest is Test {
     ) public {
         vm.assume(player1 != address(0));
         vm.assume(player2 != address(0));
-        vm.assume(keeper  != address(0));
+        vm.assume(keeper != address(0));
         vm.assume(player1 != address(game) && player1 != address(bankroll));
         vm.assume(player2 != address(game) && player2 != address(bankroll));
-        vm.assume(keeper  != address(game) && keeper  != address(bankroll));
+        vm.assume(keeper != address(game) && keeper != address(bankroll));
         vm.assume(commit != bytes32(0));
         vm.assume(stake1 >= MIN_BET && stake1 <= MAX_BET);
         vm.assume(stake2 >= MIN_BET && stake2 <= MAX_BET);
@@ -185,8 +185,8 @@ contract CosmicFlipHalmosTest is Test {
     function check_commit_reveal_one_to_one(
         address player1,
         address player2,
-        uint8   side1Raw,
-        uint8   side2Raw,
+        uint8 side1Raw,
+        uint8 side2Raw,
         bytes32 clientSeed1,
         bytes32 clientSeed2,
         bytes32 commit,
@@ -194,11 +194,7 @@ contract CosmicFlipHalmosTest is Test {
         uint256 stake2
     ) public {
         check_commitReplay_directReverts(
-            player1, player2,
-            side1Raw, side2Raw,
-            clientSeed1, clientSeed2,
-            commit,
-            stake1, stake2
+            player1, player2, side1Raw, side2Raw, clientSeed1, clientSeed2, commit, stake1, stake2
         );
     }
 
@@ -231,7 +227,7 @@ contract CosmicFlipHalmosTest is Test {
     ///         reason the two checks above hold.
     function check_commitUsed_isMonotone(
         address player,
-        uint8   sideRaw,
+        uint8 sideRaw,
         bytes32 clientSeed,
         bytes32 commit,
         bytes32 reveal,
@@ -246,8 +242,7 @@ contract CosmicFlipHalmosTest is Test {
         vm.deal(player, stake);
 
         vm.prank(player);
-        uint256 betId =
-            game.placeBet{value: stake}(CosmicFlip.Side(sideRaw), clientSeed, commit);
+        uint256 betId = game.placeBet{value: stake}(CosmicFlip.Side(sideRaw), clientSeed, commit);
 
         assertTrue(game.commitUsed(commit), "commit should be marked used");
 

--- a/contracts/casino/test/CosmicFlipUnit.t.sol
+++ b/contracts/casino/test/CosmicFlipUnit.t.sol
@@ -10,9 +10,9 @@ contract CosmicFlipUnitTest is Test {
     CasinoBankroll bankroll;
     CosmicFlip game;
 
-    address owner   = address(0xB055);
-    address player  = address(0xCAFE);
-    address keeper  = address(0xBEEF); // backend that calls settleBet
+    address owner = address(0xB055);
+    address player = address(0xCAFE);
+    address keeper = address(0xBEEF); // backend that calls settleBet
 
     bytes32 constant SERVER_SEED = bytes32(uint256(0xA11CE));
     bytes32 constant CLIENT_SEED = bytes32(uint256(0xC11ABC));
@@ -50,13 +50,10 @@ contract CosmicFlipUnitTest is Test {
         uint256 betId = _placeBet(CosmicFlip.Side.Heads, 0.01 ether);
         (
             address p,
-            uint96 stake,
-            ,
-            bytes32 commit,
-            ,
+            uint96 stake,,
+            bytes32 commit,,
             CosmicFlip.Side side,
-            CosmicFlip.Status status,
-            ,
+            CosmicFlip.Status status,,
         ) = game.bets(betId);
         assertEq(p, player);
         assertEq(stake, uint96(0.01 ether));
@@ -68,27 +65,21 @@ contract CosmicFlipUnitTest is Test {
     function test_placeBet_revertsBelowMin() public {
         vm.prank(player);
         vm.expectRevert(CosmicFlip.StakeOutOfBounds.selector);
-        game.placeBet{value: MIN_BET - 1}(
-            CosmicFlip.Side.Heads, CLIENT_SEED, _commit(SERVER_SEED)
-        );
+        game.placeBet{value: MIN_BET - 1}(CosmicFlip.Side.Heads, CLIENT_SEED, _commit(SERVER_SEED));
     }
 
     function test_placeBet_revertsAboveMax() public {
         vm.prank(player);
         vm.expectRevert(CosmicFlip.StakeOutOfBounds.selector);
-        game.placeBet{value: MAX_BET + 1}(
-            CosmicFlip.Side.Heads, CLIENT_SEED, _commit(SERVER_SEED)
-        );
+        game.placeBet{value: MAX_BET + 1}(CosmicFlip.Side.Heads, CLIENT_SEED, _commit(SERVER_SEED));
     }
 
     function test_settleBet_winnerPaysOut198x() public {
         uint256 stake = 0.01 ether;
         // Compute the rolled side off-chain (mirrors the on-chain math).
         uint256 nonceUsed = game.playerNonce(player);
-        uint256 outcome =
-            CommitRevealRandomness.rollOutcome(SERVER_SEED, CLIENT_SEED, nonceUsed, 2);
-        CosmicFlip.Side rolled =
-            outcome == 0 ? CosmicFlip.Side.Heads : CosmicFlip.Side.Tails;
+        uint256 outcome = CommitRevealRandomness.rollOutcome(SERVER_SEED, CLIENT_SEED, nonceUsed, 2);
+        CosmicFlip.Side rolled = outcome == 0 ? CosmicFlip.Side.Heads : CosmicFlip.Side.Tails;
 
         uint256 betId = _placeBet(rolled, stake);
 
@@ -99,7 +90,7 @@ contract CosmicFlipUnitTest is Test {
         uint256 expectedPayout = (stake * 198) / 100;
         assertEq(player.balance, playerBefore + expectedPayout, "winner payout = 1.98x stake");
 
-        (, , , , , , CosmicFlip.Status status, ,) = game.bets(betId);
+        (,,,,,, CosmicFlip.Status status,,) = game.bets(betId);
         assertEq(uint8(status), uint8(CosmicFlip.Status.Won));
     }
 
@@ -107,10 +98,8 @@ contract CosmicFlipUnitTest is Test {
         uint256 stake = 0.01 ether;
         // Pick the *opposite* of what would have rolled.
         uint256 nonceUsed = game.playerNonce(player);
-        uint256 outcome =
-            CommitRevealRandomness.rollOutcome(SERVER_SEED, CLIENT_SEED, nonceUsed, 2);
-        CosmicFlip.Side losing =
-            outcome == 0 ? CosmicFlip.Side.Tails : CosmicFlip.Side.Heads;
+        uint256 outcome = CommitRevealRandomness.rollOutcome(SERVER_SEED, CLIENT_SEED, nonceUsed, 2);
+        CosmicFlip.Side losing = outcome == 0 ? CosmicFlip.Side.Tails : CosmicFlip.Side.Heads;
 
         uint256 betId = _placeBet(losing, stake);
 
@@ -119,7 +108,7 @@ contract CosmicFlipUnitTest is Test {
         game.settleBet(betId, SERVER_SEED);
 
         assertEq(player.balance, playerBefore, "loser receives nothing");
-        (, , , , , , CosmicFlip.Status status, ,) = game.bets(betId);
+        (,,,,,, CosmicFlip.Status status,,) = game.bets(betId);
         assertEq(uint8(status), uint8(CosmicFlip.Status.Lost));
     }
 
@@ -156,7 +145,7 @@ contract CosmicFlipUnitTest is Test {
         game.refundBet(betId);
         assertEq(player.balance, playerBefore + stake, "refund returns full stake");
 
-        (, , , , , , CosmicFlip.Status status, ,) = game.bets(betId);
+        (,,,,,, CosmicFlip.Status status,,) = game.bets(betId);
         assertEq(uint8(status), uint8(CosmicFlip.Status.Refunded));
     }
 
@@ -212,9 +201,7 @@ contract CosmicFlipUnitTest is Test {
         game.pause();
         vm.prank(player);
         vm.expectRevert();
-        game.placeBet{value: 0.01 ether}(
-            CosmicFlip.Side.Heads, CLIENT_SEED, _commit(SERVER_SEED)
-        );
+        game.placeBet{value: 0.01 ether}(CosmicFlip.Side.Heads, CLIENT_SEED, _commit(SERVER_SEED));
     }
 
     // ---- Fuzz: settlement math holds for arbitrary (server, client, nonce) ----
@@ -225,8 +212,7 @@ contract CosmicFlipUnitTest is Test {
 
         uint256 nonceUsed = game.playerNonce(player);
         uint256 outcome = CommitRevealRandomness.rollOutcome(fSeed, fClient, nonceUsed, 2);
-        CosmicFlip.Side rolled =
-            outcome == 0 ? CosmicFlip.Side.Heads : CosmicFlip.Side.Tails;
+        CosmicFlip.Side rolled = outcome == 0 ? CosmicFlip.Side.Heads : CosmicFlip.Side.Tails;
 
         vm.prank(player);
         uint256 betId = game.placeBet{value: stake}(rolled, fClient, commit);

--- a/contracts/casino/test/DeployDeterministic.t.sol
+++ b/contracts/casino/test/DeployDeterministic.t.sol
@@ -29,16 +29,15 @@ contract DeployDeterministicTest is Test, CreateXScript {
 
     /// @dev Salt entropy values must match `Deploy.s.sol`'s defaults.
     uint88 internal constant BANKROLL_ENTROPY = 0xBB01;
-    uint88 internal constant FLIP_ENTROPY     = 0xBBC1;
-    uint88 internal constant DICE_ENTROPY     = 0xBBD1;
-    uint88 internal constant CLIMB_ENTROPY    = 0xBBA1;
+    uint88 internal constant FLIP_ENTROPY = 0xBBC1;
+    uint88 internal constant DICE_ENTROPY = 0xBBD1;
+    uint88 internal constant CLIMB_ENTROPY = 0xBBA1;
 
     /// @dev The live production deployer for `deployments/10143.json`. The
     ///      address book test below pins CREATE3 predictions for this deployer
     ///      against the Monad-testnet artifact so we notice the moment salt
     ///      encoding or default entropy drifts.
-    address internal constant PROD_DEPLOYER =
-        0xb29e6735629539cEd64F0d6f0c476Fe92539fD7B;
+    address internal constant PROD_DEPLOYER = 0xb29e6735629539cEd64F0d6f0c476Fe92539fD7B;
 
     function setUp() public withCreateX {
         vm.deal(deployer, 100 ether);
@@ -58,47 +57,47 @@ contract DeployDeterministicTest is Test, CreateXScript {
     ///         chain X" footgun for any of the games.
     function test_sameSaltYieldsSameAddressAcrossChains() public {
         bytes32 bankrollSalt = _packSalt(deployer, BANKROLL_ENTROPY);
-        bytes32 flipSalt     = _packSalt(deployer, FLIP_ENTROPY);
-        bytes32 diceSalt     = _packSalt(deployer, DICE_ENTROPY);
-        bytes32 climbSalt    = _packSalt(deployer, CLIMB_ENTROPY);
+        bytes32 flipSalt = _packSalt(deployer, FLIP_ENTROPY);
+        bytes32 diceSalt = _packSalt(deployer, DICE_ENTROPY);
+        bytes32 climbSalt = _packSalt(deployer, CLIMB_ENTROPY);
 
         // anvil
         vm.chainId(31337);
         address bankrollOnAnvil = computeCreate3Address(bankrollSalt, deployer);
-        address flipOnAnvil     = computeCreate3Address(flipSalt,     deployer);
-        address diceOnAnvil     = computeCreate3Address(diceSalt,     deployer);
-        address climbOnAnvil    = computeCreate3Address(climbSalt,    deployer);
+        address flipOnAnvil = computeCreate3Address(flipSalt, deployer);
+        address diceOnAnvil = computeCreate3Address(diceSalt, deployer);
+        address climbOnAnvil = computeCreate3Address(climbSalt, deployer);
 
         // Monad testnet
         vm.chainId(10143);
         address bankrollOnTestnet = computeCreate3Address(bankrollSalt, deployer);
-        address flipOnTestnet     = computeCreate3Address(flipSalt,     deployer);
-        address diceOnTestnet     = computeCreate3Address(diceSalt,     deployer);
-        address climbOnTestnet    = computeCreate3Address(climbSalt,    deployer);
+        address flipOnTestnet = computeCreate3Address(flipSalt, deployer);
+        address diceOnTestnet = computeCreate3Address(diceSalt, deployer);
+        address climbOnTestnet = computeCreate3Address(climbSalt, deployer);
 
         // Monad mainnet
         vm.chainId(143);
         address bankrollOnMainnet = computeCreate3Address(bankrollSalt, deployer);
-        address flipOnMainnet     = computeCreate3Address(flipSalt,     deployer);
-        address diceOnMainnet     = computeCreate3Address(diceSalt,     deployer);
-        address climbOnMainnet    = computeCreate3Address(climbSalt,    deployer);
+        address flipOnMainnet = computeCreate3Address(flipSalt, deployer);
+        address diceOnMainnet = computeCreate3Address(diceSalt, deployer);
+        address climbOnMainnet = computeCreate3Address(climbSalt, deployer);
 
         assertEq(bankrollOnAnvil, bankrollOnTestnet, "bankroll drifts anvil->testnet");
         assertEq(bankrollOnAnvil, bankrollOnMainnet, "bankroll drifts anvil->mainnet");
-        assertEq(flipOnAnvil,     flipOnTestnet,     "flip drifts anvil->testnet");
-        assertEq(flipOnAnvil,     flipOnMainnet,     "flip drifts anvil->mainnet");
-        assertEq(diceOnAnvil,     diceOnTestnet,     "dice drifts anvil->testnet");
-        assertEq(diceOnAnvil,     diceOnMainnet,     "dice drifts anvil->mainnet");
-        assertEq(climbOnAnvil,    climbOnTestnet,    "climb drifts anvil->testnet");
-        assertEq(climbOnAnvil,    climbOnMainnet,    "climb drifts anvil->mainnet");
+        assertEq(flipOnAnvil, flipOnTestnet, "flip drifts anvil->testnet");
+        assertEq(flipOnAnvil, flipOnMainnet, "flip drifts anvil->mainnet");
+        assertEq(diceOnAnvil, diceOnTestnet, "dice drifts anvil->testnet");
+        assertEq(diceOnAnvil, diceOnMainnet, "dice drifts anvil->mainnet");
+        assertEq(climbOnAnvil, climbOnTestnet, "climb drifts anvil->testnet");
+        assertEq(climbOnAnvil, climbOnMainnet, "climb drifts anvil->mainnet");
 
         // Distinct entropy => distinct addresses for every contract pair.
-        assertTrue(bankrollOnAnvil != flipOnAnvil,  "bankroll/flip share addr");
-        assertTrue(bankrollOnAnvil != diceOnAnvil,  "bankroll/dice share addr");
+        assertTrue(bankrollOnAnvil != flipOnAnvil, "bankroll/flip share addr");
+        assertTrue(bankrollOnAnvil != diceOnAnvil, "bankroll/dice share addr");
         assertTrue(bankrollOnAnvil != climbOnAnvil, "bankroll/climb share addr");
-        assertTrue(flipOnAnvil     != diceOnAnvil,  "flip/dice share addr");
-        assertTrue(flipOnAnvil     != climbOnAnvil, "flip/climb share addr");
-        assertTrue(diceOnAnvil     != climbOnAnvil, "dice/climb share addr");
+        assertTrue(flipOnAnvil != diceOnAnvil, "flip/dice share addr");
+        assertTrue(flipOnAnvil != climbOnAnvil, "flip/climb share addr");
+        assertTrue(diceOnAnvil != climbOnAnvil, "dice/climb share addr");
     }
 
     /// @notice Different deployers -> different addresses for the same salt.
@@ -106,8 +105,9 @@ contract DeployDeterministicTest is Test, CreateXScript {
     ///         bytes of the salt are the deployer's address).
     function test_differentDeployerYieldsDifferentAddress() public view {
         uint88 entropy = BANKROLL_ENTROPY;
-        address addrA = computeCreate3Address(_packSalt(address(0xA11CE), entropy), address(0xA11CE));
-        address addrB = computeCreate3Address(_packSalt(address(0xB0B),   entropy), address(0xB0B));
+        address addrA =
+            computeCreate3Address(_packSalt(address(0xA11CE), entropy), address(0xA11CE));
+        address addrB = computeCreate3Address(_packSalt(address(0xB0B), entropy), address(0xB0B));
         assertTrue(addrA != addrB, "permissioned-deploy guard broken");
     }
 
@@ -120,13 +120,13 @@ contract DeployDeterministicTest is Test, CreateXScript {
     ///         registered.
     function test_deployScriptYieldsPredictedAddresses() public {
         bytes32 bankrollSalt = _packSalt(deployer, BANKROLL_ENTROPY);
-        bytes32 flipSalt     = _packSalt(deployer, FLIP_ENTROPY);
-        bytes32 diceSalt     = _packSalt(deployer, DICE_ENTROPY);
-        bytes32 climbSalt    = _packSalt(deployer, CLIMB_ENTROPY);
+        bytes32 flipSalt = _packSalt(deployer, FLIP_ENTROPY);
+        bytes32 diceSalt = _packSalt(deployer, DICE_ENTROPY);
+        bytes32 climbSalt = _packSalt(deployer, CLIMB_ENTROPY);
         address expectedBankroll = computeCreate3Address(bankrollSalt, deployer);
-        address expectedFlip     = computeCreate3Address(flipSalt,     deployer);
-        address expectedDice     = computeCreate3Address(diceSalt,     deployer);
-        address expectedClimb    = computeCreate3Address(climbSalt,    deployer);
+        address expectedFlip = computeCreate3Address(flipSalt, deployer);
+        address expectedDice = computeCreate3Address(diceSalt, deployer);
+        address expectedClimb = computeCreate3Address(climbSalt, deployer);
 
         // Use a unique chainId so the script's `deployments/<chainId>.json`
         // writeup lands in a test-only artifact instead of clobbering the
@@ -143,24 +143,23 @@ contract DeployDeterministicTest is Test, CreateXScript {
         // and doesn't fight a vm.prank like the implicit-broadcaster branch
         // would.
         vm.setEnv("PRIVATE_KEY", vm.toString(bytes32(DEPLOYER_PK)));
-        (address bankrollAddr, address flipAddr, address diceAddr, address climbAddr) =
-            script.run();
+        (address bankrollAddr, address flipAddr, address diceAddr, address climbAddr) = script.run();
 
         assertEq(bankrollAddr, expectedBankroll, "deploy bankroll != predicted");
-        assertEq(flipAddr,     expectedFlip,     "deploy flip != predicted");
-        assertEq(diceAddr,     expectedDice,     "deploy dice != predicted");
-        assertEq(climbAddr,    expectedClimb,    "deploy climb != predicted");
+        assertEq(flipAddr, expectedFlip, "deploy flip != predicted");
+        assertEq(diceAddr, expectedDice, "deploy dice != predicted");
+        assertEq(climbAddr, expectedClimb, "deploy climb != predicted");
 
         // Sanity: deployed bytecode is non-empty.
         assertGt(bankrollAddr.code.length, 0, "bankroll has no code");
-        assertGt(flipAddr.code.length,     0, "flip has no code");
-        assertGt(diceAddr.code.length,     0, "dice has no code");
-        assertGt(climbAddr.code.length,    0, "climb has no code");
+        assertGt(flipAddr.code.length, 0, "flip has no code");
+        assertGt(diceAddr.code.length, 0, "dice has no code");
+        assertGt(climbAddr.code.length, 0, "climb has no code");
 
         // Wiring sanity: every game is registered against the bankroll.
         CasinoBankroll bankroll = CasinoBankroll(payable(bankrollAddr));
-        assertTrue(bankroll.isGame(flipAddr),  "flip not registered as game");
-        assertTrue(bankroll.isGame(diceAddr),  "dice not registered as game");
+        assertTrue(bankroll.isGame(flipAddr), "flip not registered as game");
+        assertTrue(bankroll.isGame(diceAddr), "dice not registered as game");
         assertTrue(bankroll.isGame(climbAddr), "climb not registered as game");
 
         _cleanupTestDeploymentJson();
@@ -174,14 +173,14 @@ contract DeployDeterministicTest is Test, CreateXScript {
     ///         address book.
     function test_predictionsMatchDeployments10143Json() public view {
         bytes32 bankrollSalt = _packSalt(PROD_DEPLOYER, BANKROLL_ENTROPY);
-        bytes32 flipSalt     = _packSalt(PROD_DEPLOYER, FLIP_ENTROPY);
-        bytes32 diceSalt     = _packSalt(PROD_DEPLOYER, DICE_ENTROPY);
-        bytes32 climbSalt    = _packSalt(PROD_DEPLOYER, CLIMB_ENTROPY);
+        bytes32 flipSalt = _packSalt(PROD_DEPLOYER, FLIP_ENTROPY);
+        bytes32 diceSalt = _packSalt(PROD_DEPLOYER, DICE_ENTROPY);
+        bytes32 climbSalt = _packSalt(PROD_DEPLOYER, CLIMB_ENTROPY);
 
         address predictedBankroll = computeCreate3Address(bankrollSalt, PROD_DEPLOYER);
-        address predictedFlip     = computeCreate3Address(flipSalt,     PROD_DEPLOYER);
-        address predictedDice     = computeCreate3Address(diceSalt,     PROD_DEPLOYER);
-        address predictedClimb    = computeCreate3Address(climbSalt,    PROD_DEPLOYER);
+        address predictedFlip = computeCreate3Address(flipSalt, PROD_DEPLOYER);
+        address predictedDice = computeCreate3Address(diceSalt, PROD_DEPLOYER);
+        address predictedClimb = computeCreate3Address(climbSalt, PROD_DEPLOYER);
 
         // Pinned from contracts/casino/deployments/10143.json (Monad testnet).
         // Update this test in lock-step if the deployer or default entropy

--- a/contracts/casino/test/GravityDiceUnit.t.sol
+++ b/contracts/casino/test/GravityDiceUnit.t.sol
@@ -20,9 +20,9 @@ contract GravityDiceUnitTest is Test {
     CasinoBankroll bankroll;
     GravityDice game;
 
-    address owner   = address(0xB055);
-    address player  = address(0xCAFE);
-    address keeper  = address(0xBEEF);
+    address owner = address(0xB055);
+    address player = address(0xCAFE);
+    address keeper = address(0xBEEF);
 
     bytes32 constant SERVER_SEED = bytes32(uint256(0xA11CE));
     bytes32 constant CLIENT_SEED = bytes32(uint256(0xC11ABC));
@@ -64,14 +64,11 @@ contract GravityDiceUnitTest is Test {
         uint256 betId = _placeBet(50, 0.01 ether);
         (
             address p,
-            uint96 stake,
-            ,
-            bytes32 commit,
-            ,
+            uint96 stake,,
+            bytes32 commit,,
             uint8 ru,
             GravityDice.Status status,
-            uint8 roll,
-            ,
+            uint8 roll,,
         ) = game.bets(betId);
         assertEq(p, player);
         assertEq(stake, uint96(0.01 ether));
@@ -95,13 +92,13 @@ contract GravityDiceUnitTest is Test {
 
     function test_placeBet_acceptsBoundary_min() public {
         uint256 betId = _placeBet(2, 0.01 ether);
-        (, , , , , uint8 ru, , , ,) = game.bets(betId);
+        (,,,,, uint8 ru,,,,) = game.bets(betId);
         assertEq(ru, 2);
     }
 
     function test_placeBet_acceptsBoundary_max() public {
         uint256 betId = _placeBet(98, 0.01 ether);
-        (, , , , , uint8 ru, , , ,) = game.bets(betId);
+        (,,,,, uint8 ru,,,,) = game.bets(betId);
         assertEq(ru, 98);
     }
 
@@ -139,7 +136,7 @@ contract GravityDiceUnitTest is Test {
         uint256 expectedPayout = (stake * 99) / (uint256(ru) - 1);
         assertEq(player.balance, playerBefore + expectedPayout, "winner payout = stake * 99/(R-1)");
 
-        (, , , , , , GravityDice.Status status, uint8 storedRoll, ,) = game.bets(betId);
+        (,,,,,, GravityDice.Status status, uint8 storedRoll,,) = game.bets(betId);
         assertEq(uint8(status), uint8(GravityDice.Status.Won));
         assertEq(storedRoll, roll);
     }
@@ -164,7 +161,7 @@ contract GravityDiceUnitTest is Test {
         game.settleBet(betId, SERVER_SEED);
 
         assertEq(player.balance, playerBefore, "loser receives nothing");
-        (, , , , , , GravityDice.Status status, uint8 storedRoll, ,) = game.bets(betId);
+        (,,,,,, GravityDice.Status status, uint8 storedRoll,,) = game.bets(betId);
         assertEq(uint8(status), uint8(GravityDice.Status.Lost));
         assertEq(storedRoll, roll);
     }
@@ -202,7 +199,7 @@ contract GravityDiceUnitTest is Test {
         game.refundBet(betId);
         assertEq(player.balance, playerBefore + stake, "refund returns full stake");
 
-        (, , , , , , GravityDice.Status status, , ,) = game.bets(betId);
+        (,,,,,, GravityDice.Status status,,,) = game.bets(betId);
         assertEq(uint8(status), uint8(GravityDice.Status.Refunded));
     }
 
@@ -268,8 +265,10 @@ contract GravityDiceUnitTest is Test {
     // ---- Cross-layer parity (mirrors packages/verify diceRoll vectors) ----
 
     function test_parityDice_v1() public pure {
-        bytes32 server = bytes32(uint256(0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa));
-        bytes32 client = bytes32(uint256(0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb));
+        bytes32 server =
+            bytes32(uint256(0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa));
+        bytes32 client =
+            bytes32(uint256(0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb));
         uint256 nonce = 0;
         uint256 expectedDice = 5;
 
@@ -278,8 +277,10 @@ contract GravityDiceUnitTest is Test {
     }
 
     function test_parityDice_v2() public pure {
-        bytes32 server = bytes32(uint256(0x1212121212121212121212121212121212121212121212121212121212121212));
-        bytes32 client = bytes32(uint256(0xfefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe));
+        bytes32 server =
+            bytes32(uint256(0x1212121212121212121212121212121212121212121212121212121212121212));
+        bytes32 client =
+            bytes32(uint256(0xfefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe));
         uint256 nonce = 42;
         uint256 expectedDice = 13;
 
@@ -289,7 +290,8 @@ contract GravityDiceUnitTest is Test {
 
     function test_parityDice_v3() public pure {
         bytes32 server = bytes32(uint256(0));
-        bytes32 client = bytes32(uint256(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff));
+        bytes32 client =
+            bytes32(uint256(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff));
         uint256 nonce = 999;
         uint256 expectedDice = 62;
 
@@ -361,7 +363,7 @@ contract GravityDiceUnitTest is Test {
             vm.prank(keeper);
             game.settleBet(betId, servers[i]);
 
-            (, , , , , , GravityDice.Status status, uint8 storedRoll, ,) = game.bets(betId);
+            (,,,,,, GravityDice.Status status, uint8 storedRoll,,) = game.bets(betId);
             assertEq(storedRoll, roll, "stored roll mismatch");
 
             if (roll < ru) {
@@ -413,7 +415,7 @@ contract GravityDiceUnitTest is Test {
         vm.prank(keeper);
         game.settleBet(betId, fSeed);
 
-        (, , , , , , GravityDice.Status status, uint8 storedRoll, ,) = game.bets(betId);
+        (,,,,,, GravityDice.Status status, uint8 storedRoll,,) = game.bets(betId);
         assertEq(storedRoll, expectedRoll, "stored roll mismatch");
 
         if (expectedRoll < ru) {
@@ -427,7 +429,10 @@ contract GravityDiceUnitTest is Test {
     }
 
     /// @notice Fuzz: roll is always in [1, 100] regardless of inputs.
-    function testFuzz_rollAlwaysInRange(bytes32 fSeed, bytes32 fClient, uint256 fNonce) public view {
+    function testFuzz_rollAlwaysInRange(bytes32 fSeed, bytes32 fClient, uint256 fNonce)
+        public
+        view
+    {
         uint8 r = game.previewRoll(fSeed, fClient, fNonce);
         assertGe(r, 1);
         assertLe(r, 100);
@@ -438,7 +443,10 @@ contract GravityDiceUnitTest is Test {
     ///         per-bet `payout * P(win) = stake * 99/(R-1) * (R-1)/100 = stake * 99/100`.
     ///         The cleanest invariant to assert is `payout < stake * 100 / (R-1)`
     ///         (strictly below the fair payout) for any stake ≥ 1.
-    function testFuzz_payoutBelowFairForEveryRollUnder(uint8 fRollUnder, uint96 fStake) public view {
+    function testFuzz_payoutBelowFairForEveryRollUnder(uint8 fRollUnder, uint96 fStake)
+        public
+        view
+    {
         uint8 ru = uint8(bound(uint256(fRollUnder), 2, 98));
         uint256 stake = bound(uint256(fStake), 1 ether, 100 ether);
 


### PR DESCRIPTION
## Summary
- Adds a parallel `fmt` job to `.github/workflows/casino-forge.yml` running `forge fmt --check` against `contracts/casino/` — whitespace regressions go red without waiting on the heavier build/test/coverage suite.
- Style source of truth is the `[fmt]` block in `contracts/casino/foundry.toml` (`line_length=100`, `tab_width=4`, `bracket_spacing=false`, `int_types=long`).
- Normalizes all existing casino sources / tests / scripts to that style so the new check starts green. `forge build` succeeds and the full 164-test suite still passes post-format.

## Acceptance
- (a) `forge fmt --check` job declared in workflow ✅
- (b) Intentional whitespace regression = red ✅
  - Injected `contract  CasinoBankroll` (double space) → `forge fmt --check` exits **1**.
  - Restored → exits **0**.

## Dependencies (stacked PR)
Depends on **C-CI1** = PR #296 (initial `casino-forge.yml`) and stacked on **PR #297** (coverage job).

Until #296 / #297 land on `dev`, this PR's diff includes the parent workflow blocks (`forge` job and `coverage` job) — the **only net-new logic in this PR is the `fmt` job and the formatter normalization commit**. After the parents merge, this can be rebased and the diff will collapse to just the `fmt` job + format normalization.

## Test plan
- [x] `PATH=…/foundry/bin:$PATH forge fmt --check --root contracts/casino` → exit **0** (clean)
- [x] Injected whitespace regression → `forge fmt --check` exit **1** (red), restored exit **0**
- [x] `forge build --root contracts/casino` → success
- [x] `forge test --root contracts/casino --skip 'script/**'` → **164/164 pass**
- [x] YAML lint: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/casino-forge.yml'))"` → `jobs: ['fmt', 'forge', 'coverage']`

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS (3 pre-existing module-resolution errors in `lib/colyseus/useMultiplayer.ts` and `lib/sanctuary/audio.ts` — excluded from diff)
- **vitest run**: PASS (2 pre-existing test-file failures / 4 pre-existing test failures unchanged: 794/798 pass before and after overlay)
Overall: **PASS** — no new tsc or vitest errors introduced. Mirror restored byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)