### PR TITLE
ci(casino): Vitest casino project + web.yml workflow [SWO_CASINO_CI_VITEST]

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -1,0 +1,80 @@
+name: Web CI
+
+# Vitest gates for the Next.js / TS layer. Splits into named projects so the
+# casino lane only runs when casino sources change, mirroring how the Forge
+# workflow scopes itself to contracts/casino/**.
+
+on:
+  pull_request:
+    paths:
+      - 'app/**'
+      - 'components/**'
+      - 'lib/**'
+      - 'game/**'
+      - 'server/**'
+      - 'vitest.config.ts'
+      - 'tsconfig.json'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/web.yml'
+  push:
+    branches: [dev, main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  default:
+    name: vitest (default project)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - run: npx vitest run --project default
+
+  casino:
+    name: vitest (casino project)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Path filter inside the job — keeps the casino lane red only when its
+    # own sources or the vitest config it depends on change.
+    if: |
+      github.event_name != 'pull_request' ||
+      contains(toJSON(github.event.pull_request.labels.*.name), 'casino') ||
+      true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - name: Detect casino changes
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            casino:
+              - 'lib/casino/**'
+              - 'components/casino/**'
+              - 'app/casino/**'
+              - 'contracts/casino/deployments/**'
+              - 'vitest.config.ts'
+              - '.github/workflows/web.yml'
+      - uses: actions/setup-node@v4
+        if: steps.changes.outputs.casino == 'true'
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - name: Install deps
+        if: steps.changes.outputs.casino == 'true'
+        run: npm ci
+      - name: Run casino vitest project
+        if: steps.changes.outputs.casino == 'true'
+        run: npx vitest run --project casino
+      - name: Skip notice
+        if: steps.changes.outputs.casino != 'true'
+        run: echo "No casino paths changed; skipping casino vitest project."

--- a/lib/casino/__tests__/addresses.test.ts
+++ b/lib/casino/__tests__/addresses.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Anchor test for the casino vitest project — proves the project is wired up
+ * and the address registry returns `null` for unknown chains.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  getCasinoAddresses,
+  getSupportedCasinoChainIds,
+} from '../addresses';
+
+describe('getCasinoAddresses', () => {
+  it('returns null for unknown chain', () => {
+    expect(getCasinoAddresses(1)).toBeNull();
+    expect(getCasinoAddresses(0)).toBeNull();
+    expect(getCasinoAddresses(999_999)).toBeNull();
+  });
+
+  it('returns Monad Testnet (10143) deployment', () => {
+    const addrs = getCasinoAddresses(10143);
+    expect(addrs).not.toBeNull();
+    expect(addrs!.chainId).toBe(10143);
+    expect(addrs!.bankroll).toMatch(/^0x[0-9a-fA-F]{40}$/);
+    expect(addrs!.cosmicFlip).toMatch(/^0x[0-9a-fA-F]{40}$/);
+    expect(addrs!.gravityDice).toMatch(/^0x[0-9a-fA-F]{40}$/);
+    expect(addrs!.constellationClimb).toMatch(/^0x[0-9a-fA-F]{40}$/);
+  });
+
+  it('exposes the supported chain id list', () => {
+    const ids = getSupportedCasinoChainIds();
+    expect(ids).toContain(10143);
+    expect(ids.every((id) => Number.isInteger(id))).toBe(true);
+  });
+});

--- a/lib/casino/addresses.ts
+++ b/lib/casino/addresses.ts
@@ -1,0 +1,44 @@
+/**
+ * Casino contract address registry.
+ *
+ * Reads the per-chain deployment JSON committed under
+ * `contracts/casino/deployments/<chainId>.json` and exposes a typed lookup.
+ * Returns `null` for chains that have no committed deployment so callers can
+ * fail gracefully (banner, disabled UI) instead of crashing on `undefined`.
+ */
+
+import testnet10143 from '../../contracts/casino/deployments/10143.json';
+
+export interface CasinoAddresses {
+  chainId: number;
+  bankroll: `0x${string}`;
+  allowlist: `0x${string}`;
+  allowlistEnabled: boolean;
+  cosmicFlip: `0x${string}`;
+  gravityDice: `0x${string}`;
+  constellationClimb: `0x${string}`;
+  deployer: `0x${string}`;
+  maxDrawdown24hWei: bigint;
+}
+
+const REGISTRY: Record<number, CasinoAddresses> = {
+  10143: {
+    chainId: 10143,
+    bankroll: testnet10143.bankroll as `0x${string}`,
+    allowlist: testnet10143.allowlist as `0x${string}`,
+    allowlistEnabled: testnet10143.allowlistEnabled,
+    cosmicFlip: testnet10143.cosmicFlip as `0x${string}`,
+    gravityDice: testnet10143.gravityDice as `0x${string}`,
+    constellationClimb: testnet10143.constellationClimb as `0x${string}`,
+    deployer: testnet10143.deployer as `0x${string}`,
+    maxDrawdown24hWei: BigInt(testnet10143.maxDrawdown24hWei),
+  },
+};
+
+export function getCasinoAddresses(chainId: number): CasinoAddresses | null {
+  return REGISTRY[chainId] ?? null;
+}
+
+export function getSupportedCasinoChainIds(): number[] {
+  return Object.keys(REGISTRY).map((k) => Number(k));
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,36 +1,62 @@
 import { defineConfig } from 'vitest/config';
 import path from 'path';
 
+const sharedAlias = {
+  '@': path.resolve(__dirname, './'),
+};
+
 export default defineConfig({
+  resolve: {
+    alias: sharedAlias,
+  },
   test: {
-    // Test environment
     environment: 'node',
-    
-    // Include test files
-    include: ['**/*.test.ts', '**/*.spec.ts'],
-    
-    // Exclude
     exclude: ['node_modules', '.next', 'contracts'],
-    
-    // Coverage settings
+    testTimeout: 10000,
+    reporters: ['verbose'],
+
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html'],
-      include: ['lib/starforge/**/*.ts'],
+      include: ['lib/starforge/**/*.ts', 'lib/casino/**/*.ts'],
       exclude: ['**/*.test.ts', '**/*.spec.ts'],
     },
-    
-    // Global test timeout (10 seconds)
-    testTimeout: 10000,
-    
-    // Reporter
-    reporters: ['verbose'],
-  },
-  
-  // Path aliases to match tsconfig
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './'),
-    },
+
+    // Vitest projects: each entry defines a named sub-suite. CI can target
+    // a single project with `vitest run --project <name>`, e.g. `casino`.
+    projects: [
+      {
+        resolve: { alias: sharedAlias },
+        test: {
+          name: 'default',
+          environment: 'node',
+          include: ['**/*.test.ts', '**/*.spec.ts'],
+          exclude: [
+            'node_modules',
+            '.next',
+            'contracts',
+            'lib/casino/**',
+            'components/casino/**',
+            'app/casino/**',
+          ],
+        },
+      },
+      {
+        resolve: { alias: sharedAlias },
+        test: {
+          name: 'casino',
+          environment: 'node',
+          include: [
+            'lib/casino/**/*.test.ts',
+            'lib/casino/**/*.spec.ts',
+            'components/casino/**/*.test.ts',
+            'components/casino/**/*.spec.ts',
+            'app/casino/**/*.test.ts',
+            'app/casino/**/*.spec.ts',
+          ],
+          exclude: ['node_modules', '.next', 'contracts'],
+        },
+      },
+    ],
   },
 });


### PR DESCRIPTION
## Summary

Adds a dedicated **Vitest \`casino\` project** plus a new `.github/workflows/web.yml` CI lane so casino-area JS/TS code gets its own focused test surface, mirroring the way `casino-forge.yml` scopes the on-chain layer.

## Changes

- **`vitest.config.ts`** — converted to the `test.projects` API with two named projects:
  - **`default`** — every existing `*.test.ts` except the casino subtrees (no behavior change for current suites).
  - **`casino`** — scoped to `lib/casino/**`, `components/casino/**`, `app/casino/**`. CI / devs can run only this slice via `npx vitest run --project casino`.
- **`lib/casino/addresses.ts`** — typed registry over `contracts/casino/deployments/10143.json`. `getCasinoAddresses(chainId)` returns `CasinoAddresses | null` (null for unknown chains) so callers fail closed instead of dereferencing `undefined`.
- **`lib/casino/__tests__/addresses.test.ts`** — anchor test: null for unknown chains (1, 0, 999_999), positive read for Monad Testnet (10143), and a sanity check on `getSupportedCasinoChainIds()`.
- **`.github/workflows/web.yml`** — new web CI gate. The `default` job always runs; the `casino` job uses `dorny/paths-filter@v3` to only execute `npx vitest run --project casino` when paths under `lib/casino/**`, `components/casino/**`, `app/casino/**`, the deployments JSON, `vitest.config.ts`, or the workflow itself change.

## Acceptance checklist

- [x] Project config in `vitest.config.ts` (`projects[].name = 'casino'`)
- [x] CI workflow `.github/workflows/web.yml` picks it up with paths-filter on the casino dirs
- [x] Anchor test passes — `getCasinoAddresses(1) === null` ✅

## Verification

```
$ npx vitest run --project casino
✓ casino lib/casino/__tests__/addresses.test.ts (3 tests)
Test Files  1 passed (1)
     Tests  3 passed (3)

$ npx tsc --noEmit
(clean)
```

Default project unchanged from baseline (794 passed; 4 pre-existing `lib/sanctuary/__tests__/api-e2e.test.ts` failures untouched — tracked separately).

## Test plan

- [ ] CI `Web CI / vitest (casino project)` runs green on this PR (the workflow itself + `vitest.config.ts` are in the paths filter)
- [ ] CI `Web CI / vitest (default project)` reproduces baseline (4 pre-existing sanctuary failures only)
- [ ] After merge, edit a casino path on a future PR and confirm the casino job triggers; edit an unrelated path and confirm it skips with the "No casino paths changed" notice

🤖 Generated with [Claude Code](https://claude.com/claude-code)