### PR TITLE
feat(casino): useAllowlistGate hook + Coinflip/Dice UI gate

### DIFF
--- a/app/casino/coinflip/CoinflipContent.tsx
+++ b/app/casino/coinflip/CoinflipContent.tsx
@@ -27,6 +27,7 @@ import {
 import { parseEther, type Address, type Hex } from 'viem';
 
 import { getCasinoAddresses } from '@/lib/casino/addresses';
+import { useAllowlistGate } from '@/lib/casino/useAllowlistGate';
 
 import {
   CoinflipPanel,
@@ -111,6 +112,20 @@ export default function CoinflipContent() {
 
   const serverCommit = useMemo(() => resolveCommitFromEnv(), []);
 
+  // Pre-bet allowlist gate (see lib/casino/useAllowlistGate.ts). When the
+  // gate is `blocked` we render "Allowlist required" via `betError` and
+  // short-circuit `placeBet` so no signing prompt is triggered.
+  const gate = useAllowlistGate({
+    gameAddress: cosmicFlipAddress,
+    player: address,
+    chainId: activeChainId,
+    enabled: Boolean(cosmicFlipAddress && isConnected),
+  });
+  const allowlistBlocked = gate.status === 'blocked';
+  const effectiveBetError = allowlistBlocked
+    ? 'Allowlist required'
+    : betError;
+
   useWatchContractEvent({
     address: cosmicFlipAddress,
     abi: COSMIC_FLIP_ABI,
@@ -139,6 +154,10 @@ export default function CoinflipContent() {
 
   const placeBet = useCallback(() => {
     if (!cosmicFlipAddress) return;
+    // Allowlist gate: when the player is denied, do NOT call writeContract
+    // — the wallet must never surface a signing prompt for a bet that the
+    // contract will revert with `NotAllowed()`.
+    if (allowlistBlocked) return;
     setBetError(null);
     const commit = serverCommit ?? ZERO_BYTES32;
     if (commit === ZERO_BYTES32) {
@@ -162,6 +181,7 @@ export default function CoinflipContent() {
     });
   }, [
     cosmicFlipAddress,
+    allowlistBlocked,
     serverCommit,
     stake,
     side,
@@ -183,7 +203,7 @@ export default function CoinflipContent() {
       cosmicFlipAddress={cosmicFlipAddress}
       signing={signing}
       txHash={txHash ?? null}
-      betError={betError}
+      betError={effectiveBetError}
       writeError={writeError ?? null}
       onPlaceBet={placeBet}
       outcome={outcome}

--- a/app/casino/dice/DiceContent.tsx
+++ b/app/casino/dice/DiceContent.tsx
@@ -27,6 +27,7 @@ import {
 import { parseEther, type Address, type Hex } from 'viem';
 
 import { getCasinoAddresses } from '@/lib/casino/addresses';
+import { useAllowlistGate } from '@/lib/casino/useAllowlistGate';
 
 import {
   DicePanel,
@@ -110,6 +111,20 @@ export default function DiceContent() {
 
   const serverCommit = useMemo(() => resolveCommitFromEnv(), []);
 
+  // Pre-bet allowlist gate (see lib/casino/useAllowlistGate.ts). When the
+  // gate is `blocked` we render "Allowlist required" via `betError` and
+  // short-circuit `placeBet` so no signing prompt is triggered.
+  const gate = useAllowlistGate({
+    gameAddress: gravityDiceAddress,
+    player: address,
+    chainId: activeChainId,
+    enabled: Boolean(gravityDiceAddress && isConnected),
+  });
+  const allowlistBlocked = gate.status === 'blocked';
+  const effectiveBetError = allowlistBlocked
+    ? 'Allowlist required'
+    : betError;
+
   useWatchContractEvent({
     address: gravityDiceAddress,
     abi: GRAVITY_DICE_ABI,
@@ -138,6 +153,10 @@ export default function DiceContent() {
 
   const placeBet = useCallback(() => {
     if (!gravityDiceAddress) return;
+    // Allowlist gate: when the player is denied, do NOT call writeContract
+    // — the wallet must never surface a signing prompt for a bet that the
+    // contract will revert with `NotAllowed()`.
+    if (allowlistBlocked) return;
     setBetError(null);
     const commit = serverCommit ?? ZERO_BYTES32;
     if (commit === ZERO_BYTES32) {
@@ -161,6 +180,7 @@ export default function DiceContent() {
     });
   }, [
     gravityDiceAddress,
+    allowlistBlocked,
     serverCommit,
     stake,
     rollUnder,
@@ -182,7 +202,7 @@ export default function DiceContent() {
       gravityDiceAddress={gravityDiceAddress}
       signing={signing}
       txHash={txHash ?? null}
-      betError={betError}
+      betError={effectiveBetError}
       writeError={writeError ?? null}
       onPlaceBet={placeBet}
       outcome={outcome}

--- a/lib/casino/__tests__/useAllowlistGate.test.tsx
+++ b/lib/casino/__tests__/useAllowlistGate.test.tsx
@@ -1,0 +1,226 @@
+// @vitest-environment happy-dom
+//
+// useAllowlistGate — acceptance contract for [SWO_CASINO_ALLOWLIST_UI_GATE]:
+//
+//   (i)   No allowlist (game.allowlist() == 0x0)         → passthrough
+//   (ii)  Allowlist set but disabled (enabled == false)   → passthrough
+//   (iii) Allowlist enabled + denied (isAllowed == false) → blocked
+//   (iv)  Allowlist enabled + allowed (isAllowed == true) → passthrough
+//
+// We stub `wagmi.useReadContract` so each test can script the per-call
+// return value by `functionName`. This keeps the test independent of any
+// QueryClientProvider plumbing and matches the existing wagmi-stubbing
+// pattern in `components/casino/__tests__/CasinoAccessGate.test.tsx`.
+
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  vi,
+} from 'vitest';
+import { act, useEffect } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+type ReadContractCall = {
+  address?: `0x${string}`;
+  functionName?: string;
+  args?: readonly unknown[];
+  query?: { enabled?: boolean };
+};
+
+type Scripted = {
+  data?: unknown;
+  isLoading?: boolean;
+};
+
+const scriptedByFn: Record<string, Scripted> = {};
+
+vi.mock('wagmi', () => ({
+  useReadContract: vi.fn((opts: ReadContractCall) => {
+    const fn = opts.functionName ?? '';
+    const queryEnabled = opts.query?.enabled !== false;
+    const scripted: Scripted = scriptedByFn[fn] ?? {};
+    if (!queryEnabled) {
+      // Mirror wagmi's behaviour: disabled queries don't fetch and
+      // `data` stays undefined while `isLoading` is false.
+      return {
+        data: undefined,
+        isLoading: false,
+        isError: false,
+      } as const;
+    }
+    return {
+      data: scripted.data,
+      isLoading: scripted.isLoading ?? false,
+      isError: false,
+    } as const;
+  }),
+}));
+
+import {
+  useAllowlistGate,
+  ZERO_ADDRESS,
+  type AllowlistGateState,
+} from '../useAllowlistGate';
+
+(
+  globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const GAME = '0x064b8bfc03b23D2b525deD9d3969090347A21983' as const;
+const ALLOWLIST = '0x1111111111111111111111111111111111111111' as const;
+const PLAYER = '0x2222222222222222222222222222222222222222' as const;
+
+let container: HTMLDivElement;
+let root: Root;
+const sink: { value: AllowlistGateState | null } = { value: null };
+
+function Probe(props: {
+  gameAddress?: `0x${string}`;
+  player?: `0x${string}`;
+  chainId?: number;
+  enabled?: boolean;
+}) {
+  const state = useAllowlistGate(props);
+  // Mutating an external ref inside an effect is allowed under
+  // react-hooks/globals — the assignment lives off the render path.
+  useEffect(() => {
+    sink.value = state;
+  }, [state]);
+  return null;
+}
+
+function render(node: React.ReactElement) {
+  act(() => {
+    root.render(node);
+  });
+}
+
+function script(map: Record<string, Scripted>) {
+  for (const k of Object.keys(scriptedByFn)) delete scriptedByFn[k];
+  Object.assign(scriptedByFn, map);
+}
+
+beforeEach(() => {
+  sink.value = null;
+  for (const k of Object.keys(scriptedByFn)) delete scriptedByFn[k];
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+describe('useAllowlistGate — (i) no allowlist → passthrough', () => {
+  it('returns passthrough when game.allowlist() == ZERO_ADDRESS', () => {
+    script({
+      allowlist: { data: ZERO_ADDRESS },
+    });
+    render(<Probe gameAddress={GAME} player={PLAYER} chainId={10143} />);
+    expect(sink.value?.status).toBe('passthrough');
+    expect(sink.value?.reason).toBe('no-allowlist');
+    expect(sink.value?.allowlistAddress).toBeNull();
+  });
+
+  it('testnet posture: deployment with allowlist=0x0 → always passthrough', () => {
+    // Mirrors `contracts/casino/deployments/10143.json` — `allowlist`
+    // field is zero, so the on-chain `game.allowlist()` returns 0x0
+    // regardless of the deployment JSON's `allowlistEnabled` flag.
+    script({
+      allowlist: { data: ZERO_ADDRESS },
+      // These should NOT be consulted, but if they were they'd say
+      // "blocked" — proving the short-circuit holds.
+      allowlistEnabled: { data: true },
+      isAllowed: { data: false },
+    });
+    render(<Probe gameAddress={GAME} player={PLAYER} chainId={10143} />);
+    expect(sink.value?.status).toBe('passthrough');
+    expect(sink.value?.reason).toBe('no-allowlist');
+  });
+});
+
+describe('useAllowlistGate — (ii) allowlist disabled → passthrough', () => {
+  it('returns passthrough when allowlist.allowlistEnabled() == false', () => {
+    script({
+      allowlist: { data: ALLOWLIST },
+      allowlistEnabled: { data: false },
+      // isAllowed would block, but enabled=false must short-circuit.
+      isAllowed: { data: false },
+    });
+    render(<Probe gameAddress={GAME} player={PLAYER} chainId={143} />);
+    expect(sink.value?.status).toBe('passthrough');
+    expect(sink.value?.reason).toBe('disabled');
+    expect(sink.value?.allowlistAddress?.toLowerCase()).toBe(
+      ALLOWLIST.toLowerCase(),
+    );
+  });
+});
+
+describe('useAllowlistGate — (iii) enabled + denied → blocked', () => {
+  it('returns blocked when allowlist enabled and player not on list', () => {
+    script({
+      allowlist: { data: ALLOWLIST },
+      allowlistEnabled: { data: true },
+      isAllowed: { data: false },
+    });
+    render(<Probe gameAddress={GAME} player={PLAYER} chainId={143} />);
+    expect(sink.value?.status).toBe('blocked');
+    expect(sink.value?.reason).toBe('denied');
+    expect(sink.value?.allowlistAddress?.toLowerCase()).toBe(
+      ALLOWLIST.toLowerCase(),
+    );
+  });
+});
+
+describe('useAllowlistGate — (iv) enabled + allowed → passthrough', () => {
+  it('returns passthrough when allowlist enabled and player allowed', () => {
+    script({
+      allowlist: { data: ALLOWLIST },
+      allowlistEnabled: { data: true },
+      isAllowed: { data: true },
+    });
+    render(<Probe gameAddress={GAME} player={PLAYER} chainId={143} />);
+    expect(sink.value?.status).toBe('passthrough');
+    expect(sink.value?.reason).toBe('allowed');
+    expect(sink.value?.allowlistAddress?.toLowerCase()).toBe(
+      ALLOWLIST.toLowerCase(),
+    );
+  });
+});
+
+describe('useAllowlistGate — loading + disabled-hook semantics', () => {
+  it('returns loading while game.allowlist() is unresolved', () => {
+    script({
+      allowlist: { isLoading: true, data: undefined },
+    });
+    render(<Probe gameAddress={GAME} player={PLAYER} chainId={143} />);
+    expect(sink.value?.status).toBe('loading');
+  });
+
+  it('returns passthrough when the hook is explicitly disabled', () => {
+    // No scripted reads — `enabled:false` must short-circuit BEFORE any
+    // chain read happens.
+    render(
+      <Probe
+        gameAddress={GAME}
+        player={PLAYER}
+        chainId={143}
+        enabled={false}
+      />,
+    );
+    expect(sink.value?.status).toBe('passthrough');
+    expect(sink.value?.reason).toBe('no-allowlist');
+  });
+
+  it('returns loading when the game address is undefined', () => {
+    render(<Probe player={PLAYER} chainId={143} />);
+    expect(sink.value?.status).toBe('loading');
+  });
+});

--- a/lib/casino/useAllowlistGate.ts
+++ b/lib/casino/useAllowlistGate.ts
@@ -1,0 +1,234 @@
+// useAllowlistGate — chain-aware pre-bet access check for [SWO_CASINO_ALLOWLIST_UI_GATE].
+//
+// Before submitting a bet, each game UI calls this hook once with the active
+// game contract address + the connected wallet address. The hook does three
+// on-chain reads:
+//
+//   1. `game.allowlist()` → resolves the soft-launch allowlist contract.
+//       When this is the zero address the game has no allowlist set
+//       (current testnet posture) and the gate short-circuits to
+//       `passthrough`.
+//   2. `allowlist.allowlistEnabled()` → owner-flippable kill-switch on
+//       the allowlist itself. When `false` (post-soft-launch steady
+//       state) the gate is `passthrough`.
+//   3. `allowlist.isAllowed(player)` → per-address access flag. Only
+//       consulted when (1) is non-zero AND (2) is true. `true` →
+//       passthrough; `false` → blocked.
+//
+// When the gate is `blocked`, the UI MUST render an "Allowlist required"
+// banner instead of triggering `useWriteContract`/`signMessage`. The
+// rationale is twofold: (a) the on-chain `placeBet` would revert with
+// `NotAllowed()` anyway, wasting the user's gas estimation round-trip;
+// (b) surfacing the block pre-sign avoids a confusing MetaMask prompt
+// that a non-allowlisted player has no way to satisfy.
+
+'use client';
+
+import { useReadContract } from 'wagmi';
+import type { Abi, Address } from 'viem';
+
+/** Sentinel returned by `game.allowlist()` when the game has no allowlist set. */
+export const ZERO_ADDRESS: Address =
+  '0x0000000000000000000000000000000000000000';
+
+/**
+ * Minimal allowlist ABI fragment. We re-declare only the two read methods
+ * the hook calls — pulling the full artefact would balloon the client
+ * bundle and the surface here is intentionally narrow.
+ */
+export const ALLOWLIST_READ_ABI = [
+  {
+    type: 'function',
+    name: 'allowlistEnabled',
+    stateMutability: 'view',
+    inputs: [],
+    outputs: [{ name: '', type: 'bool' }],
+  },
+  {
+    type: 'function',
+    name: 'isAllowed',
+    stateMutability: 'view',
+    inputs: [{ name: '', type: 'address' }],
+    outputs: [{ name: '', type: 'bool' }],
+  },
+] as const satisfies Abi;
+
+/**
+ * Subset of a game-contract ABI required by `useAllowlistGate` — every game
+ * (CosmicFlip, GravityDice, ConstellationClimb) exposes the public storage
+ * getter `allowlist() returns (address)` via Solidity's auto-generated
+ * accessor.
+ */
+export const GAME_ALLOWLIST_READ_ABI = [
+  {
+    type: 'function',
+    name: 'allowlist',
+    stateMutability: 'view',
+    inputs: [],
+    outputs: [{ name: '', type: 'address' }],
+  },
+] as const satisfies Abi;
+
+export type AllowlistGateStatus = 'loading' | 'passthrough' | 'blocked';
+
+export type AllowlistGateReason =
+  | 'loading'
+  | 'no-allowlist'
+  | 'disabled'
+  | 'allowed'
+  | 'denied';
+
+export interface AllowlistGateState {
+  status: AllowlistGateStatus;
+  /**
+   * Resolved on-chain allowlist contract address. `null` when the game has
+   * no allowlist set (gate (1)) or the resolve is still pending.
+   */
+  allowlistAddress: Address | null;
+  /** Human-readable reason — useful for telemetry & test assertions. */
+  reason: AllowlistGateReason;
+}
+
+export interface UseAllowlistGateOptions {
+  /** Address of the live game contract (CosmicFlip / GravityDice / etc). */
+  gameAddress?: Address;
+  /** Connected wallet address — when undefined the gate stays `loading`. */
+  player?: Address;
+  /** Active chain id; forwarded to wagmi reads to pin the network. */
+  chainId?: number;
+  /**
+   * When `false`, the hook skips all reads and returns `passthrough` so
+   * callers can disable the gate during e.g. SSR or when the wallet is
+   * disconnected. Defaults to `true`.
+   */
+  enabled?: boolean;
+}
+
+/**
+ * Pre-bet allowlist access check. See file header for the staged read
+ * pipeline and the acceptance criteria for
+ * [SWO_CASINO_ALLOWLIST_UI_GATE].
+ */
+export function useAllowlistGate(
+  opts: UseAllowlistGateOptions,
+): AllowlistGateState {
+  const { gameAddress, player, chainId, enabled = true } = opts;
+
+  const baseEnabled = enabled && Boolean(gameAddress);
+
+  const allowlistRead = useReadContract({
+    address: gameAddress,
+    abi: GAME_ALLOWLIST_READ_ABI,
+    functionName: 'allowlist',
+    chainId,
+    query: { enabled: baseEnabled },
+  });
+
+  const resolvedAllowlist =
+    (allowlistRead.data as Address | undefined) ?? undefined;
+  const hasAllowlist =
+    Boolean(resolvedAllowlist) &&
+    (resolvedAllowlist as string).toLowerCase() !==
+      ZERO_ADDRESS.toLowerCase();
+
+  const enabledRead = useReadContract({
+    address: hasAllowlist ? (resolvedAllowlist as Address) : undefined,
+    abi: ALLOWLIST_READ_ABI,
+    functionName: 'allowlistEnabled',
+    chainId,
+    query: { enabled: baseEnabled && hasAllowlist },
+  });
+
+  const allowlistOn = enabledRead.data === true;
+
+  const allowedRead = useReadContract({
+    address: hasAllowlist ? (resolvedAllowlist as Address) : undefined,
+    abi: ALLOWLIST_READ_ABI,
+    functionName: 'isAllowed',
+    args: player ? [player] : undefined,
+    chainId,
+    query: {
+      enabled:
+        baseEnabled && hasAllowlist && allowlistOn && Boolean(player),
+    },
+  });
+
+  if (!enabled) {
+    return {
+      status: 'passthrough',
+      allowlistAddress: null,
+      reason: 'no-allowlist',
+    };
+  }
+
+  if (!gameAddress) {
+    return {
+      status: 'loading',
+      allowlistAddress: null,
+      reason: 'loading',
+    };
+  }
+
+  if (allowlistRead.isLoading || allowlistRead.data === undefined) {
+    return {
+      status: 'loading',
+      allowlistAddress: null,
+      reason: 'loading',
+    };
+  }
+
+  if (!hasAllowlist) {
+    return {
+      status: 'passthrough',
+      allowlistAddress: null,
+      reason: 'no-allowlist',
+    };
+  }
+
+  if (enabledRead.isLoading || enabledRead.data === undefined) {
+    return {
+      status: 'loading',
+      allowlistAddress: resolvedAllowlist as Address,
+      reason: 'loading',
+    };
+  }
+
+  if (!allowlistOn) {
+    return {
+      status: 'passthrough',
+      allowlistAddress: resolvedAllowlist as Address,
+      reason: 'disabled',
+    };
+  }
+
+  if (!player) {
+    // Allowlist is on but we don't know who the player is. Stay loading —
+    // the UI surface is typically already in a "Connect wallet" state and
+    // the gate decision happens once the wallet is wired up.
+    return {
+      status: 'loading',
+      allowlistAddress: resolvedAllowlist as Address,
+      reason: 'loading',
+    };
+  }
+
+  if (allowedRead.isLoading || allowedRead.data === undefined) {
+    return {
+      status: 'loading',
+      allowlistAddress: resolvedAllowlist as Address,
+      reason: 'loading',
+    };
+  }
+
+  return allowedRead.data === true
+    ? {
+        status: 'passthrough',
+        allowlistAddress: resolvedAllowlist as Address,
+        reason: 'allowed',
+      }
+    : {
+        status: 'blocked',
+        allowlistAddress: resolvedAllowlist as Address,
+        reason: 'denied',
+      };
+}


### PR DESCRIPTION
## Summary
- New `useAllowlistGate` hook in `lib/casino/` reads `game.allowlist()` once; if non-zero, reads `allowlistEnabled()` and `isAllowed(player)`. Returns `{ status, allowlistAddress, reason }`.
- Wired into `CoinflipContent` and `DiceContent`: when the gate is `blocked`, `useWriteContract` is never called and the panel renders **\"Allowlist required\"** via the existing `betError` surface — no signing prompt.
- Testnet posture (`game.allowlist() == 0x0`) → always passthrough, so QA on Monad testnet (10143) is unaffected.

Implements [SWO_CASINO_ALLOWLIST_UI_GATE]. Coinflip + Dice covered now; HiLo to follow when D10 lands.

## Test plan
- Vitest covers the four required cases:
  - [x] (i) no allowlist → passthrough
  - [x] (ii) allowlist disabled → passthrough
  - [x] (iii) allowlist enabled + denied → blocked
  - [x] (iv) allowlist enabled + allowed → passthrough
- Plus loading + disabled-hook semantics + testnet posture (5 extra cases).
- \`npm run test\` → **908 passed (50 files)**.
- \`npx eslint\` on changed files → **clean**.
- \`npm run type-check\` → only pre-existing errors in \`game/scenes/\` and \`game/v3/scenes/\` (unrelated).

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS (36 pre-existing errors excluded — same set before/after overlay)
- **vitest run --project casino**: PASS — 15 pre-existing tests still pass; one **pre-existing** \"Cannot find package 'happy-dom'\" error class adds one more instance because the new test file also declares \`@vitest-environment happy-dom\` (same pattern as all 9 existing PROD failures of this class). No new test failures.
- Overall: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)