### PR TITLE
feat(casino): testnet bypass for Skrumpey AccessGate (CasinoAccessGate)

### DIFF
--- a/app/casino/CasinoContent.tsx
+++ b/app/casino/CasinoContent.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useAccount } from 'wagmi';
 import Link from 'next/link';
-import AccessGate from '@/components/AccessGate';
+import CasinoAccessGate from '@/components/casino/CasinoAccessGate';
 
 // ============================================================================
 // Types
@@ -420,7 +420,7 @@ export default function CasinoContent() {
         {/* Jackpot Ticker */}
         <JackpotTicker jackpots={stats?.activeJackpots || []} />
 
-        <AccessGate
+        <CasinoAccessGate
           title="CASINO ACCESS RESTRICTED"
           message="Only Star Skrumpey holders may enter the Cosmic Casino."
         >
@@ -462,7 +462,7 @@ export default function CasinoContent() {
               </span>
             </div>
           </div>
-        </AccessGate>
+        </CasinoAccessGate>
       </div>
 
       {/* CSS Animations */}

--- a/app/casino/slots/SlotsContent.tsx
+++ b/app/casino/slots/SlotsContent.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useAccount } from 'wagmi';
 import Link from 'next/link';
-import AccessGate from '@/components/AccessGate';
+import CasinoAccessGate from '@/components/casino/CasinoAccessGate';
 import { getWalletAuthHeader } from '@/lib/clientWalletAuth';
 
 // ============================================================================
@@ -835,7 +835,7 @@ export default function SlotsContent() {
         </p>
       </div>
       
-      <AccessGate
+      <CasinoAccessGate
         title="STAR FORGE LOCKED"
         message="Only Star Skrumpey holders may play Star Forge."
       >
@@ -987,7 +987,7 @@ export default function SlotsContent() {
             </span>
           </div>
         </div>
-      </AccessGate>
+      </CasinoAccessGate>
       
       {/* CSS for scan line animation */}
       <style jsx global>{`

--- a/components/casino/CasinoAccessGate.tsx
+++ b/components/casino/CasinoAccessGate.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+// CasinoAccessGate — chain-aware wrapper around the Star Skrumpey access
+// gate for the SWO Cosmic Casino. Branches on the live `wagmi.useChainId()`
+// reading three ways:
+//
+//   • Monad mainnet (143)      → enforce the full <AccessGate> (Skrumpey
+//                                ownership check, unchanged from the rest
+//                                of the dapp).
+//   • Monad testnet (10143)    → BYPASS the Skrumpey check entirely so QA
+//                                can exercise the casino flows without
+//                                holding a Star Skrumpey NFT. Children
+//                                render directly; no AccessGate ever
+//                                mounts on this branch.
+//   • Any other chain          → render <ChainGate> with the "Switch to
+//                                Monad mainnet" CTA. We deliberately do
+//                                NOT mount <AccessGate> on the wrong-chain
+//                                branch so the user sees the network CTA
+//                                first (per acceptance: wrong-chain shows
+//                                ChainGate, not AccessGate).
+//
+// Cites task row [SWO_CASINO_TESTNET_OPEN_ACCESS] (PROJECT:SWO, P1 — depends
+// on D11). The testnet:mainnet chain-id ratio is 10143 / 143 ≈ 70.93×, i.e.
+// the two chains differ by ~71× in their numeric chain id — this is the
+// signal we branch on, no env flag is involved so the rule survives both
+// `next build` and `next start` in any environment.
+//
+// `chainIdOverride` is a test hook so unit tests can drive the branch
+// without standing up a `WagmiProvider`. Production callers should leave
+// it undefined.
+
+import type { ReactNode } from 'react';
+import { useChainId } from 'wagmi';
+import AccessGate from '@/components/AccessGate';
+import {
+  ChainGate,
+  MONAD_MAINNET_CHAIN_ID,
+  MONAD_TESTNET_CHAIN_ID,
+  SUPPORTED_CHAIN_IDS,
+} from './ChainGate';
+
+export type CasinoAccessGateProps = {
+  children: ReactNode;
+  /** Optional custom title for the locked screen (mainnet branch only). */
+  title?: string;
+  /** Optional custom message for the locked screen (mainnet branch only). */
+  message?: string;
+  /**
+   * Test hook: when set, replaces the default `useChainId()` read so unit
+   * tests can drive the branch deterministically. Production code should
+   * leave this undefined.
+   */
+  chainIdOverride?: number;
+};
+
+export default function CasinoAccessGate({
+  children,
+  title,
+  message,
+  chainIdOverride,
+}: CasinoAccessGateProps) {
+  const wagmiChainId = useChainId();
+  const effectiveChainId = chainIdOverride ?? wagmiChainId;
+
+  // Wrong chain — surface ChainGate, NOT the Skrumpey AccessGate. Users
+  // need to pick the right network before we can even decide whether
+  // they hold a Star Skrumpey.
+  if (!SUPPORTED_CHAIN_IDS.includes(effectiveChainId)) {
+    return (
+      <ChainGate
+        chainIdOverride={effectiveChainId}
+        targetChainId={MONAD_MAINNET_CHAIN_ID}
+      >
+        {children}
+      </ChainGate>
+    );
+  }
+
+  // Monad testnet — QA bypass. Skrumpey ownership is NOT required.
+  if (effectiveChainId === MONAD_TESTNET_CHAIN_ID) {
+    return <>{children}</>;
+  }
+
+  // Monad mainnet — production rules apply.
+  return (
+    <AccessGate title={title} message={message}>
+      {children}
+    </AccessGate>
+  );
+}

--- a/components/casino/__tests__/CasinoAccessGate.test.tsx
+++ b/components/casino/__tests__/CasinoAccessGate.test.tsx
@@ -1,0 +1,211 @@
+// @vitest-environment happy-dom
+//
+// CasinoAccessGate — acceptance contract for
+// [SWO_CASINO_TESTNET_OPEN_ACCESS] (PROJECT:SWO, P1, depends D11):
+//
+//   (i)   On Monad TESTNET (chainId 10143), the Skrumpey ownership gate
+//         must be BYPASSED so QA can exercise casino flows without
+//         holding a Star Skrumpey NFT.
+//   (ii)  On Monad MAINNET (chainId 143), the Skrumpey ownership gate
+//         must be ENFORCED — production rules apply unchanged.
+//   (iii) On any OTHER chain (e.g. Ethereum mainnet 1), the wrong-chain
+//         CTA from <ChainGate> must render INSTEAD of <AccessGate>. The
+//         user sees the "Switch to Monad ..." prompt first, not the
+//         Skrumpey lock screen.
+//
+// We stub out the underlying `wagmi` hook so the tests don't need a
+// WagmiProvider, and we stub `@/components/AccessGate` to a sentinel so
+// we can assert presence/absence without standing up DAOAccessProvider /
+// DemoModeProvider / useDAOAccess plumbing.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+vi.mock('wagmi', () => ({
+  useChainId: vi.fn<() => number>(() => 1),
+}));
+
+vi.mock('@/components/AccessGate', () => ({
+  default: ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid="swo-access-gate">{children}</div>
+  ),
+}));
+
+import { useChainId } from 'wagmi';
+import CasinoAccessGate from '../CasinoAccessGate';
+import {
+  MONAD_MAINNET_CHAIN_ID,
+  MONAD_TESTNET_CHAIN_ID,
+} from '../ChainGate';
+
+// React 19's act(...) checks for this flag and warns otherwise.
+(
+  globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mockedUseChainId = useChainId as unknown as ReturnType<typeof vi.fn>;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  mockedUseChainId.mockReset();
+  mockedUseChainId.mockReturnValue(1);
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+function render(node: React.ReactElement) {
+  act(() => {
+    root.render(node);
+  });
+}
+
+function findAccessGate(): HTMLElement | null {
+  return container.querySelector('[data-testid="swo-access-gate"]');
+}
+
+function findChainGate(): HTMLElement | null {
+  return container.querySelector('[data-testid="swo-chain-gate"]');
+}
+
+function findProtectedChild(): HTMLElement | null {
+  return container.querySelector('[data-testid="protected-child"]');
+}
+
+describe('CasinoAccessGate — Monad testnet bypass (10143)', () => {
+  it('renders children WITHOUT AccessGate on testnet', () => {
+    mockedUseChainId.mockReturnValue(MONAD_TESTNET_CHAIN_ID);
+    render(
+      <CasinoAccessGate>
+        <span data-testid="protected-child">SECRET</span>
+      </CasinoAccessGate>,
+    );
+    // AccessGate must NOT mount — that is the whole point of the
+    // testnet bypass.
+    expect(findAccessGate()).toBeNull();
+    // ChainGate must NOT mount either — testnet is a supported chain.
+    expect(findChainGate()).toBeNull();
+    // Children render directly.
+    const child = findProtectedChild();
+    expect(child).toBeTruthy();
+    expect(child?.textContent).toBe('SECRET');
+  });
+
+  it('bypass works regardless of `title` / `message` props', () => {
+    mockedUseChainId.mockReturnValue(MONAD_TESTNET_CHAIN_ID);
+    render(
+      <CasinoAccessGate title="ZZZ" message="ZZZ">
+        <span data-testid="protected-child">SECRET</span>
+      </CasinoAccessGate>,
+    );
+    expect(findAccessGate()).toBeNull();
+    expect(findProtectedChild()).toBeTruthy();
+  });
+
+  it('chainIdOverride=10143 forces the testnet bypass branch', () => {
+    mockedUseChainId.mockReturnValue(1);
+    render(
+      <CasinoAccessGate chainIdOverride={MONAD_TESTNET_CHAIN_ID}>
+        <span data-testid="protected-child">SECRET</span>
+      </CasinoAccessGate>,
+    );
+    expect(findAccessGate()).toBeNull();
+    expect(findChainGate()).toBeNull();
+    expect(findProtectedChild()).toBeTruthy();
+  });
+});
+
+describe('CasinoAccessGate — Monad mainnet enforced (143)', () => {
+  it('mounts AccessGate on mainnet so the Skrumpey check applies', () => {
+    mockedUseChainId.mockReturnValue(MONAD_MAINNET_CHAIN_ID);
+    render(
+      <CasinoAccessGate
+        title="CASINO ACCESS RESTRICTED"
+        message="Only Star Skrumpey holders may enter the Cosmic Casino."
+      >
+        <span data-testid="protected-child">SECRET</span>
+      </CasinoAccessGate>,
+    );
+    // AccessGate is the enforcement layer — must mount on mainnet.
+    expect(findAccessGate()).toBeTruthy();
+    // ChainGate must NOT mount — we are on the correct chain.
+    expect(findChainGate()).toBeNull();
+    // Children live INSIDE the AccessGate (so AccessGate decides
+    // whether to actually render them).
+    const child = findProtectedChild();
+    expect(child).toBeTruthy();
+    expect(findAccessGate()?.contains(child)).toBe(true);
+  });
+
+  it('chainIdOverride=143 forces the mainnet enforcement branch', () => {
+    mockedUseChainId.mockReturnValue(1);
+    render(
+      <CasinoAccessGate chainIdOverride={MONAD_MAINNET_CHAIN_ID}>
+        <span data-testid="protected-child">SECRET</span>
+      </CasinoAccessGate>,
+    );
+    expect(findAccessGate()).toBeTruthy();
+    expect(findChainGate()).toBeNull();
+  });
+});
+
+describe('CasinoAccessGate — wrong chain shows ChainGate, NOT AccessGate', () => {
+  it('renders ChainGate on Ethereum mainnet (chainId 1)', () => {
+    mockedUseChainId.mockReturnValue(1);
+    render(
+      <CasinoAccessGate>
+        <button type="button" data-testid="protected-child">
+          Bet
+        </button>
+      </CasinoAccessGate>,
+    );
+    // CRITICAL: AccessGate must NOT mount on wrong-chain. The wrong-
+    // network CTA wins priority over the Skrumpey prompt.
+    expect(findAccessGate()).toBeNull();
+    // ChainGate must mount and surface the "Switch to Monad ..." CTA.
+    const gate = findChainGate();
+    expect(gate).toBeTruthy();
+    expect(gate?.getAttribute('role')).toBe('region');
+    expect(gate?.getAttribute('aria-label')).toBe('Wrong network');
+    expect(gate?.getAttribute('data-current-chain')).toBe('1');
+    const switchBtn = container.querySelector(
+      '[data-testid="swo-chain-gate-switch"]',
+    );
+    expect(switchBtn?.textContent).toBe('Switch to Monad mainnet');
+  });
+
+  it('renders ChainGate on Polygon mainnet (chainId 137), not AccessGate', () => {
+    mockedUseChainId.mockReturnValue(137);
+    render(
+      <CasinoAccessGate>
+        <span data-testid="protected-child">SECRET</span>
+      </CasinoAccessGate>,
+    );
+    expect(findAccessGate()).toBeNull();
+    const gate = findChainGate();
+    expect(gate).toBeTruthy();
+    expect(gate?.getAttribute('data-current-chain')).toBe('137');
+  });
+
+  it('chainIdOverride beats useChainId() (testability)', () => {
+    // Wagmi says we are on mainnet, but the override pins us off-chain.
+    mockedUseChainId.mockReturnValue(MONAD_MAINNET_CHAIN_ID);
+    render(
+      <CasinoAccessGate chainIdOverride={1}>
+        <span data-testid="protected-child">SECRET</span>
+      </CasinoAccessGate>,
+    );
+    expect(findAccessGate()).toBeNull();
+    expect(findChainGate()).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- New `components/casino/CasinoAccessGate.tsx` branches on `wagmi.useChainId()`:
  - **Monad testnet (10143)** → bypass Star Skrumpey check (children render directly) so QA can exercise casino flows without a Star NFT.
  - **Monad mainnet (143)** → enforce full `<AccessGate>` unchanged.
  - **Any other chain** → render `<ChainGate>` (Switch-to-Monad CTA), NOT `<AccessGate>` — the network prompt wins priority.
- Wires the new gate into `app/casino/CasinoContent.tsx` and `app/casino/slots/SlotsContent.tsx`.
- Source cites task row `[SWO_CASINO_TESTNET_OPEN_ACCESS]` and the testnet/mainnet chain-id ratio (10143/143 ≈ 70.93×).

## Acceptance
- (a) Gate logic updated — testnet bypass / mainnet enforce / wrong-chain → ChainGate.
- (b) Vitest covers all three branches in `components/casino/__tests__/CasinoAccessGate.test.tsx`:
  - (i) testnet bypass → no AccessGate, no ChainGate, children render
  - (ii) mainnet → AccessGate mounted with children inside
  - (iii) wrong chain (1, 137) → ChainGate "Switch to Monad mainnet" CTA, NO AccessGate
- (c) Source comment cites task row + testnet/mainnet chain-id ratio.

Task: `[SWO_CASINO_TESTNET_OPEN_ACCESS]` (PROJECT:SWO, P1, depends D11)

## Test plan
- [x] `npx vitest run --project casino` — 102/102 pass (8 new tests in CasinoAccessGate.test.tsx + all 94 prior casino tests still green)
- [x] `npx eslint` on new files — clean
- [x] `npm run type-check` — no new errors (pre-existing `game/scenes/*` errors unchanged)

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS (8.3s, cache cleared) — 0 errors with overlay
- **vitest run**: skipped in mirror (stale orphan vitest processes from prior agent runs blocking the runner; the local casino suite at `/home/agent/agents/star-world-order/workspace` ran clean — 102/102, including all 8 new tests).
- Mirror restored to byte-identical state.

Overall: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)