### PR TITLE
feat(casino): port BB RecentBetsList → components/casino/RecentBets [SWO_CASINO_COMPONENT_RECENT_BETS]

### DIFF
--- a/components/casino/RecentBets.tsx
+++ b/components/casino/RecentBets.tsx
@@ -1,0 +1,329 @@
+// RecentBets — settled-bets list for the SWO Cosmic Casino wallet sheet,
+// ported from BunnyBagz `apps/web/src/components/RecentBetsList.tsx`.
+//
+// Until the SWO indexer lands the component is a graceful empty surface:
+// callers that do not pass a `bets` prop see the "No recent bets yet"
+// pill with `data-state="empty"` so the wallet sheet never appears
+// broken while the data layer is still in flight. Once the indexer
+// arrives a parent can thread the rows in directly — the row markup is
+// already in place and exercised by the test suite.
+//
+// Wire contract (parent-fed for now):
+//   - Accepts a `bets` array of cross-game settled bets.
+//   - Each row links the `betId` to `/verify/[betId]` and the optional
+//     `txHash` to the MegaETH Blockscout explorer.
+//   - `symbolFor` lets callers override the currency label per bet
+//     (defaults to "MON", SWO's native gas token on Monad — vs BB's ETH).
+
+'use client';
+
+import type { CSSProperties } from 'react';
+
+const EMPTY_COPY = 'No recent bets yet';
+const DEFAULT_EXPLORER = 'https://explorer.monad-testnet.category.xyz';
+
+export type WalletGame = 'coinflip' | 'dice' | 'hilo';
+
+export interface WalletBet {
+  game: WalletGame;
+  betId: string;
+  stakeWei: string;
+  payoutWei: string | null;
+  outcome: string;
+  blockNumber: string;
+  txHash: string | null;
+}
+
+export interface RecentBetsProps {
+  /** Settled-bet rows. Undefined or empty renders the empty-state pill. */
+  bets?: WalletBet[];
+  /** Block-explorer base URL for txHash links. Defaults to Monad testnet. */
+  explorerBaseUrl?: string;
+  /**
+   * Currency-symbol resolver per bet — defaults to "MON" (SWO's native
+   * gas token). Override in tests that mix MON/USDm denominated rows.
+   */
+  symbolFor?: (bet: WalletBet) => 'MON' | 'USDm';
+}
+
+const ICON_FOR: Record<WalletGame, string> = {
+  coinflip: '🪙',
+  dice: '🎲',
+  hilo: '🃏',
+};
+
+function gameLabel(game: WalletGame): string {
+  return game === 'hilo' ? 'Hi-Lo' : game === 'coinflip' ? 'Coinflip' : 'Dice';
+}
+
+function shortHash(hash: string): string {
+  return hash.length > 12 ? `${hash.slice(0, 6)}…${hash.slice(-4)}` : hash;
+}
+
+/**
+ * Format a wei amount as a fixed-precision human string.
+ *
+ * 4 dp keeps sub-MON stakes legible without overflowing the row. Trailing
+ * zeros are trimmed so "0.0100" reads as "0.01"; "0" passes through.
+ */
+export function formatWei(wei: string, decimals = 18): string {
+  if (!wei || wei === '0') return '0';
+  let s = wei;
+  let neg = false;
+  if (s.startsWith('-')) {
+    neg = true;
+    s = s.slice(1);
+  }
+  const padded = s.padStart(decimals + 1, '0');
+  const whole = padded
+    .slice(0, padded.length - decimals)
+    .replace(/^0+(?=\d)/, '');
+  const frac = padded
+    .slice(padded.length - decimals)
+    .replace(/0+$/, '')
+    .slice(0, 4);
+  const result = frac.length > 0 ? `${whole}.${frac}` : whole;
+  return neg ? `-${result}` : result;
+}
+
+export function outcomeChipKind(
+  outcome: string,
+  payoutWei: string | null,
+): 'won' | 'lost' | 'refunded' | 'pushed' {
+  if (outcome === 'won' || outcome === 'cashed') return 'won';
+  if (outcome === 'refunded') return 'refunded';
+  if (outcome === 'pushed') return 'pushed';
+  if (payoutWei && payoutWei !== '0') return 'won';
+  return 'lost';
+}
+
+function explorerTxUrl(base: string, txHash: string): string {
+  const trimmed = base.replace(/\/+$/, '');
+  return `${trimmed}/tx/${txHash}`;
+}
+
+export function RecentBets({
+  bets,
+  explorerBaseUrl = DEFAULT_EXPLORER,
+  symbolFor,
+}: RecentBetsProps = {}) {
+  const rows = bets ?? [];
+  const symbol = symbolFor ?? (() => 'MON' as const);
+
+  if (rows.length === 0) {
+    return (
+      <section
+        data-testid="swo-recent-bets"
+        data-state="empty"
+        aria-label="Recent bets"
+        style={containerStyle}
+      >
+        <h3 style={headingStyle}>Recent bets</h3>
+        <p
+          role="status"
+          aria-live="polite"
+          data-testid="swo-recent-bets-status"
+          style={statusStyle}
+        >
+          {EMPTY_COPY}
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section
+      data-testid="swo-recent-bets"
+      data-state="populated"
+      aria-label="Recent bets"
+      style={containerStyle}
+    >
+      <h3 style={headingStyle}>Recent bets</h3>
+      <p
+        role="status"
+        aria-live="polite"
+        data-testid="swo-recent-bets-status"
+        style={visuallyHiddenStyle}
+      >
+        Loaded {rows.length} recent {rows.length === 1 ? 'bet' : 'bets'}
+      </p>
+      <ol role="list" style={listStyle}>
+        {rows.map((bet) => {
+          const sym = symbol(bet);
+          const chipKind = outcomeChipKind(bet.outcome, bet.payoutWei);
+          return (
+            <li
+              key={`${bet.game}:${bet.betId}`}
+              data-testid="swo-recent-bet-row"
+              data-game={bet.game}
+              data-outcome={chipKind}
+              style={rowStyle}
+            >
+              <span style={iconCellStyle} aria-hidden="true">
+                {ICON_FOR[bet.game]}
+              </span>
+              <span style={gameCellStyle} data-testid="swo-recent-bet-game">
+                {gameLabel(bet.game)}
+              </span>
+              <span
+                data-testid="swo-recent-bet-outcome-chip"
+                data-outcome={chipKind}
+                style={chipStyleFor(chipKind)}
+              >
+                {chipKind}
+              </span>
+              <span data-testid="swo-recent-bet-stake" style={amountCellStyle}>
+                {formatWei(bet.stakeWei)} {sym}
+              </span>
+              <span aria-hidden="true" style={arrowCellStyle}>
+                →
+              </span>
+              <span
+                data-testid="swo-recent-bet-payout"
+                style={amountCellStyle}
+              >
+                {bet.payoutWei
+                  ? `${formatWei(bet.payoutWei)} ${sym}`
+                  : `0 ${sym}`}
+              </span>
+              <a
+                href={`/verify/${encodeURIComponent(bet.betId)}`}
+                data-testid="swo-recent-bet-betid-link"
+                style={linkStyle}
+                aria-label={`Verify bet ${bet.betId}`}
+              >
+                #{bet.betId}
+              </a>
+              {bet.txHash ? (
+                <a
+                  href={explorerTxUrl(explorerBaseUrl, bet.txHash)}
+                  target="_blank"
+                  rel="noreferrer"
+                  data-testid="swo-recent-bet-tx-link"
+                  style={linkStyle}
+                  aria-label={`View transaction ${bet.txHash} on the block explorer`}
+                >
+                  {shortHash(bet.txHash)}
+                </a>
+              ) : null}
+            </li>
+          );
+        })}
+      </ol>
+    </section>
+  );
+}
+
+const containerStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.5rem',
+  fontVariantNumeric: 'tabular-nums',
+};
+
+const headingStyle: CSSProperties = {
+  margin: 0,
+  fontSize: '0.85rem',
+  textTransform: 'uppercase',
+  letterSpacing: '0.08em',
+  opacity: 0.7,
+};
+
+const statusStyle: CSSProperties = {
+  margin: 0,
+  fontSize: '0.85rem',
+  color: 'var(--swo-fg-subtle, rgba(255,255,255,0.72))',
+  fontStyle: 'italic',
+};
+
+const listStyle: CSSProperties = {
+  margin: 0,
+  padding: 0,
+  listStyle: 'none',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.5rem',
+};
+
+const rowStyle: CSSProperties = {
+  display: 'grid',
+  gridTemplateColumns: 'auto auto auto 1fr auto 1fr auto auto',
+  alignItems: 'center',
+  gap: '0.5rem',
+  padding: '0.5rem 0.6rem',
+  background: 'var(--swo-elevated, rgba(255,255,255,0.04))',
+  border: '1px solid var(--swo-border, rgba(255,255,255,0.12))',
+  borderRadius: 10,
+  fontSize: '0.85rem',
+  fontVariantNumeric: 'tabular-nums',
+};
+
+const iconCellStyle: CSSProperties = {
+  fontSize: '1rem',
+  lineHeight: 1,
+};
+
+const gameCellStyle: CSSProperties = {
+  fontWeight: 600,
+};
+
+const amountCellStyle: CSSProperties = {
+  fontVariantNumeric: 'tabular-nums',
+  textAlign: 'right',
+  minWidth: 0,
+  whiteSpace: 'nowrap',
+};
+
+const arrowCellStyle: CSSProperties = {
+  opacity: 0.5,
+};
+
+const linkStyle: CSSProperties = {
+  color: 'var(--swo-link-fg, #ffd166)',
+  textDecoration: 'underline',
+  textUnderlineOffset: '2px',
+  fontSize: '0.8rem',
+};
+
+const visuallyHiddenStyle: CSSProperties = {
+  position: 'absolute',
+  width: 1,
+  height: 1,
+  overflow: 'hidden',
+  clip: 'rect(0 0 0 0)',
+  whiteSpace: 'nowrap',
+};
+
+const chipBaseStyle: CSSProperties = {
+  padding: '0.05rem 0.35rem',
+  borderRadius: 999,
+  fontSize: '0.875rem',
+  fontWeight: 600,
+  textTransform: 'uppercase',
+  letterSpacing: '0.05em',
+};
+
+function chipStyleFor(
+  kind: 'won' | 'lost' | 'refunded' | 'pushed',
+): CSSProperties {
+  if (kind === 'won') {
+    return {
+      ...chipBaseStyle,
+      background: 'var(--swo-success-bg, #1f3a1f)',
+      color: 'var(--swo-success-fg, #6ee46e)',
+    };
+  }
+  if (kind === 'lost') {
+    return {
+      ...chipBaseStyle,
+      background: 'var(--swo-danger-bg, #3a1f1f)',
+      color: 'var(--swo-danger-fg, #ff6e6e)',
+    };
+  }
+  return {
+    ...chipBaseStyle,
+    background: 'var(--swo-elevated, rgba(255,255,255,0.04))',
+    color: 'var(--swo-fg-subtle, rgba(255,255,255,0.72))',
+    border: '1px solid var(--swo-border, rgba(255,255,255,0.12))',
+  };
+}

--- a/components/casino/__tests__/RecentBets.test.tsx
+++ b/components/casino/__tests__/RecentBets.test.tsx
@@ -1,0 +1,214 @@
+// @vitest-environment happy-dom
+//
+// RecentBets — acceptance contract for SWO_CASINO_COMPONENT_RECENT_BETS:
+//   (a) component exists & renders the graceful empty-state pill
+//       (`data-state="empty"`, "No recent bets yet") until the indexer
+//       lands
+//   (b) when fed mock indexer rows it renders one row per bet with the
+//       game label, outcome chip, stake/payout, verify-link, and
+//       (optional) explorer link
+//
+// Pure parent-fed component for now — no fetcher to mock.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import {
+  RecentBets,
+  formatWei,
+  outcomeChipKind,
+  type WalletBet,
+} from '../RecentBets';
+
+// React 19's act(...) checks for this flag and warns otherwise.
+(
+  globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+const COINFLIP_WIN: WalletBet = {
+  game: 'coinflip',
+  betId: '1',
+  stakeWei: '10000000000000000', // 0.01
+  payoutWei: '19800000000000000', // 0.0198
+  outcome: 'won',
+  blockNumber: '100',
+  txHash: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+};
+
+const DICE_LOSS: WalletBet = {
+  game: 'dice',
+  betId: '7',
+  stakeWei: '5000000000000000', // 0.005
+  payoutWei: null,
+  outcome: 'lost',
+  blockNumber: '200',
+  txHash: null,
+};
+
+const HILO_CASHED: WalletBet = {
+  game: 'hilo',
+  betId: '3',
+  stakeWei: '20000000000000000', // 0.02
+  payoutWei: '33000000000000000', // 0.033
+  outcome: 'cashed',
+  blockNumber: '300',
+  txHash: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+};
+
+describe('RecentBets — formatWei + outcomeChipKind helpers', () => {
+  it('formats wei with sub-MON precision and trims trailing zeros', () => {
+    expect(formatWei('10000000000000000')).toBe('0.01');
+    expect(formatWei('19800000000000000')).toBe('0.0198');
+    expect(formatWei('1000000000000000000')).toBe('1');
+    expect(formatWei('0')).toBe('0');
+  });
+
+  it('derives outcome chip kind from status + payout', () => {
+    expect(outcomeChipKind('won', '1')).toBe('won');
+    expect(outcomeChipKind('cashed', '1')).toBe('won');
+    expect(outcomeChipKind('lost', null)).toBe('lost');
+    expect(outcomeChipKind('refunded', null)).toBe('refunded');
+    expect(outcomeChipKind('pushed', null)).toBe('pushed');
+  });
+});
+
+describe('<RecentBets> (acceptance: SWO_CASINO_COMPONENT_RECENT_BETS)', () => {
+  // (a) Component exists and renders the graceful empty state.
+  it('(a) renders "No recent bets yet" with data-state="empty" when no bets given', () => {
+    act(() => {
+      root.render(<RecentBets />);
+    });
+    const section = container.querySelector('[data-testid="swo-recent-bets"]');
+    expect(section).not.toBeNull();
+    expect(section!.getAttribute('data-state')).toBe('empty');
+    expect(section!.getAttribute('aria-label')).toBe('Recent bets');
+    const status = container.querySelector(
+      '[data-testid="swo-recent-bets-status"]',
+    );
+    expect(status!.textContent).toBe('No recent bets yet');
+    // No rows in the empty surface.
+    expect(
+      container.querySelectorAll('[data-testid="swo-recent-bet-row"]'),
+    ).toHaveLength(0);
+  });
+
+  it('also renders the empty surface when bets=[] is explicitly passed', () => {
+    act(() => {
+      root.render(<RecentBets bets={[]} />);
+    });
+    const section = container.querySelector('[data-testid="swo-recent-bets"]');
+    expect(section!.getAttribute('data-state')).toBe('empty');
+  });
+
+  // (b/c) Renders rows when fed mock indexer data.
+  it('(b) renders one row per bet across all three games (coinflip + dice + hilo)', () => {
+    act(() => {
+      root.render(
+        <RecentBets bets={[HILO_CASHED, DICE_LOSS, COINFLIP_WIN]} />,
+      );
+    });
+    const section = container.querySelector('[data-testid="swo-recent-bets"]');
+    expect(section!.getAttribute('data-state')).toBe('populated');
+
+    const rows = container.querySelectorAll(
+      '[data-testid="swo-recent-bet-row"]',
+    );
+    expect(rows).toHaveLength(3);
+    const games = Array.from(rows).map((r) => r.getAttribute('data-game'));
+    expect(games).toEqual(['hilo', 'dice', 'coinflip']);
+
+    const chipKinds = Array.from(
+      container.querySelectorAll('[data-testid="swo-recent-bet-outcome-chip"]'),
+    ).map((c) => c.getAttribute('data-outcome'));
+    expect(chipKinds).toEqual(['won', 'lost', 'won']);
+  });
+
+  it('formats stake → payout columns with 4dp precision (mixed MON/USDm via symbolFor)', () => {
+    const symbolFor = (b: WalletBet) =>
+      b.game === 'dice' ? ('USDm' as const) : ('MON' as const);
+
+    act(() => {
+      root.render(
+        <RecentBets
+          bets={[COINFLIP_WIN, HILO_CASHED, DICE_LOSS]}
+          symbolFor={symbolFor}
+        />,
+      );
+    });
+
+    const stakes = Array.from(
+      container.querySelectorAll('[data-testid="swo-recent-bet-stake"]'),
+    ).map((el) => el.textContent);
+    expect(stakes[0]).toBe('0.01 MON');
+    expect(stakes[1]).toBe('0.02 MON');
+    expect(stakes[2]).toBe('0.005 USDm');
+
+    const payouts = Array.from(
+      container.querySelectorAll('[data-testid="swo-recent-bet-payout"]'),
+    ).map((el) => el.textContent);
+    expect(payouts[0]).toBe('0.0198 MON');
+    expect(payouts[1]).toBe('0.033 MON');
+    // Null payoutWei renders the zero placeholder with the row's symbol.
+    expect(payouts[2]).toBe('0 USDm');
+  });
+
+  it('links betId to /verify/[betId] and txHash to the supplied explorer base', () => {
+    act(() => {
+      root.render(
+        <RecentBets
+          bets={[COINFLIP_WIN, DICE_LOSS]}
+          explorerBaseUrl="https://explorer.example"
+        />,
+      );
+    });
+
+    const verifyLinks = container.querySelectorAll(
+      '[data-testid="swo-recent-bet-betid-link"]',
+    );
+    expect(verifyLinks[0].getAttribute('href')).toBe('/verify/1');
+    expect(verifyLinks[1].getAttribute('href')).toBe('/verify/7');
+
+    // Only the first bet has a txHash → exactly one explorer link.
+    const txLinks = container.querySelectorAll(
+      '[data-testid="swo-recent-bet-tx-link"]',
+    );
+    expect(txLinks).toHaveLength(1);
+    expect(txLinks[0].getAttribute('href')).toBe(
+      `https://explorer.example/tx/${COINFLIP_WIN.txHash}`,
+    );
+    expect(txLinks[0].getAttribute('target')).toBe('_blank');
+    expect(txLinks[0].getAttribute('rel')).toBe('noreferrer');
+    expect(txLinks[0].textContent).toMatch(/^0x[a-f]{4}…[a-f]{4}$/);
+  });
+
+  it('announces the populated row count once for screen readers', () => {
+    act(() => {
+      root.render(
+        <RecentBets bets={[COINFLIP_WIN, DICE_LOSS, HILO_CASHED]} />,
+      );
+    });
+    const announces = container.querySelectorAll(
+      '[data-testid="swo-recent-bets-status"]',
+    );
+    expect(announces).toHaveLength(1);
+    expect(announces[0].getAttribute('aria-live')).toBe('polite');
+    expect(announces[0].textContent).toMatch(/loaded 3 recent bets/i);
+  });
+});


### PR DESCRIPTION
## Summary
- Ports BunnyBagz `RecentBetsList.tsx` to `components/casino/RecentBets.tsx` as a graceful empty surface until the SWO indexer lands.
- Empty state renders **"No recent bets yet"** with `data-state="empty"`; populated state renders one row per bet (game label, outcome chip, stake → payout, `/verify/[betId]` link, optional explorer link).
- Currency symbol defaults to **MON** (SWO's native gas token on Monad) instead of BB's ETH; parents can override per-row via `symbolFor`.
- Pure parent-fed component — no fetcher complexity until the indexer lands; the row markup is already in place and exercised by the test suite so wiring the indexer later is purely data-plumbing.

## Acceptance (SWO_CASINO_COMPONENT_RECENT_BETS)
- (a) Component exists at `components/casino/RecentBets.tsx`.
- (b) Vitest covers the empty state (both `bets` omitted and `bets={[]}`), asserts `data-state="empty"`, "No recent bets yet" copy, and 0 rendered rows.
- (c) Vitest covers populated rendering with mock indexer data across all three games (coinflip + dice + hilo), 4dp stake/payout formatting with mixed MON/USDm, `/verify/[betId]` link wiring, explorer link wiring with short-hash text, single live-region announce.

## Test plan
- [x] `npx vitest run --project casino components/casino/__tests__/RecentBets.test.tsx` — 8/8 pass
- [x] `npx vitest run --project casino` — 26/26 pass (no regressions in BetPanel/StakeChip/TrustStrip/WalletSheet)
- [x] `npm run type-check` — clean
- [x] `npx eslint components/casino/RecentBets.tsx components/casino/__tests__/RecentBets.test.tsx` — clean

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS (0 errors baseline; 0 errors with overlay)
- **vitest run --project casino**: 3 pre-existing unhandled errors baseline → 4 with overlay. The +1 delta is the **same** pre-existing error class (`Cannot find package 'happy-dom'`): PROD's `node_modules` is missing `happy-dom`, so every `@vitest-environment happy-dom` file already fails to load there (BetPanel.test.tsx, TrustStrip.test.tsx, WalletSheet.test.tsx). The new RecentBets.test.tsx hits the same ERR_MODULE_NOT_FOUND for the same reason — not a regression introduced by this PR. In the workspace (where `happy-dom` is installed) all 8 tests pass.
- Overall: PASS (no new error class; pre-existing PROD dependency gap)

PR Class: A — task fully implemented, validated, shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)