### PR TITLE
feat(casino): port BB coinflip page → /casino/coinflip [SWO_CASINO_COINFLIP_UI]

### DIFF
--- a/app/casino/coinflip/CoinflipContent.tsx
+++ b/app/casino/coinflip/CoinflipContent.tsx
@@ -1,0 +1,240 @@
+// CoinflipContent — wagmi-backed wrapper around <CoinflipPanel>.
+//
+// Ported from BunnyBagz `apps/web/src/app/play/coinflip/page.tsx` to
+// SWO's `/casino/coinflip` route. The BB original drags in a stack of
+// optional rails (CoinSpin, MascotFrame, LiveActivityFeed, …) that
+// don't exist in this repo; this port keeps only the pieces the task
+// calls out: BetPanel + TrustStrip + FairnessProof + chain gate.
+//
+// Wire contract:
+//   1. Reads the CosmicFlip address from the chain-keyed deployment
+//      registry (`lib/casino/addresses.ts`).
+//   2. Fetches a fresh server commit from `/api/seed/claim` before
+//      each bet — if that endpoint isn't deployed yet the bet aborts
+//      with a visible error rather than burning gas on a zero commit.
+//   3. Calls `CosmicFlip.placeBet(sideEnum, clientSeed, serverCommit)`
+//      via `writeContract`.
+//   4. Listens for the `BetSettled` event via `useWatchContractEvent`,
+//      filters to the current player, and surfaces Won/Lost in the
+//      <CoinflipPanel> via the `settledSide` + `settledPayout` props.
+//   5. Acceptance (d): chain-gate fires whenever wagmi reports a
+//      chainId outside the Monad mainnet/testnet pair (143 / 10143).
+
+'use client';
+
+import { useCallback, useState } from 'react';
+import { formatEther, parseEther, type Hex } from 'viem';
+import {
+  useAccount,
+  useConnect,
+  useSwitchChain,
+  useWatchContractEvent,
+  useWriteContract,
+} from 'wagmi';
+
+import { TrustStrip } from '@/components/casino/TrustStrip';
+import { getCasinoAddresses } from '@/lib/casino/addresses';
+import { monad } from '@/lib/wagmi';
+
+import {
+  ALLOWED_CHAIN_IDS,
+  CoinflipPanel,
+  type CoinflipSide,
+} from './CoinflipPanel';
+
+// Minimal ABI: only the two members this page actually touches. Avoids
+// pulling in `contracts/casino/out/CosmicFlip.sol/CosmicFlip.json`,
+// which (a) isn't committed in every environment and (b) drags in the
+// full ~40KB artifact for two members. The full ABI is still consumed
+// by the bankroll/admin surfaces that need it.
+const COSMIC_FLIP_ABI = [
+  {
+    type: 'function',
+    name: 'placeBet',
+    stateMutability: 'payable',
+    inputs: [
+      { name: 'side', type: 'uint8' },
+      { name: 'clientSeed', type: 'bytes32' },
+      { name: 'serverCommit', type: 'bytes32' },
+    ],
+    outputs: [{ name: 'betId', type: 'uint256' }],
+  },
+  {
+    type: 'event',
+    name: 'BetSettled',
+    inputs: [
+      { name: 'betId', type: 'uint256', indexed: true },
+      { name: 'player', type: 'address', indexed: true },
+      { name: 'outcome', type: 'uint8', indexed: false },
+      { name: 'won', type: 'bool', indexed: false },
+      { name: 'payout', type: 'uint256', indexed: false },
+      { name: 'serverReveal', type: 'bytes32', indexed: false },
+    ],
+  },
+] as const;
+
+const ZERO_BYTES32: Hex =
+  '0x0000000000000000000000000000000000000000000000000000000000000000';
+
+function randomClientSeed(): Hex {
+  if (typeof crypto !== 'undefined' && 'getRandomValues' in crypto) {
+    const buf = new Uint8Array(32);
+    crypto.getRandomValues(buf);
+    return ('0x' +
+      Array.from(buf, (b) => b.toString(16).padStart(2, '0')).join('')) as Hex;
+  }
+  return ZERO_BYTES32;
+}
+
+async function claimFreshCommit(): Promise<Hex | null> {
+  try {
+    const r = await fetch('/api/seed/claim', { method: 'POST' });
+    if (!r.ok) return null;
+    const j = (await r.json()) as { commit?: Hex };
+    return j.commit ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function chainNameFor(chainId: number): string {
+  if (chainId === 10143) return 'Monad Testnet';
+  if (chainId === 143) return 'Monad';
+  return `chain ${chainId}`;
+}
+
+export default function CoinflipContent() {
+  const [side, setSide] = useState<CoinflipSide>('heads');
+  const [stake, setStake] = useState('0.01');
+  const [lastStake, setLastStake] = useState<string | undefined>(undefined);
+  const [clientSeed, setClientSeed] = useState<Hex | null>(null);
+  const [serverCommit, setServerCommit] = useState<Hex | null>(null);
+  const [settledSide, setSettledSide] = useState<CoinflipSide | null>(null);
+  const [settledPayout, setSettledPayout] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const { address, isConnected, chainId } = useAccount();
+  const { connect, connectors } = useConnect();
+  const { switchChain, isPending: switching } = useSwitchChain();
+  const {
+    writeContract,
+    data: txHash,
+    isPending: signing,
+    error: writeError,
+  } = useWriteContract();
+
+  const onAllowedChain =
+    chainId != null &&
+    (ALLOWED_CHAIN_IDS as readonly number[]).includes(chainId);
+  const needsConnect = !isConnected;
+  const chainGate =
+    isConnected && !onAllowedChain
+      ? {
+          chainName: chainNameFor(monad.id),
+          onSwitch: () => switchChain({ chainId: monad.id }),
+          switching,
+        }
+      : null;
+
+  const addresses = getCasinoAddresses(monad.id);
+  const cosmicFlipAddress = addresses?.cosmicFlip ?? null;
+
+  // Subscribe to BetSettled. Filter to the current player so other
+  // bettors' settlements don't repaint our UI.
+  useWatchContractEvent({
+    address: cosmicFlipAddress ?? undefined,
+    abi: COSMIC_FLIP_ABI,
+    eventName: 'BetSettled',
+    chainId: monad.id,
+    enabled: Boolean(cosmicFlipAddress && address),
+    onLogs(logs) {
+      for (const log of logs as Array<{
+        args?: {
+          player?: `0x${string}`;
+          outcome?: number;
+          payout?: bigint;
+        };
+      }>) {
+        const args = log.args;
+        if (!args || !args.player || !address) continue;
+        if (args.player.toLowerCase() !== address.toLowerCase()) continue;
+        const outcomeSide: CoinflipSide =
+          (args.outcome ?? 0) === 0 ? 'heads' : 'tails';
+        setSettledSide(outcomeSide);
+        if (args.payout != null) {
+          setSettledPayout(
+            parseFloat(formatEther(args.payout)).toFixed(6).replace(/0+$/, '').replace(/\.$/, ''),
+          );
+        }
+      }
+    },
+  });
+
+  const placeBet = useCallback(async () => {
+    if (!cosmicFlipAddress) {
+      setError('Coinflip is not deployed on this chain yet.');
+      return;
+    }
+    setError(null);
+    setSettledSide(null);
+    setSettledPayout(null);
+    const fresh = await claimFreshCommit();
+    if (!fresh) {
+      setError(
+        'Could not claim a fresh server commit. Try again in a moment.',
+      );
+      return;
+    }
+    const seed = randomClientSeed();
+    setClientSeed(seed);
+    setServerCommit(fresh);
+    setLastStake(stake);
+    const sideEnum = side === 'heads' ? 0 : 1;
+    writeContract({
+      address: cosmicFlipAddress,
+      abi: COSMIC_FLIP_ABI,
+      functionName: 'placeBet',
+      args: [sideEnum, seed, fresh],
+      value: parseEther(stake || '0'),
+      chainId: monad.id,
+    });
+  }, [cosmicFlipAddress, side, stake, writeContract]);
+
+  const onConnect = useCallback(() => {
+    const connector = connectors[0];
+    if (!connector) return;
+    connect({ connector });
+  }, [connect, connectors]);
+
+  const ctaDisabled = !cosmicFlipAddress;
+  // Derive the user-visible error: prefer the local claim/deploy error,
+  // then fall back to wagmi's writeContract error. Avoids a
+  // setState-in-effect cascade for surfacing write errors.
+  const displayError = error ?? (writeError ? writeError.message : null);
+
+  return (
+    <CoinflipPanel
+      side={side}
+      onSideChange={setSide}
+      stake={stake}
+      onStakeChange={setStake}
+      lastStake={lastStake}
+      chainGate={chainGate}
+      needsConnect={needsConnect}
+      onConnect={onConnect}
+      busy={signing}
+      onPlaceBet={placeBet}
+      ctaDisabled={ctaDisabled}
+      ctaLabelOverride={
+        !cosmicFlipAddress ? 'Coinflip not deployed' : undefined
+      }
+      settledSide={settledSide}
+      settledPayout={settledPayout}
+      error={displayError}
+      txHash={txHash ?? null}
+      serverCommit={serverCommit}
+      clientSeed={clientSeed}
+      trustStrip={<TrustStrip />}
+    />
+  );
+}

--- a/app/casino/coinflip/CoinflipPanel.tsx
+++ b/app/casino/coinflip/CoinflipPanel.tsx
@@ -1,0 +1,366 @@
+// CoinflipPanel — pure presentational shell for the /casino/coinflip
+// page, ported from BunnyBagz `apps/web/src/app/play/coinflip/page.tsx`.
+//
+// CoinflipContent (the wagmi wrapper) owns all chain state and feeds
+// this component via props. Keeping the panel side-effect-free lets the
+// vitest suite assert the synchronous code path (acceptance (b) of
+// SWO_CASINO_COINFLIP_UI) without spinning up a WagmiProvider.
+//
+// Surface contract:
+//   • Heads/tails toggle calls `onSideChange`.
+//   • <BetPanel> CTA fires `onPlaceBet` (proxied through `cta.onClick`).
+//   • When `chainGate` is set, a banner overrides the bet UI and the
+//     primary CTA becomes "Switch to <chainName>" — acceptance (d).
+//   • `settledOutcome` ("won" | "lost") drives the live-region message
+//     and the bold result line above the panel.
+//
+// The component intentionally stays Tailwind-free and uses inline styles
+// so it matches the existing SWO casino primitives (BetPanel,
+// TrustStrip, WalletSheet) and stays portable into the PROD mirror.
+
+'use client';
+
+import type { CSSProperties, ReactNode } from 'react';
+
+import { BetPanel, type BetPanelCta } from '@/components/casino/BetPanel';
+import { FairnessProof } from '@/components/casino/FairnessProof';
+
+export type CoinflipSide = 'heads' | 'tails';
+export type CoinflipOutcome = 'won' | 'lost' | null;
+
+export interface CoinflipChainGate {
+  /** Human-readable name of the required chain (e.g. "Monad Testnet"). */
+  chainName: string;
+  /** Switch-chain click handler. */
+  onSwitch: () => void;
+  /** Disable the switch CTA while wagmi is flipping chains. */
+  switching: boolean;
+}
+
+export interface CoinflipPanelProps {
+  /** Currently selected side ("heads" or "tails"). */
+  side: CoinflipSide;
+  /** Side toggle handler — clicking heads/tails fires this. */
+  onSideChange: (next: CoinflipSide) => void;
+  /** Current stake value (controlled). */
+  stake: string;
+  /** Stake setter wired to the BetPanel input. */
+  onStakeChange: (next: string) => void;
+  /** Last-submitted stake — feeds the "Bet last" chip. */
+  lastStake?: string;
+  /** Token unit shown next to the stake (MON / USDm). */
+  stakeUnit?: string;
+  /**
+   * When non-null, the bet UI is replaced by a chain-gate banner.
+   * Acceptance (d): fires when wagmi reports chainId ≠ 10143/143.
+   */
+  chainGate: CoinflipChainGate | null;
+  /** Show the "Connect wallet" CTA instead of the bet CTA. */
+  needsConnect: boolean;
+  /** Connect-wallet click handler. Wired from RainbowKit / wagmi. */
+  onConnect: () => void;
+  /** Whether `placeBet` is currently in flight. */
+  busy: boolean;
+  /** Place-bet click handler. Fires the wagmi `placeBet` call. */
+  onPlaceBet: () => void;
+  /** Hard-disabled CTA (e.g. contract not deployed on this chain). */
+  ctaDisabled?: boolean;
+  /** When set, replaces the dynamic CTA label (e.g. for diagnostics). */
+  ctaLabelOverride?: string;
+  /**
+   * Result side reported by the on-chain `BetSettled` event listener.
+   * `null` before settlement; "heads" | "tails" after.
+   */
+  settledSide: CoinflipSide | null;
+  /** Payout in MON (string, formatted). */
+  settledPayout?: string | null;
+  /** Optional error string surfaced under the CTA. */
+  error?: string | null;
+  /** Tx hash for the FairnessProof card. */
+  txHash?: string | null;
+  /** Server commit hash for the FairnessProof card. */
+  serverCommit?: string | null;
+  /** Client seed for the FairnessProof card. */
+  clientSeed?: string | null;
+  /** Slot for a TrustStrip or other live widget above the panel. */
+  trustStrip?: ReactNode;
+}
+
+export const ALLOWED_CHAIN_IDS = [143, 10143] as const;
+export const PAYOUT_MULTIPLIER = 1.98;
+
+function outcomeFor(
+  settledSide: CoinflipSide | null,
+  pickedSide: CoinflipSide,
+): CoinflipOutcome {
+  if (settledSide == null) return null;
+  return settledSide === pickedSide ? 'won' : 'lost';
+}
+
+function profitOnWin(stake: string, unit: string): string | undefined {
+  const n = parseFloat(stake || '0');
+  if (!Number.isFinite(n) || n <= 0) return undefined;
+  const profit = n * PAYOUT_MULTIPLIER - n;
+  return `${parseFloat(profit.toFixed(6))} ${unit}`;
+}
+
+export function CoinflipPanel(props: CoinflipPanelProps) {
+  const {
+    side,
+    onSideChange,
+    stake,
+    onStakeChange,
+    lastStake,
+    stakeUnit = 'MON',
+    chainGate,
+    needsConnect,
+    onConnect,
+    busy,
+    onPlaceBet,
+    ctaDisabled = false,
+    ctaLabelOverride,
+    settledSide,
+    settledPayout,
+    error,
+    txHash,
+    serverCommit,
+    clientSeed,
+    trustStrip,
+  } = props;
+
+  const outcome = outcomeFor(settledSide, side);
+
+  // Live-region message (acceptance (c) for screen readers and tests).
+  let liveMessage = '';
+  if (outcome === 'won') {
+    const payout = settledPayout ?? '';
+    liveMessage = payout
+      ? `You won ${payout} ${stakeUnit} on ${side}.`
+      : `You won on ${side}.`;
+  } else if (outcome === 'lost') {
+    liveMessage = `You lost ${stake} ${stakeUnit} on ${side}. The coin landed ${settledSide}.`;
+  }
+
+  let cta: BetPanelCta;
+  if (chainGate) {
+    cta = {
+      label: chainGate.switching
+        ? 'Switching network…'
+        : `Switch to ${chainGate.chainName}`,
+      onClick: chainGate.onSwitch,
+      disabled: chainGate.switching,
+    };
+  } else if (needsConnect) {
+    cta = {
+      label: 'Connect wallet',
+      onClick: onConnect,
+      disabled: false,
+    };
+  } else if (busy) {
+    cta = {
+      label: 'Confirm in wallet…',
+      onClick: () => {},
+      disabled: true,
+    };
+  } else {
+    cta = {
+      label: ctaLabelOverride ?? `Flip for ${stake} ${stakeUnit}`,
+      onClick: onPlaceBet,
+      disabled: ctaDisabled,
+    };
+  }
+
+  const sideSelector = (
+    <div style={sideRowStyle} data-testid="coinflip-side-selector">
+      {(['heads', 'tails'] as const).map((s) => (
+        <button
+          key={s}
+          type="button"
+          onClick={() => onSideChange(s)}
+          aria-pressed={side === s}
+          className="swo-casino-hit-44"
+          style={side === s ? sideSelectedStyle : sideStyle}
+          data-testid={`coinflip-side-${s}`}
+        >
+          {s}
+        </button>
+      ))}
+    </div>
+  );
+
+  return (
+    <main style={pageStyle} data-testid="coinflip-page">
+      <header style={headerStyle}>
+        <h1 style={titleStyle}>Coinflip</h1>
+        <span style={chainHintStyle} data-testid="coinflip-multiplier">
+          Cosmic Casino · 1.98×
+        </span>
+      </header>
+
+      {trustStrip}
+
+      {chainGate && (
+        <div
+          role="alert"
+          data-testid="coinflip-chain-gate"
+          style={chainGateBannerStyle}
+        >
+          <p style={chainGateTitleStyle}>Wrong network</p>
+          <p style={chainGateBodyStyle}>
+            Coinflip runs on {chainGate.chainName}. Switch chains to place a
+            bet.
+          </p>
+        </div>
+      )}
+
+      {outcome && (
+        <div
+          style={outcome === 'won' ? wonBannerStyle : lostBannerStyle}
+          data-testid={`coinflip-outcome-${outcome}`}
+        >
+          {outcome === 'won' ? 'Won' : 'Lost'}
+          {outcome === 'won' && settledPayout
+            ? ` · +${settledPayout} ${stakeUnit}`
+            : ''}
+        </div>
+      )}
+
+      <BetPanel
+        testIdPrefix="coinflip"
+        ariaLabel="Coinflip controls"
+        multiplier="1.98×"
+        sideSelector={sideSelector}
+        stakeUnit={stakeUnit}
+        stake={stake}
+        onStakeChange={onStakeChange}
+        lastStake={lastStake}
+        chipMax="0.1"
+        profitOnWin={profitOnWin(stake, stakeUnit)}
+        liveMessage={liveMessage}
+        cta={cta}
+        onPanelEnter={
+          !chainGate && !needsConnect && !busy && !ctaDisabled
+            ? onPlaceBet
+            : undefined
+        }
+        extras={
+          error ? (
+            <p style={errorStyle} data-testid="coinflip-error">
+              {error}
+            </p>
+          ) : undefined
+        }
+      />
+
+      <FairnessProof
+        testIdPrefix="coinflip"
+        serverCommit={serverCommit ?? null}
+        clientSeed={clientSeed ?? undefined}
+        txHash={txHash ?? null}
+      />
+    </main>
+  );
+}
+
+const pageStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.75rem',
+  width: '100%',
+  maxWidth: 480,
+  margin: '0 auto',
+  padding: '1rem 1rem 2rem',
+  color: 'var(--swo-casino-fg, #e8e8e8)',
+  fontFamily: 'system-ui, -apple-system, sans-serif',
+};
+
+const headerStyle: CSSProperties = {
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'baseline',
+};
+
+const titleStyle: CSSProperties = {
+  margin: 0,
+  color: 'var(--swo-casino-fg-strong, #fff)',
+  fontSize: '1.5rem',
+};
+
+const chainHintStyle: CSSProperties = {
+  color: 'var(--swo-casino-fg-muted, rgba(232,232,232,0.6))',
+  fontSize: '0.8125rem',
+  fontVariantNumeric: 'tabular-nums',
+};
+
+const sideRowStyle: CSSProperties = {
+  display: 'flex',
+  gap: '0.5rem',
+};
+
+const sideStyle: CSSProperties = {
+  flex: 1,
+  padding: '0.875rem',
+  borderRadius: 12,
+  border: '1px solid var(--swo-casino-border, rgba(255,255,255,0.16))',
+  background: 'var(--swo-casino-elevated, rgba(255,255,255,0.06))',
+  color: 'var(--swo-casino-fg, #e8e8e8)',
+  fontWeight: 600,
+  textTransform: 'capitalize',
+  cursor: 'pointer',
+  minHeight: 44,
+  fontSize: '1rem',
+};
+
+const sideSelectedStyle: CSSProperties = {
+  ...sideStyle,
+  border: '2px solid var(--swo-casino-brand-gold, #ffd700)',
+  background: 'var(--swo-casino-brand-gold, #ffd700)',
+  color: 'var(--swo-casino-brand-ink, #0a0a1a)',
+};
+
+const chainGateBannerStyle: CSSProperties = {
+  borderRadius: 12,
+  border: '1px solid var(--swo-casino-danger-border, rgba(255,68,102,0.45))',
+  background: 'var(--swo-casino-danger-bg, rgba(255,68,102,0.12))',
+  padding: '0.75rem 0.9rem',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.25rem',
+};
+
+const chainGateTitleStyle: CSSProperties = {
+  margin: 0,
+  fontSize: '0.875rem',
+  fontWeight: 700,
+  color: 'var(--swo-casino-danger-fg, #ff6680)',
+};
+
+const chainGateBodyStyle: CSSProperties = {
+  margin: 0,
+  fontSize: '0.8125rem',
+  color: 'var(--swo-casino-fg-muted, rgba(232,232,232,0.7))',
+};
+
+const wonBannerStyle: CSSProperties = {
+  borderRadius: 12,
+  border: '1px solid var(--swo-casino-win-border, rgba(68,255,136,0.5))',
+  background: 'var(--swo-casino-win-bg, rgba(68,255,136,0.12))',
+  color: 'var(--swo-casino-win-fg, #44ff88)',
+  padding: '0.6rem 0.9rem',
+  fontSize: '1rem',
+  fontWeight: 700,
+  letterSpacing: '0.05em',
+};
+
+const lostBannerStyle: CSSProperties = {
+  ...wonBannerStyle,
+  borderColor: 'var(--swo-casino-loss-border, rgba(153,102,255,0.45))',
+  background: 'var(--swo-casino-loss-bg, rgba(153,102,255,0.12))',
+  color: 'var(--swo-casino-loss-fg, #b894ff)',
+};
+
+const errorStyle: CSSProperties = {
+  margin: 0,
+  fontSize: '0.8125rem',
+  color: 'var(--swo-casino-danger-fg, #ff6680)',
+};

--- a/app/casino/coinflip/__tests__/CoinflipPanel.test.tsx
+++ b/app/casino/coinflip/__tests__/CoinflipPanel.test.tsx
@@ -1,0 +1,223 @@
+// @vitest-environment happy-dom
+//
+// CoinflipPanel — synchronous-render acceptance for
+// SWO_CASINO_COINFLIP_UI(b): the panel exists and its CTAs wire to the
+// props the wagmi wrapper supplies. Tests stay free of wagmi so the
+// suite can run under vitest's casino project without a WagmiProvider.
+//
+// Covers:
+//   (a) renders the page surface (header, side selector, bet panel,
+//       fairness proof card)
+//   (b) heads/tails buttons call `onSideChange` with the side they show
+//   (c) primary CTA fires `onPlaceBet` when the user is connected on
+//       the right chain and not busy
+//   (d) `chainGate` prop replaces the bet CTA with a "Switch to X" CTA
+//       that calls `onSwitch` — proves the chain-gate fires for
+//       chainId ≠ 10143/143 (acceptance (d))
+//   (e) `settledSide` drives the Won / Lost banner based on which side
+//       the player picked
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { CoinflipPanel, type CoinflipPanelProps } from '../CoinflipPanel';
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+  vi.useRealTimers();
+});
+
+function renderPanel(overrides: Partial<CoinflipPanelProps> = {}) {
+  const baseProps: CoinflipPanelProps = {
+    side: 'heads',
+    onSideChange: vi.fn(),
+    stake: '0.01',
+    onStakeChange: vi.fn(),
+    chainGate: null,
+    needsConnect: false,
+    onConnect: vi.fn(),
+    busy: false,
+    onPlaceBet: vi.fn(),
+    settledSide: null,
+  };
+  const props: CoinflipPanelProps = { ...baseProps, ...overrides };
+  act(() => {
+    root.render(<CoinflipPanel {...props} />);
+  });
+  return props;
+}
+
+describe('<CoinflipPanel> (SWO_CASINO_COINFLIP_UI acceptance b/d/e)', () => {
+  it('(a) renders the page surface', () => {
+    renderPanel();
+    expect(container.querySelector('[data-testid="coinflip-page"]')).not.toBeNull();
+    expect(
+      container.querySelector('[data-testid="coinflip-bet-panel"]'),
+    ).not.toBeNull();
+    expect(
+      container.querySelector('[data-testid="coinflip-side-selector"]'),
+    ).not.toBeNull();
+    expect(
+      container.querySelector('[data-testid="coinflip-fairness-proof"]'),
+    ).not.toBeNull();
+    expect(
+      container.querySelector('[data-testid="coinflip-multiplier"]')!
+        .textContent,
+    ).toContain('1.98×');
+  });
+
+  it('(b) heads/tails buttons fire onSideChange', () => {
+    const onSideChange = vi.fn();
+    renderPanel({ side: 'heads', onSideChange });
+    const tails = container.querySelector(
+      '[data-testid="coinflip-side-tails"]',
+    ) as HTMLButtonElement;
+    expect(tails.getAttribute('aria-pressed')).toBe('false');
+    act(() => {
+      tails.click();
+    });
+    expect(onSideChange).toHaveBeenCalledWith('tails');
+  });
+
+  it('(b) selected side has aria-pressed=true', () => {
+    renderPanel({ side: 'tails' });
+    const tails = container.querySelector(
+      '[data-testid="coinflip-side-tails"]',
+    ) as HTMLButtonElement;
+    const heads = container.querySelector(
+      '[data-testid="coinflip-side-heads"]',
+    ) as HTMLButtonElement;
+    expect(tails.getAttribute('aria-pressed')).toBe('true');
+    expect(heads.getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('(c) primary CTA shows "Flip for <stake> MON" and fires onPlaceBet', () => {
+    const onPlaceBet = vi.fn();
+    renderPanel({ stake: '0.05', onPlaceBet });
+    const cta = container.querySelector(
+      '[data-testid="coinflip-primary-cta"]',
+    ) as HTMLButtonElement;
+    expect(cta.textContent).toBe('Flip for 0.05 MON');
+    expect(cta.disabled).toBe(false);
+    act(() => {
+      cta.click();
+    });
+    expect(onPlaceBet).toHaveBeenCalledTimes(1);
+  });
+
+  it('(c) CTA shows "Connect wallet" and fires onConnect when needsConnect', () => {
+    const onConnect = vi.fn();
+    renderPanel({ needsConnect: true, onConnect });
+    const cta = container.querySelector(
+      '[data-testid="coinflip-primary-cta"]',
+    ) as HTMLButtonElement;
+    expect(cta.textContent).toBe('Connect wallet');
+    act(() => {
+      cta.click();
+    });
+    expect(onConnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('(d) chainGate renders the banner and replaces the CTA with Switch', () => {
+    const onSwitch = vi.fn();
+    renderPanel({
+      chainGate: {
+        chainName: 'Monad Testnet',
+        onSwitch,
+        switching: false,
+      },
+    });
+    const banner = container.querySelector('[data-testid="coinflip-chain-gate"]');
+    expect(banner).not.toBeNull();
+    expect(banner!.textContent).toContain('Monad Testnet');
+    const cta = container.querySelector(
+      '[data-testid="coinflip-primary-cta"]',
+    ) as HTMLButtonElement;
+    expect(cta.textContent).toBe('Switch to Monad Testnet');
+    act(() => {
+      cta.click();
+    });
+    expect(onSwitch).toHaveBeenCalledTimes(1);
+  });
+
+  it('(d) chainGate switching=true disables the switch CTA', () => {
+    renderPanel({
+      chainGate: {
+        chainName: 'Monad Testnet',
+        onSwitch: vi.fn(),
+        switching: true,
+      },
+    });
+    const cta = container.querySelector(
+      '[data-testid="coinflip-primary-cta"]',
+    ) as HTMLButtonElement;
+    expect(cta.disabled).toBe(true);
+    expect(cta.textContent).toBe('Switching network…');
+  });
+
+  it('(e) settledSide matching pick → Won banner with payout', () => {
+    renderPanel({
+      side: 'heads',
+      settledSide: 'heads',
+      settledPayout: '0.0198',
+    });
+    const won = container.querySelector('[data-testid="coinflip-outcome-won"]');
+    expect(won).not.toBeNull();
+    expect(won!.textContent).toContain('Won');
+    expect(won!.textContent).toContain('0.0198 MON');
+  });
+
+  it('(e) settledSide mismatching pick → Lost banner', () => {
+    renderPanel({ side: 'heads', settledSide: 'tails' });
+    const lost = container.querySelector(
+      '[data-testid="coinflip-outcome-lost"]',
+    );
+    expect(lost).not.toBeNull();
+    expect(lost!.textContent).toContain('Lost');
+    // Won banner must NOT render.
+    expect(
+      container.querySelector('[data-testid="coinflip-outcome-won"]'),
+    ).toBeNull();
+  });
+
+  it('(e) before settlement, neither Won nor Lost banner renders', () => {
+    renderPanel({ settledSide: null });
+    expect(
+      container.querySelector('[data-testid="coinflip-outcome-won"]'),
+    ).toBeNull();
+    expect(
+      container.querySelector('[data-testid="coinflip-outcome-lost"]'),
+    ).toBeNull();
+  });
+
+  it('busy=true replaces the CTA label with "Confirm in wallet…"', () => {
+    renderPanel({ busy: true });
+    const cta = container.querySelector(
+      '[data-testid="coinflip-primary-cta"]',
+    ) as HTMLButtonElement;
+    expect(cta.textContent).toBe('Confirm in wallet…');
+    expect(cta.disabled).toBe(true);
+  });
+
+  it('error string renders into the BetPanel extras slot', () => {
+    renderPanel({ error: 'Could not claim a fresh server commit.' });
+    const err = container.querySelector('[data-testid="coinflip-error"]');
+    expect(err).not.toBeNull();
+    expect(err!.textContent).toContain('Could not claim');
+  });
+});

--- a/app/casino/coinflip/page.tsx
+++ b/app/casino/coinflip/page.tsx
@@ -1,0 +1,15 @@
+import CoinflipContent from './CoinflipContent';
+
+export const metadata = {
+  title: 'Coinflip | Cosmic Casino | Star World Order',
+  description:
+    'Play Cosmic Casino Coinflip on Monad — provably fair, 1.98× payouts, instant settlement.',
+};
+
+export default function CoinflipPage() {
+  return (
+    <main className="min-h-screen">
+      <CoinflipContent />
+    </main>
+  );
+}

--- a/components/casino/FairnessProof.tsx
+++ b/components/casino/FairnessProof.tsx
@@ -1,0 +1,180 @@
+// FairnessProof — provably-fair receipt card for SWO Cosmic Casino game
+// pages.  Each bet surface (coinflip, dice, hilo) renders this beneath
+// its <BetPanel> to expose the server commit hash, the user's client
+// seed, and the tx hash once a bet has been submitted — the three
+// inputs a player needs to independently reproduce the result via the
+// /verify page.
+//
+// Anatomy:
+//   ┌──────────────────────────────────────────┐
+//   │  PROVABLY FAIR                           │
+//   │  Server commit:  0xabc…123  [copy]       │
+//   │  Client seed:    0xdef…456  [copy]       │
+//   │  Tx hash:        0x789…abc  [explorer ↗] │
+//   │  → Verify any bet                        │
+//   └──────────────────────────────────────────┘
+//
+// Pure presentational: callers pass the strings, the component renders
+// them. The `/verify` link is always visible so a player can audit even
+// before submitting a bet.
+
+'use client';
+
+import Link from 'next/link';
+import type { CSSProperties } from 'react';
+
+const DEFAULT_EXPLORER = 'https://testnet.monadscan.com';
+
+export interface FairnessProofProps {
+  /** Stable prefix for `data-testid` (e.g. `coinflip`). */
+  testIdPrefix: string;
+  /** Server commit hash (pre-shared before bet). */
+  serverCommit: string | null;
+  /** Client seed (random per bet). */
+  clientSeed?: string | null;
+  /** Tx hash, once the bet has been broadcast. */
+  txHash?: string | null;
+  /** Block-explorer base URL. Defaults to Monad testnet Monadscan. */
+  explorerBaseUrl?: string;
+}
+
+function short(hex: string | null | undefined): string {
+  if (!hex) return '—';
+  if (hex.length <= 14) return hex;
+  return `${hex.slice(0, 8)}…${hex.slice(-6)}`;
+}
+
+export function FairnessProof({
+  testIdPrefix,
+  serverCommit,
+  clientSeed,
+  txHash,
+  explorerBaseUrl = DEFAULT_EXPLORER,
+}: FairnessProofProps) {
+  return (
+    <section
+      aria-label="Provably fair proof"
+      data-testid={`${testIdPrefix}-fairness-proof`}
+      style={cardStyle}
+    >
+      <h3 style={titleStyle}>Provably fair</h3>
+
+      <dl style={listStyle}>
+        <div style={rowStyle} data-testid={`${testIdPrefix}-fairness-commit-row`}>
+          <dt style={labelStyle}>Server commit</dt>
+          <dd
+            className="swo-casino-tabular"
+            style={valueStyle}
+            data-testid={`${testIdPrefix}-fairness-commit`}
+          >
+            {short(serverCommit)}
+          </dd>
+        </div>
+
+        {clientSeed !== undefined && (
+          <div style={rowStyle} data-testid={`${testIdPrefix}-fairness-client-row`}>
+            <dt style={labelStyle}>Client seed</dt>
+            <dd
+              className="swo-casino-tabular"
+              style={valueStyle}
+              data-testid={`${testIdPrefix}-fairness-client`}
+            >
+              {short(clientSeed)}
+            </dd>
+          </div>
+        )}
+
+        <div style={rowStyle} data-testid={`${testIdPrefix}-fairness-tx-row`}>
+          <dt style={labelStyle}>Tx hash</dt>
+          <dd
+            className="swo-casino-tabular"
+            style={valueStyle}
+            data-testid={`${testIdPrefix}-fairness-tx`}
+          >
+            {txHash ? (
+              <a
+                href={`${explorerBaseUrl}/tx/${txHash}`}
+                target="_blank"
+                rel="noreferrer"
+                style={linkStyle}
+                data-testid={`${testIdPrefix}-fairness-tx-link`}
+                className="swo-casino-hit-44"
+              >
+                {short(txHash)} ↗
+              </a>
+            ) : (
+              '—'
+            )}
+          </dd>
+        </div>
+      </dl>
+
+      <Link
+        href="/verify"
+        style={verifyLinkStyle}
+        data-testid={`${testIdPrefix}-fairness-verify-link`}
+        className="swo-casino-hit-44"
+      >
+        Verify any bet →
+      </Link>
+    </section>
+  );
+}
+
+const cardStyle: CSSProperties = {
+  background: 'var(--swo-casino-elevated, rgba(255,255,255,0.04))',
+  border: '1px solid var(--swo-casino-border, rgba(255,255,255,0.16))',
+  borderRadius: 12,
+  padding: '0.75rem 0.9rem',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.5rem',
+};
+
+const titleStyle: CSSProperties = {
+  margin: 0,
+  fontSize: '0.75rem',
+  textTransform: 'uppercase',
+  letterSpacing: '0.08em',
+  color: 'var(--swo-casino-fg-muted, rgba(232,232,232,0.7))',
+  fontWeight: 700,
+};
+
+const listStyle: CSSProperties = {
+  margin: 0,
+  padding: 0,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.4rem',
+};
+
+const rowStyle: CSSProperties = {
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'baseline',
+  gap: '0.75rem',
+};
+
+const labelStyle: CSSProperties = {
+  fontSize: '0.75rem',
+  color: 'var(--swo-casino-fg-muted, rgba(232,232,232,0.6))',
+};
+
+const valueStyle: CSSProperties = {
+  margin: 0,
+  fontSize: '0.8125rem',
+  color: 'var(--swo-casino-fg, #e8e8e8)',
+  fontVariantNumeric: 'tabular-nums',
+};
+
+const linkStyle: CSSProperties = {
+  color: 'var(--swo-link-fg, #ffd166)',
+  textDecoration: 'none',
+  fontWeight: 600,
+};
+
+const verifyLinkStyle: CSSProperties = {
+  ...linkStyle,
+  fontSize: '0.8125rem',
+  alignSelf: 'flex-end',
+};

--- a/components/casino/__tests__/FairnessProof.test.tsx
+++ b/components/casino/__tests__/FairnessProof.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment happy-dom
+//
+// FairnessProof — proves the proof-card surface contract:
+//   (a) component renders with no proof yet (—) and exposes the
+//       verify-any-bet link so players can audit before betting
+//   (b) when fed a server commit / client seed / tx hash, each value is
+//       truncated and surfaced via stable data-testids
+//   (c) tx hash, when present, becomes an <a> linking to the explorer
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { FairnessProof } from '../FairnessProof';
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+  vi.useRealTimers();
+});
+
+describe('<FairnessProof>', () => {
+  it('(a) renders empty proof and shows the verify-any-bet link', () => {
+    act(() => {
+      root.render(<FairnessProof testIdPrefix="t" serverCommit={null} />);
+    });
+    expect(
+      container.querySelector('[data-testid="t-fairness-proof"]'),
+    ).not.toBeNull();
+    expect(
+      container.querySelector('[data-testid="t-fairness-commit"]')!
+        .textContent,
+    ).toBe('—');
+    expect(
+      container.querySelector('[data-testid="t-fairness-tx"]')!.textContent,
+    ).toBe('—');
+    expect(
+      container.querySelector('[data-testid="t-fairness-verify-link"]'),
+    ).not.toBeNull();
+  });
+
+  it('(b) truncates commit / client seed values', () => {
+    act(() => {
+      root.render(
+        <FairnessProof
+          testIdPrefix="t"
+          serverCommit="0xabcdef0011223344556677889900112233445566778899aabbccddeeff001122"
+          clientSeed="0x99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa"
+        />,
+      );
+    });
+    const commit = container.querySelector(
+      '[data-testid="t-fairness-commit"]',
+    )!.textContent!;
+    expect(commit.startsWith('0xabcdef')).toBe(true);
+    expect(commit).toContain('…');
+    expect(commit.length).toBeLessThan(20);
+
+    expect(
+      container.querySelector('[data-testid="t-fairness-client"]'),
+    ).not.toBeNull();
+  });
+
+  it('(c) tx hash becomes an explorer link when present', () => {
+    act(() => {
+      root.render(
+        <FairnessProof
+          testIdPrefix="t"
+          serverCommit={null}
+          txHash="0x1111222233334444555566667777888899990000aaaabbbbccccddddeeee0011"
+          explorerBaseUrl="https://example.test"
+        />,
+      );
+    });
+    const link = container.querySelector(
+      '[data-testid="t-fairness-tx-link"]',
+    ) as HTMLAnchorElement | null;
+    expect(link).not.toBeNull();
+    expect(link!.tagName).toBe('A');
+    expect(link!.getAttribute('href')).toBe(
+      'https://example.test/tx/0x1111222233334444555566667777888899990000aaaabbbbccccddddeeee0011',
+    );
+  });
+});

--- a/tests/e2e/casino/coinflip.spec.ts
+++ b/tests/e2e/casino/coinflip.spec.ts
@@ -1,0 +1,135 @@
+// Playwright spec — SWO Cosmic Casino coinflip wallet-mock flow.
+//
+// Acceptance (c) for SWO_CASINO_COINFLIP_UI: a wallet-mock spec places a
+// bet → settles → UI shows `Won` / `Lost`. The spec gates on a mock
+// wallet harness exposed by the dev server. Until the harness lands,
+// the workflow (`.github/workflows/casino-e2e.yml`) skips because no
+// `playwright.config.ts` is committed, so this spec ships as the
+// contract description the harness must satisfy.
+//
+// Companion to `app/casino/coinflip/__tests__/CoinflipPanel.test.tsx`
+// (unit-level proof of the same UI surface).
+//
+// Expectations on the live page (`/casino/coinflip`):
+//   - The page renders with `data-testid="coinflip-page"`.
+//   - When disconnected, the primary CTA shows "Connect wallet".
+//   - When connected to a non-Monad chain, the chain-gate banner
+//     surfaces with `data-testid="coinflip-chain-gate"`.
+//   - When connected to Monad, heads/tails toggle works and the
+//     primary CTA shows "Flip for <stake> MON".
+//   - After the mock wallet settles a bet on the user's side, the
+//     `coinflip-outcome-won` banner appears (and `-lost` on a miss).
+//
+// The wallet-mock harness is expected to expose:
+//   • window.__SWO_MOCK_WALLET__.connect()
+//   • window.__SWO_MOCK_WALLET__.switchChain(chainId)
+//   • window.__SWO_MOCK_WALLET__.settleCoinflip({ side, payoutEth })
+// These hooks are the SWO mirror of BB's e2e wallet bridge. The Playwright
+// runner threads them in via page.evaluate() so the page never needs to
+// know it's running against a mock.
+
+import { expect, test } from '@playwright/test';
+
+declare global {
+  interface Window {
+    __SWO_MOCK_WALLET__?: {
+      connect: () => void;
+      switchChain: (chainId: number) => void;
+      settleCoinflip: (args: { side: 'heads' | 'tails'; payoutEth?: string }) => void;
+    };
+  }
+}
+
+test.describe('Coinflip (casino) wallet-mock flow', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/casino/coinflip');
+  });
+
+  test('renders the coinflip page surface', async ({ page }) => {
+    await expect(page.getByTestId('coinflip-page')).toBeVisible();
+    await expect(page.getByTestId('coinflip-bet-panel')).toBeVisible();
+    await expect(page.getByTestId('coinflip-side-selector')).toBeVisible();
+    await expect(page.getByTestId('coinflip-fairness-proof')).toBeVisible();
+  });
+
+  test('disconnected user sees the Connect wallet CTA', async ({ page }) => {
+    const cta = page.getByTestId('coinflip-primary-cta');
+    await expect(cta).toBeVisible();
+    await expect(cta).toHaveText('Connect wallet');
+  });
+
+  test('heads/tails toggle updates aria-pressed', async ({ page }) => {
+    const heads = page.getByTestId('coinflip-side-heads');
+    const tails = page.getByTestId('coinflip-side-tails');
+    await expect(heads).toHaveAttribute('aria-pressed', 'true');
+    await expect(tails).toHaveAttribute('aria-pressed', 'false');
+    await tails.click();
+    await expect(tails).toHaveAttribute('aria-pressed', 'true');
+    await expect(heads).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  test('chain-gate surfaces for non-Monad chains', async ({ page }) => {
+    // Drive the mock wallet to connect on a non-Monad chain (e.g. 1)
+    // — the chain-gate banner must appear with the Monad chain name.
+    await page.evaluate(() => {
+      window.__SWO_MOCK_WALLET__?.connect();
+      window.__SWO_MOCK_WALLET__?.switchChain(1);
+    });
+    await expect(page.getByTestId('coinflip-chain-gate')).toBeVisible();
+    await expect(page.getByTestId('coinflip-primary-cta')).toContainText(
+      /Switch to/,
+    );
+  });
+
+  test('place bet → mock settles win → Won banner shows', async ({ page }) => {
+    // Connect on Monad, pick heads, place bet, mock the settle event
+    // for heads → the Won banner with payout must render.
+    await page.evaluate(() => {
+      window.__SWO_MOCK_WALLET__?.connect();
+      window.__SWO_MOCK_WALLET__?.switchChain(10143);
+    });
+
+    const heads = page.getByTestId('coinflip-side-heads');
+    await heads.click();
+
+    const cta = page.getByTestId('coinflip-primary-cta');
+    await expect(cta).toContainText(/Flip for/);
+    await cta.click();
+
+    // Drive the mock wallet's BetSettled callback for the same side.
+    await page.evaluate(() => {
+      window.__SWO_MOCK_WALLET__?.settleCoinflip({
+        side: 'heads',
+        payoutEth: '0.0198',
+      });
+    });
+
+    await expect(page.getByTestId('coinflip-outcome-won')).toBeVisible();
+    await expect(page.getByTestId('coinflip-outcome-won')).toContainText(
+      /Won/,
+    );
+  });
+
+  test('place bet → mock settles loss → Lost banner shows', async ({
+    page,
+  }) => {
+    await page.evaluate(() => {
+      window.__SWO_MOCK_WALLET__?.connect();
+      window.__SWO_MOCK_WALLET__?.switchChain(10143);
+    });
+
+    await page.getByTestId('coinflip-side-heads').click();
+    await page.getByTestId('coinflip-primary-cta').click();
+
+    // Settle on tails — the user picked heads, so this is a loss.
+    await page.evaluate(() => {
+      window.__SWO_MOCK_WALLET__?.settleCoinflip({ side: 'tails' });
+    });
+
+    await expect(page.getByTestId('coinflip-outcome-lost')).toBeVisible();
+    await expect(page.getByTestId('coinflip-outcome-lost')).toContainText(
+      /Lost/,
+    );
+    await expect(page.getByTestId('coinflip-outcome-won')).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary

Ports BunnyBagz `apps/web/src/app/play/coinflip/page.tsx` to SWO's `/casino/coinflip` route. Wires the shared `BetPanel` primitive, the `TrustStrip` live band, a new `FairnessProof` proof-receipt card, and a chain gate that fires whenever wagmi reports a `chainId` outside Monad (`143` or `10143`).

## Acceptance (SWO_CASINO_COINFLIP_UI)

- **(a) Page exists** — `app/casino/coinflip/page.tsx` + `CoinflipContent` (wagmi wrapper) + `CoinflipPanel` (pure presentational).
- **(b) Vitest covers the synchronous code path** — `app/casino/coinflip/__tests__/CoinflipPanel.test.tsx` asserts render, CTA wiring (`onPlaceBet`, `onConnect`, `onSideChange`, `onSwitch`), the chain-gate banner, the Won/Lost banner derivation, the busy state, and the error slot. `components/casino/__tests__/FairnessProof.test.tsx` covers the proof card. **All 41 casino tests pass.**
- **(c) Playwright wallet-mock spec** — `tests/e2e/casino/coinflip.spec.ts` describes the contract for the forthcoming `window.__SWO_MOCK_WALLET__` harness: connect → switch chain → place bet → mock settles → `coinflip-outcome-won` / `coinflip-outcome-lost` banner. Mirrors the BB pattern.
- **(d) Chain-gate fires when chain ≠ 10143/143** — `ALLOWED_CHAIN_IDS = [143, 10143]` in `CoinflipPanel.tsx`. `CoinflipContent` builds the gate from `useAccount().chainId` and feeds the panel; the panel replaces the bet CTA with "Switch to <Monad>" wired to `useSwitchChain`. Test (d) covers both the banner and the disabled `Switching network…` state.

## Architecture decision

`CoinflipPanel` is pure presentational (no wagmi imports) so vitest can render it without a `WagmiProvider`. `CoinflipContent` is the thin wagmi wrapper that owns `placeBet`, the `BetSettled` listener, and chain detection. Mirrors the BB→SWO porting pattern used by `BetPanel`, `TrustStrip`, and `WalletSheet`.

ABI is inlined to the two members the page touches (`placeBet`, `BetSettled`) so we don't have to ship the full `~40KB` `CosmicFlip.json` artifact — the full ABI is still consumed by the bankroll/admin surfaces.

## Validations

- `npm run type-check` — PASS
- `npx eslint components/casino/FairnessProof.tsx components/casino/__tests__/FairnessProof.test.tsx app/casino/coinflip/ tests/e2e/casino/coinflip.spec.ts` — clean
- `npx vitest run --project casino` — 7 files, 41 tests, all pass
- `npm run test` (full) — 835 pre-existing pass; 4 pre-existing failures in `game/` and `lib/sanctuary/` are unrelated to this PR

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS (after inlining the CosmicFlip ABI so PROD doesn't need the `contracts/casino/out/` artifact)
- **vitest run --project casino**: 6 errors observed (PROD baseline was 4). All 6 are the **same** `Cannot find package 'happy-dom'` error: PROD's `node_modules` is missing the `happy-dom` devDependency that the casino unit tests use. The 2 additional errors are this PR's two new happy-dom tests hitting the same pre-existing missing-package, not a new failure mode.
- Overall: **PASS** (no new error types; soft gate)

## Test plan
- [x] `npx vitest run --project casino` passes (41/41)
- [x] `npm run type-check` passes
- [x] eslint clean on touched files
- [x] PROD mirror tsc passes after overlay; restored byte-identical after
- [ ] Manual UI smoke once the dev server + mock wallet harness lands (`/casino/coinflip` → connect → flip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)