### PR TITLE
feat(casino): port BB WalletSheet → components/casino/WalletSheet [SWO_CASINO_COMPONENT_WALLET_SHEET]

### DIFF
--- a/components/casino/WalletSheet.tsx
+++ b/components/casino/WalletSheet.tsx
@@ -1,0 +1,341 @@
+// WalletSheet — modal-on-mobile / slide-over wallet surface for SWO Cosmic Casino.
+//
+// Ported from BunnyBagz `apps/web/src/components/WalletSheet.tsx`. Carried
+// forward intact (lesson D2 in `bb_keyboard_nav_audit_2026-05-09.md` and
+// the WALLETSHEET_ESCAPE_AND_FOCUS_TRAP refinement, mega-house 1a22b6a):
+//
+//   • Esc closes the sheet (handler bound on `document` in the keydown
+//     phase so the press is observed even when focus is on the overlay
+//     backdrop button — a sibling of <aside>).
+//   • Tab / Shift+Tab cycle inside the dialog and never escape it.
+//   • On open, focus moves to the first focusable descendant; on close,
+//     focus returns to the opener element (the trigger button that
+//     opened the sheet) so keyboard users land where they started.
+//   • Close button + identity rows carry the `swo-casino-hit-44` class
+//     (the SWO-side rename of BB's `bb-hit-target-44`) so every
+//     interactive child clears the 44px mobile touch-target floor.
+//
+// The BB original ships a rich `WalletPanel` body (wagmi balances, theme
+// toggle, recent bets, …). Those depend on BB-only packages so the SWO
+// shell exposes the same surface contract via the `children` prop and
+// a simple default body that renders identity rows. Consumers wire in
+// their own balances/CTAs by passing children.
+
+'use client';
+
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  type CSSProperties,
+  type ReactNode,
+} from 'react';
+
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  "[tabindex]:not([tabindex='-1'])",
+].join(',');
+
+export type WalletIdentityRow = {
+  label: string;
+  value: string;
+  testId?: string;
+};
+
+export type WalletSheetProps = {
+  open: boolean;
+  onClose: () => void;
+  /**
+   * Optional address (short or full). When provided and `children` is
+   * omitted, the default body renders an "Address" identity row.
+   */
+  address?: string;
+  /**
+   * Extra identity rows for the default body (e.g. balance, USDm, …).
+   * Each row gets the `swo-casino-hit-44` class so the 44px mobile
+   * touch-target floor is met.
+   */
+  identityRows?: WalletIdentityRow[];
+  /**
+   * Override body. When provided, replaces the default identity-row
+   * rendering entirely. Consumers should still add `swo-casino-hit-44`
+   * to interactive children so the touch-target contract holds.
+   */
+  children?: ReactNode;
+};
+
+function shortAddress(addr: string): string {
+  if (addr.length <= 12) return addr;
+  return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
+}
+
+export function WalletSheet({
+  open,
+  onClose,
+  address,
+  identityRows,
+  children,
+}: WalletSheetProps) {
+  const asideRef = useRef<HTMLElement | null>(null);
+  // Captured at open time so Esc-close can return focus to wherever
+  // the user was before the sheet stole it. Without this, the page's
+  // active element is the wallet trigger only by coincidence; with
+  // it, focus returns deterministically.
+  const openerRef = useRef<HTMLElement | null>(null);
+
+  // Capture the opener on the open→true edge. We use an effect rather
+  // than the click handler so the contract holds for callers that flip
+  // `open` programmatically too.
+  useEffect(() => {
+    if (!open) return;
+    if (typeof document === 'undefined') return;
+    const active = document.activeElement as HTMLElement | null;
+    if (active && active !== document.body) {
+      openerRef.current = active;
+    }
+  }, [open]);
+
+  // Esc-to-close + Tab focus trap. See header comment for why the
+  // listener is bound on `document` rather than `aside`.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+        return;
+      }
+      if (e.key !== 'Tab') return;
+      const aside = asideRef.current;
+      if (!aside) return;
+      const focusables = Array.from(
+        aside.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+      ).filter(
+        (el) =>
+          !el.hasAttribute('disabled') &&
+          el.getAttribute('aria-hidden') !== 'true',
+      );
+      if (focusables.length === 0) {
+        e.preventDefault();
+        return;
+      }
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+      if (!active || !aside.contains(active)) {
+        e.preventDefault();
+        (e.shiftKey ? last : first).focus();
+        return;
+      }
+      if (e.shiftKey && active === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  // On open, move focus to the first focusable descendant so the Tab
+  // trap above starts inside the dialog (deep-QA D2 from
+  // bb_qa_deep_pass_2026-05-12.md).
+  useEffect(() => {
+    if (!open) return;
+    const aside = asideRef.current;
+    if (!aside) return;
+    const first = aside.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
+    const id =
+      typeof window !== 'undefined'
+        ? window.requestAnimationFrame(() => first?.focus())
+        : 0;
+    return () => {
+      if (typeof window !== 'undefined') window.cancelAnimationFrame(id);
+    };
+  }, [open]);
+
+  // On close, return focus to the opener. Effect runs on the
+  // open→false transition; opener was captured on the open→true edge.
+  const wasOpenRef = useRef(false);
+  useEffect(() => {
+    if (open) {
+      wasOpenRef.current = true;
+      return;
+    }
+    if (!wasOpenRef.current) return;
+    wasOpenRef.current = false;
+    const opener = openerRef.current;
+    if (opener && typeof opener.focus === 'function') {
+      opener.focus();
+    }
+    openerRef.current = null;
+  }, [open]);
+
+  const onBackdropClick = useCallback(() => onClose(), [onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Wallet"
+      data-testid="wallet-sheet"
+      style={overlayStyle}
+    >
+      <button
+        type="button"
+        aria-label="Close wallet overlay"
+        data-testid="wallet-sheet-overlay"
+        onClick={onBackdropClick}
+        style={overlayBackdropStyle}
+      />
+      <aside
+        ref={asideRef}
+        data-testid="wallet-sheet-aside"
+        style={sheetStyle}
+      >
+        <header style={sheetHeaderStyle}>
+          <h2 style={sheetTitleStyle}>Wallet</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close wallet"
+            data-testid="wallet-close"
+            className="swo-casino-hit-44"
+            style={closeButtonStyle}
+          >
+            ×
+          </button>
+        </header>
+        {children ?? (
+          <WalletSheetDefaultBody address={address} identityRows={identityRows} />
+        )}
+      </aside>
+    </div>
+  );
+}
+
+function WalletSheetDefaultBody({
+  address,
+  identityRows,
+}: {
+  address?: string;
+  identityRows?: WalletIdentityRow[];
+}) {
+  const rows: WalletIdentityRow[] = [
+    {
+      label: 'Address',
+      value: address ? shortAddress(address) : 'Not connected',
+      testId: 'wallet-address',
+    },
+    ...(identityRows ?? []),
+  ];
+  return (
+    <dl style={fieldListStyle} data-testid="wallet-identity-list">
+      {rows.map((row) => (
+        <div
+          key={row.label}
+          // Identity rows clear the 44-px floor too — per the BB QA
+          // contract and the task's acceptance (c).
+          className="swo-casino-hit-44"
+          style={fieldRowStyle}
+          data-testid={row.testId ?? `wallet-row-${row.label.toLowerCase()}`}
+        >
+          <dt style={fieldLabelStyle}>{row.label}</dt>
+          <dd style={fieldValueStyle}>{row.value}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+const overlayStyle: CSSProperties = {
+  position: 'fixed',
+  inset: 0,
+  zIndex: 50,
+  display: 'flex',
+  justifyContent: 'flex-end',
+};
+
+const overlayBackdropStyle: CSSProperties = {
+  position: 'absolute',
+  inset: 0,
+  background: 'var(--swo-casino-overlay-backdrop, rgba(0,0,0,0.6))',
+  border: 'none',
+  padding: 0,
+  cursor: 'pointer',
+};
+
+const sheetStyle: CSSProperties = {
+  position: 'relative',
+  width: 'min(420px, 100vw)',
+  height: '100%',
+  background: 'var(--swo-casino-surface, #0f0f1e)',
+  color: 'var(--swo-casino-fg, #e8e8e8)',
+  padding: '1rem 1.25rem',
+  boxShadow: '-12px 0 32px rgba(0,0,0,0.45)',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1rem',
+  overflowY: 'auto',
+  borderLeft: '1px solid var(--swo-casino-border, rgba(255,255,255,0.16))',
+};
+
+const sheetHeaderStyle: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+};
+
+const sheetTitleStyle: CSSProperties = {
+  margin: 0,
+  fontSize: '1.1rem',
+  letterSpacing: '-0.01em',
+};
+
+const closeButtonStyle: CSSProperties = {
+  background: 'transparent',
+  border: 'none',
+  color: 'inherit',
+  fontSize: '1.5rem',
+  lineHeight: 1,
+  cursor: 'pointer',
+  minWidth: 44,
+  minHeight: 44,
+};
+
+const fieldListStyle: CSSProperties = {
+  margin: 0,
+  padding: 0,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.75rem',
+};
+
+const fieldRowStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.25rem',
+  minHeight: 44,
+  justifyContent: 'center',
+};
+
+const fieldLabelStyle: CSSProperties = {
+  fontSize: '0.75rem',
+  textTransform: 'uppercase',
+  letterSpacing: '0.08em',
+  opacity: 0.7,
+};
+
+const fieldValueStyle: CSSProperties = {
+  margin: 0,
+  fontSize: '1rem',
+  fontVariantNumeric: 'tabular-nums',
+};

--- a/components/casino/__tests__/WalletSheet.test.tsx
+++ b/components/casino/__tests__/WalletSheet.test.tsx
@@ -1,0 +1,193 @@
+// @vitest-environment happy-dom
+//
+// WalletSheet — proves the focus-trap + Esc-returns-focus + hit-target
+// contracts carried forward from BunnyBagz (lesson D2 in
+// `bb_keyboard_nav_audit_2026-05-09.md` and the
+// WALLETSHEET_ESCAPE_AND_FOCUS_TRAP refinement).
+//
+//   (a) Component exists & renders
+//   (b1) Tab cycles forward inside the sheet (last → first)
+//   (b2) Shift+Tab cycles backward (first → last)
+//   (b3) Esc closes the sheet and returns focus to the opener
+//   (c) Close button + identity rows carry `swo-casino-hit-44`
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { useState } from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { WalletSheet } from '../WalletSheet';
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+function Harness() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button
+        type="button"
+        data-testid="wallet-trigger"
+        onClick={() => setOpen(true)}
+      >
+        Open wallet
+      </button>
+      <WalletSheet
+        open={open}
+        onClose={() => setOpen(false)}
+        address="0x1234567890abcdef1234567890abcdef12345678"
+        identityRows={[
+          { label: 'Balance', value: '1.234 MON', testId: 'wallet-balance' },
+          { label: 'USDm', value: '42.00 USDm', testId: 'wallet-usdm' },
+        ]}
+      />
+    </>
+  );
+}
+
+function press(target: HTMLElement, key: string, shiftKey = false): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', {
+    key,
+    shiftKey,
+    bubbles: true,
+    cancelable: true,
+  });
+  target.dispatchEvent(event);
+  return event;
+}
+
+function openSheet(): HTMLButtonElement {
+  const trigger = container.querySelector(
+    '[data-testid="wallet-trigger"]',
+  ) as HTMLButtonElement;
+  trigger.focus();
+  act(() => {
+    trigger.click();
+  });
+  return trigger;
+}
+
+describe('<WalletSheet> (acceptance: SWO_CASINO_COMPONENT_WALLET_SHEET)', () => {
+  it('(a) component renders inside components/casino/', () => {
+    act(() => {
+      root.render(<Harness />);
+    });
+    openSheet();
+    const sheet = container.querySelector('[data-testid="wallet-sheet"]');
+    expect(sheet).not.toBeNull();
+    expect(sheet?.getAttribute('role')).toBe('dialog');
+    expect(sheet?.getAttribute('aria-modal')).toBe('true');
+  });
+
+  // (b1) Forward Tab cycling — when focus is on the last focusable
+  // descendant of <aside>, Tab loops back to the first.
+  it('(b1) Tab from the last focusable element cycles back to the first', () => {
+    act(() => {
+      root.render(<Harness />);
+    });
+    openSheet();
+    const aside = container.querySelector(
+      '[data-testid="wallet-sheet-aside"]',
+    ) as HTMLElement;
+    const focusables = Array.from(
+      aside.querySelectorAll<HTMLElement>(
+        'a[href],button:not([disabled]),input:not([disabled]),select:not([disabled]),textarea:not([disabled]),[tabindex]:not([tabindex="-1"])',
+      ),
+    );
+    expect(focusables.length).toBeGreaterThan(0);
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+
+    last.focus();
+    expect(document.activeElement).toBe(last);
+
+    const event = press(last, 'Tab');
+    expect(event.defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(first);
+  });
+
+  // (b2) Backward Tab cycling.
+  it('(b2) Shift+Tab from the first focusable element cycles to the last', () => {
+    act(() => {
+      root.render(<Harness />);
+    });
+    openSheet();
+    const aside = container.querySelector(
+      '[data-testid="wallet-sheet-aside"]',
+    ) as HTMLElement;
+    const focusables = Array.from(
+      aside.querySelectorAll<HTMLElement>(
+        'a[href],button:not([disabled]),input:not([disabled]),select:not([disabled]),textarea:not([disabled]),[tabindex]:not([tabindex="-1"])',
+      ),
+    );
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+
+    first.focus();
+    expect(document.activeElement).toBe(first);
+
+    const event = press(first, 'Tab', true);
+    expect(event.defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(last);
+  });
+
+  // (b3) Esc closes the sheet and returns focus to the trigger.
+  it('(b3) Esc closes the sheet and returns focus to the opener', () => {
+    act(() => {
+      root.render(<Harness />);
+    });
+    const trigger = openSheet();
+    expect(container.querySelector('[data-testid="wallet-sheet"]')).not.toBeNull();
+
+    act(() => {
+      press(document.body, 'Escape');
+    });
+
+    expect(container.querySelector('[data-testid="wallet-sheet"]')).toBeNull();
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  // (c) Hit-target contract — the close button and every identity row
+  // carry the `swo-casino-hit-44` class (which `globals.css` maps to
+  // `min-height: 44px`).
+  it('(c) close button + identity rows carry swo-casino-hit-44', () => {
+    act(() => {
+      root.render(<Harness />);
+    });
+    openSheet();
+    const close = container.querySelector(
+      '[data-testid="wallet-close"]',
+    ) as HTMLElement;
+    expect(close).not.toBeNull();
+    expect(close.classList.contains('swo-casino-hit-44')).toBe(true);
+
+    const addressRow = container.querySelector(
+      '[data-testid="wallet-address"]',
+    ) as HTMLElement;
+    const balanceRow = container.querySelector(
+      '[data-testid="wallet-balance"]',
+    ) as HTMLElement;
+    const usdmRow = container.querySelector(
+      '[data-testid="wallet-usdm"]',
+    ) as HTMLElement;
+    for (const row of [addressRow, balanceRow, usdmRow]) {
+      expect(row).not.toBeNull();
+      expect(row.classList.contains('swo-casino-hit-44')).toBe(true);
+    }
+  });
+});

--- a/tests/e2e/casino/wallet-sheet.spec.ts
+++ b/tests/e2e/casino/wallet-sheet.spec.ts
@@ -1,0 +1,84 @@
+// Playwright spec — SWO Cosmic Casino WalletSheet keyboard contract.
+//
+// Acceptance (b) for SWO_CASINO_COMPONENT_WALLET_SHEET:
+//   • Tab cycles within the sheet (last → first; Shift+Tab first → last)
+//   • Esc closes the sheet and returns focus to the opener button
+//   • Close button + identity rows carry `swo-casino-hit-44`
+//
+// Companion to `components/casino/__tests__/WalletSheet.test.tsx`, which
+// runs the same contract under happy-dom in unit tests. This file is the
+// browser-level proof so the casino-e2e workflow (`.github/workflows/
+// casino-e2e.yml`) can gate the focus-trap behaviour against a real
+// rendering engine once `playwright.config.ts` lands (the workflow
+// currently skips when no config is present).
+//
+// Expectations on the live page (`/casino/wallet` or similar host):
+//   - A button with `data-testid="wallet-trigger"` opens the sheet.
+//   - The sheet exposes `data-testid="wallet-sheet"`,
+//     `data-testid="wallet-close"`, and identity-row `data-testid`s
+//     (`wallet-address`, `wallet-balance`, …).
+
+import { expect, test } from '@playwright/test';
+
+test.describe('WalletSheet (casino) keyboard contract', () => {
+  test.beforeEach(async ({ page }) => {
+    // Page that mounts the WalletSheet via a `wallet-trigger` button.
+    // Adjust path when the SWO casino lobby exposes the sheet at a
+    // different route.
+    await page.goto('/casino');
+  });
+
+  test('Tab cycles within the sheet and never escapes', async ({ page }) => {
+    const trigger = page.getByTestId('wallet-trigger');
+    await trigger.focus();
+    await trigger.press('Enter');
+
+    const sheet = page.getByTestId('wallet-sheet');
+    await expect(sheet).toBeVisible();
+
+    const close = page.getByTestId('wallet-close');
+    await close.focus();
+    // Tab from the close button (last focusable inside <aside>) should
+    // wrap back to the first focusable, not escape into the page.
+    await page.keyboard.press('Tab');
+    const stillInsideAfterTab = await sheet.evaluate(
+      (el) => el.contains(document.activeElement),
+    );
+    expect(stillInsideAfterTab).toBe(true);
+
+    // Shift+Tab from the first focusable should land back on the last.
+    await page.keyboard.press('Shift+Tab');
+    const stillInsideAfterShiftTab = await sheet.evaluate(
+      (el) => el.contains(document.activeElement),
+    );
+    expect(stillInsideAfterShiftTab).toBe(true);
+  });
+
+  test('Esc closes the sheet and returns focus to the opener', async ({ page }) => {
+    const trigger = page.getByTestId('wallet-trigger');
+    await trigger.focus();
+    await trigger.press('Enter');
+
+    await expect(page.getByTestId('wallet-sheet')).toBeVisible();
+
+    await page.keyboard.press('Escape');
+
+    await expect(page.getByTestId('wallet-sheet')).toHaveCount(0);
+    const triggerIsFocused = await trigger.evaluate(
+      (el) => document.activeElement === el,
+    );
+    expect(triggerIsFocused).toBe(true);
+  });
+
+  test('close button and identity rows carry swo-casino-hit-44', async ({ page }) => {
+    const trigger = page.getByTestId('wallet-trigger');
+    await trigger.focus();
+    await trigger.press('Enter');
+
+    await expect(page.getByTestId('wallet-sheet')).toBeVisible();
+
+    for (const id of ['wallet-close', 'wallet-address']) {
+      await expect(page.getByTestId(id)).toHaveClass(/swo-casino-hit-44/);
+    }
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,7 +11,10 @@ export default defineConfig({
   },
   test: {
     environment: 'node',
-    exclude: ['node_modules', '.next', 'contracts'],
+    // `tests/e2e/**` is the Playwright surface (see
+    // `.github/workflows/casino-e2e.yml`); vitest must not try to load
+    // those specs because they import `@playwright/test`.
+    exclude: ['node_modules', '.next', 'contracts', 'tests/e2e/**'],
     testTimeout: 10000,
     reporters: ['verbose'],
 
@@ -38,6 +41,7 @@ export default defineConfig({
             'lib/casino/**',
             'components/casino/**',
             'app/casino/**',
+            'tests/e2e/**',
           ],
         },
       },
@@ -60,7 +64,7 @@ export default defineConfig({
             'app/casino/**/*.test.tsx',
             'app/casino/**/*.spec.tsx',
           ],
-          exclude: ['node_modules', '.next', 'contracts'],
+          exclude: ['node_modules', '.next', 'contracts', 'tests/e2e/**'],
         },
       },
     ],


### PR DESCRIPTION
## Summary
- Ports BunnyBagz `apps/web/src/components/WalletSheet.tsx` → `components/casino/WalletSheet.tsx`.
- Carries the focus-trap fix (D2 in `bb_keyboard_nav_audit_2026-05-09.md`) and the `WALLETSHEET_ESCAPE_AND_FOCUS_TRAP` refinement (mega-house `1a22b6a`): Esc closes the sheet **and returns focus to the opener** element.
- Close button + identity rows carry `swo-casino-hit-44` (SWO-side rename of BB's `bb-hit-target-44`), so every interactive child clears the 44 px mobile touch-target floor.

## Acceptance (SWO_CASINO_COMPONENT_WALLET_SHEET)
- **(a) component exists** — `components/casino/WalletSheet.tsx` renders with `role="dialog"`, `aria-modal="true"`, `aria-label="Wallet"`, `data-testid="wallet-sheet"`.
- **(b) Playwright spec confirms Tab cycles within the sheet, Esc closes and returns focus to opener** — `tests/e2e/casino/wallet-sheet.spec.ts` is the browser-level proof for the `casino-e2e` workflow. The companion unit-level proof (vitest + happy-dom) lives in `components/casino/__tests__/WalletSheet.test.tsx` and runs today; all 5 specs pass.
- **(c) `bb-hit-target-44` carried over for the close button and identity rows** — close button (`data-testid="wallet-close"`) + identity rows (`Address`, `Balance`, `USDm`, …) all carry the renamed `swo-casino-hit-44` class.

## Notes
- BB's `WalletPanel` body depends on BB-only packages (wagmi balances, `@bunnybagz/ui` IconButton, etc.). The SWO shell keeps the keyboard contract intact and exposes the body via a `children` prop + a small default identity-row renderer so consumers wire in their own balances/CTAs.
- `vitest.config.ts`: excludes `tests/e2e/**` from both projects so the Playwright spec isn't loaded by the vitest runner.
- The Playwright spec runs once `playwright.config.ts` lands — the `casino-e2e` workflow currently skips with a notice when no config is present (pre-flight in `.github/workflows/casino-e2e.yml`).

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS (overlaid + restored byte-identical)
- **vitest run --project casino**: SKIPPED — PROD mirror has stale vitest workers (orphan processes from earlier sessions) that hang fresh runs; local workspace casino project passes all 12 tests (5 new + 7 existing). Soft gate will re-run on the post-spawn check.

Overall: PASS (tsc clean in mirror; vitest verified in workspace).

## Test plan
- [x] `npx vitest run --project casino` (workspace) — 12 passed (5 new WalletSheet + existing)
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint components/casino/WalletSheet.tsx components/casino/__tests__/WalletSheet.test.tsx tests/e2e/casino/wallet-sheet.spec.ts vitest.config.ts` — clean
- [ ] Playwright `casino-connected` project — pending `playwright.config.ts` (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)