### PR TITLE
test(casino): regression guard for Star Skrumpey mascot swap

### DIFF
--- a/components/casino/__tests__/mascotSwap.test.ts
+++ b/components/casino/__tests__/mascotSwap.test.ts
@@ -1,0 +1,134 @@
+// Regression guard for [SWO_CASINO_MASCOT_SWAP] (PR #317).
+//
+// Locks in the three acceptance criteria so the Star Skrumpey dealer art
+// can't silently regress to upstream BunnyBagz rabbit imagery:
+//
+//   (a) BB rabbit asset filenames absent from casino routes / components /
+//       public assets — `bunny` and `rabbit` must not appear (case-insensitive)
+//       under app/casino, components/casino, or public/casino.
+//   (b) The Skrumpey dealer image set is present at the expected paths
+//       (idle / happy / excited) and is a non-empty PNG.
+//   (c) BetPanel and FairnessProof default their dealer art to the
+//       Skrumpey dealer image set, so every game page that consumes those
+//       components renders Skrumpey art without an explicit override.
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+import {
+  DEFAULT_DEALER_ART_SRC,
+} from '../BetPanel';
+import {
+  DEFAULT_FAIRNESS_DEALER_ART_SRC,
+} from '../FairnessProof';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
+
+const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+const DEALER_ASSETS = [
+  'public/casino/skrumpey-dealer-idle.png',
+  'public/casino/skrumpey-dealer-happy.png',
+  'public/casino/skrumpey-dealer-excited.png',
+];
+
+const SCAN_ROOTS = ['app/casino', 'components/casino', 'public/casino'];
+
+const TEXT_EXTENSIONS = new Set([
+  '.ts',
+  '.tsx',
+  '.js',
+  '.jsx',
+  '.mjs',
+  '.cjs',
+  '.json',
+  '.css',
+  '.scss',
+  '.md',
+  '.html',
+  '.svg',
+  '.yml',
+  '.yaml',
+]);
+
+// Self-reference tokens (case-insensitive) — used to keep this test file
+// itself out of the scan so the bare words below don't trip the guard.
+const SELF_FILE = path.resolve(__dirname, 'mascotSwap.test.ts');
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(full, out);
+    } else if (entry.isFile()) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe('[SWO_CASINO_MASCOT_SWAP] regression guard', () => {
+  it('default dealer art for BetPanel points at the Skrumpey idle sprite', () => {
+    expect(DEFAULT_DEALER_ART_SRC).toBe('/casino/skrumpey-dealer-idle.png');
+  });
+
+  it('default dealer art for FairnessProof points at the Skrumpey happy sprite', () => {
+    expect(DEFAULT_FAIRNESS_DEALER_ART_SRC).toBe(
+      '/casino/skrumpey-dealer-happy.png',
+    );
+  });
+
+  it.each(DEALER_ASSETS)(
+    'ships a non-empty PNG at %s',
+    (relPath) => {
+      const abs = path.join(REPO_ROOT, relPath);
+      const stats = statSync(abs);
+      expect(stats.isFile()).toBe(true);
+      expect(stats.size).toBeGreaterThan(0);
+      const head = readFileSync(abs).subarray(0, PNG_SIGNATURE.length);
+      expect(head.equals(PNG_SIGNATURE)).toBe(true);
+    },
+  );
+
+  it('contains no bunny / rabbit references under casino routes, components, or public assets', () => {
+    const offenders: Array<{ file: string; match: string }> = [];
+    const pattern = /bunny|rabbit/i;
+
+    for (const rel of SCAN_ROOTS) {
+      const root = path.join(REPO_ROOT, rel);
+      let files: string[];
+      try {
+        files = walk(root);
+      } catch {
+        // Missing scan root is fine — nothing to inspect there.
+        continue;
+      }
+
+      for (const file of files) {
+        if (path.resolve(file) === SELF_FILE) continue;
+        const ext = path.extname(file).toLowerCase();
+        if (!TEXT_EXTENSIONS.has(ext)) {
+          // For binaries (e.g. PNGs) the filename itself is the surface,
+          // so guard against renamed bb_rabbit.png-style assets.
+          const base = path.basename(file);
+          if (pattern.test(base)) {
+            offenders.push({ file, match: base });
+          }
+          continue;
+        }
+        const text = readFileSync(file, 'utf8');
+        const hit = text.match(pattern);
+        if (hit) {
+          offenders.push({ file, match: hit[0] });
+        }
+        const base = path.basename(file);
+        if (pattern.test(base)) {
+          offenders.push({ file, match: base });
+        }
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `components/casino/__tests__/mascotSwap.test.ts` — a Vitest regression guard that locks in the three acceptance criteria from `[SWO_CASINO_MASCOT_SWAP]` (the mascot swap itself landed in #317).
- No source/asset changes; the dealer art and component defaults are already in place on `dev`. This PR ensures the swap can't silently regress later (e.g. a future port re-introducing `bunny`/`rabbit` strings or a default sprite path drift).

## Context — Class B
The mascot swap was already shipped via #317 before this run began (HEAD == upstream/dev, no diff). Rather than re-do shipped work or ship nothing, this run adds the missing regression guard so the acceptance criteria are continuously verifiable in CI.

- **Original task**: `[SWO_CASINO_MASCOT_SWAP]` — replace BB rabbit refs in ported casino components/pages with Star Skrumpey dealer art reused from `public/sanctuary/companions/`; provide `public/casino/skrumpey-dealer-*.png` referenced from `BetPanel`/`FairnessProof`.
- **Already complete on `dev`**:
  - `public/casino/skrumpey-dealer-{idle,happy,excited}.png` — byte-identical copies of `public/sanctuary/companions/prime/{idle,happy,excited}.png` (no RD spend, IP reuse as specified).
  - `BetPanel.DEFAULT_DEALER_ART_SRC = '/casino/skrumpey-dealer-idle.png'`.
  - `FairnessProof.DEFAULT_FAIRNESS_DEALER_ART_SRC = '/casino/skrumpey-dealer-happy.png'`.
  - `app/casino/slots/SlotsContent.tsx` renders `skrumpey-dealer-excited.png`; dice and coinflip pages render dealer art via `BetPanel` + `FairnessProof` defaults.
  - `grep -ri 'bunny\|rabbit' app/casino components/casino public/casino` returns no hits.

## Guard contract
The new test asserts:

1. **No rabbit/bunny references** — recursively scans `app/casino`, `components/casino`, `public/casino` for `bunny`/`rabbit` (case-insensitive) in both source text AND binary filenames (so a renamed `bb_rabbit.png` wouldn't slip through). The test file itself is excluded from the scan.
2. **Dealer PNGs ship** — `public/casino/skrumpey-dealer-{idle,happy,excited}.png` exist, are non-empty, and start with the PNG signature.
3. **Component defaults are wired** — imports `DEFAULT_DEALER_ART_SRC` from `BetPanel` and `DEFAULT_FAIRNESS_DEALER_ART_SRC` from `FairnessProof` and asserts they point at the Skrumpey sprite paths.

## Validation
- `npx vitest run --project casino` — 108 tests pass (102 existing + 6 new). The 6 new tests:
  - `default dealer art for BetPanel points at the Skrumpey idle sprite` ✓
  - `default dealer art for FairnessProof points at the Skrumpey happy sprite` ✓
  - `ships a non-empty PNG at public/casino/skrumpey-dealer-{idle,happy,excited}.png` ✓ (×3)
  - `contains no bunny / rabbit references under casino routes, components, or public assets` ✓
- `npm run type-check` — 36 pre-existing errors in `game/v3/scenes/*` (unrelated to this change; same count before/after).
- `npx eslint components/casino/__tests__/mascotSwap.test.ts` — clean.

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS — 36 errors before overlay, 36 after (0 new; pre-existing in `game/v3/scenes/*`)
- **vitest run --project casino**: PASS — 15 tests / 2 files before overlay, 21 tests / 3 files after (+6 tests from this PR, all passing; 9 pre-existing unhandled errors unchanged)
- Mirror restored to byte-identical state after validation.
- Overall: **PASS**

## Test plan
- [x] New tests pass locally in the `casino` vitest project
- [x] Full casino suite stays green (108 / 108)
- [x] No new tsc errors introduced
- [x] PROD mirror baseline-diff: 0 new errors
- [ ] CI re-runs all checks on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)