### PR TITLE
feat(casino): disable bet CTA when allowlist gate blocks

### DIFF
--- a/app/casino/coinflip/CoinflipContent.tsx
+++ b/app/casino/coinflip/CoinflipContent.tsx
@@ -205,6 +205,7 @@ export default function CoinflipContent() {
       txHash={txHash ?? null}
       betError={effectiveBetError}
       writeError={writeError ?? null}
+      allowlistBlocked={allowlistBlocked}
       onPlaceBet={placeBet}
       outcome={outcome}
       serverReveal={serverReveal}

--- a/app/casino/coinflip/CoinflipPanel.tsx
+++ b/app/casino/coinflip/CoinflipPanel.tsx
@@ -51,6 +51,13 @@ export interface CoinflipPanelProps {
   /** Bet-flow error surfaces. */
   betError: string | null;
   writeError: Error | null;
+  /**
+   * Allowlist gate decision lifted from the container. When `true`, the
+   * primary CTA renders as disabled "Allowlist required" so the user
+   * cannot trigger a wallet signing prompt for a bet the contract would
+   * revert. See lib/casino/useAllowlistGate.ts.
+   */
+  allowlistBlocked?: boolean;
   /** placeBet handler — pure callback from the container. */
   onPlaceBet: () => void;
   /** Settled outcome state. */
@@ -87,6 +94,7 @@ export function CoinflipPanel(props: CoinflipPanelProps) {
     txHash,
     betError,
     writeError,
+    allowlistBlocked,
     onPlaceBet,
     outcome,
     serverReveal,
@@ -102,7 +110,11 @@ export function CoinflipPanel(props: CoinflipPanelProps) {
   const onWrongChain = isConnected && !onSupportedChain;
 
   const canFlip =
-    isConnected && !onWrongChain && Boolean(cosmicFlipAddress) && !signing;
+    isConnected &&
+    !onWrongChain &&
+    Boolean(cosmicFlipAddress) &&
+    !signing &&
+    !allowlistBlocked;
 
   let cta: BetPanelCta;
   if (!isConnected) {
@@ -121,6 +133,12 @@ export function CoinflipPanel(props: CoinflipPanelProps) {
     };
   } else if (signing) {
     cta = { label: 'Confirm in wallet…', onClick: () => {}, disabled: true };
+  } else if (allowlistBlocked) {
+    cta = {
+      label: 'Allowlist required',
+      onClick: () => {},
+      disabled: true,
+    };
   } else {
     cta = {
       label: `Flip for ${stake} MON`,

--- a/app/casino/coinflip/__tests__/CoinflipPanel.test.tsx
+++ b/app/casino/coinflip/__tests__/CoinflipPanel.test.tsx
@@ -171,6 +171,18 @@ describe('CoinflipPanel — synchronous contract', () => {
     expect(cta.textContent).toMatch(/Confirm in wallet/);
   });
 
+  it('disables CTA with "Allowlist required" label when allowlistBlocked', () => {
+    const onPlaceBet = vi.fn();
+    render({ allowlistBlocked: true, onPlaceBet });
+    const cta = get('coinflip-primary-cta') as HTMLButtonElement;
+    expect(cta.disabled).toBe(true);
+    expect(cta.textContent).toMatch(/Allowlist required/);
+    act(() => {
+      cta.click();
+    });
+    expect(onPlaceBet).not.toHaveBeenCalled();
+  });
+
   it('renders the Won banner when outcome is "won"', () => {
     render({ outcome: 'won', stake: '0.05', side: 'heads' });
     const won = get('coinflip-outcome-won');

--- a/app/casino/dice/DiceContent.tsx
+++ b/app/casino/dice/DiceContent.tsx
@@ -204,6 +204,7 @@ export default function DiceContent() {
       txHash={txHash ?? null}
       betError={effectiveBetError}
       writeError={writeError ?? null}
+      allowlistBlocked={allowlistBlocked}
       onPlaceBet={placeBet}
       outcome={outcome}
       serverReveal={serverReveal}

--- a/app/casino/dice/DicePanel.tsx
+++ b/app/casino/dice/DicePanel.tsx
@@ -59,6 +59,13 @@ export interface DicePanelProps {
   /** Bet-flow error surfaces. */
   betError: string | null;
   writeError: Error | null;
+  /**
+   * Allowlist gate decision lifted from the container. When `true`, the
+   * primary CTA renders as disabled "Allowlist required" so the user
+   * cannot trigger a wallet signing prompt for a bet the contract would
+   * revert. See lib/casino/useAllowlistGate.ts.
+   */
+  allowlistBlocked?: boolean;
   /** placeBet handler — pure callback from the container. */
   onPlaceBet: () => void;
   /** Settled outcome state. */
@@ -139,6 +146,7 @@ export function DicePanel(props: DicePanelProps) {
     txHash,
     betError,
     writeError,
+    allowlistBlocked,
     onPlaceBet,
     outcome,
     serverReveal,
@@ -155,7 +163,11 @@ export function DicePanel(props: DicePanelProps) {
   const multLabel = fmtMultiplier(mult);
 
   const canRoll =
-    isConnected && !onWrongChain && Boolean(gravityDiceAddress) && !signing;
+    isConnected &&
+    !onWrongChain &&
+    Boolean(gravityDiceAddress) &&
+    !signing &&
+    !allowlistBlocked;
 
   let cta: BetPanelCta;
   if (!isConnected) {
@@ -174,6 +186,12 @@ export function DicePanel(props: DicePanelProps) {
     };
   } else if (signing) {
     cta = { label: 'Confirm in wallet…', onClick: () => {}, disabled: true };
+  } else if (allowlistBlocked) {
+    cta = {
+      label: 'Allowlist required',
+      onClick: () => {},
+      disabled: true,
+    };
   } else {
     cta = {
       label: `Roll for ${stake} MON`,

--- a/app/casino/dice/__tests__/DicePanel.test.tsx
+++ b/app/casino/dice/__tests__/DicePanel.test.tsx
@@ -273,6 +273,18 @@ describe('DicePanel — synchronous render contract', () => {
     expect(cta.textContent).toMatch(/Confirm in wallet/);
   });
 
+  it('disables CTA with "Allowlist required" label when allowlistBlocked', () => {
+    const onPlaceBet = vi.fn();
+    render({ allowlistBlocked: true, onPlaceBet });
+    const cta = get('dice-primary-cta') as HTMLButtonElement;
+    expect(cta.disabled).toBe(true);
+    expect(cta.textContent).toMatch(/Allowlist required/);
+    act(() => {
+      cta.click();
+    });
+    expect(onPlaceBet).not.toHaveBeenCalled();
+  });
+
   it('renders the Won banner when outcome is "won"', () => {
     render({ outcome: 'won', stake: '0.05', rollUnder: 50 });
     const won = get('dice-outcome-won');


### PR DESCRIPTION
## Summary
- When `useAllowlistGate` returns `'blocked'`, the Coinflip and Dice primary CTA now renders as **disabled** with the label `Allowlist required` instead of the live `Flip for X MON` / `Roll for X MON`.
- The container already short-circuited `writeContract` on a blocked gate (PR #319), but the bet button stayed interactive and silently no-oped on click. This change makes the *no signing prompt* intent visible: the user sees the same disabled-CTA pattern already used for `signing` and `!cosmicFlipAddress`.
- `canFlip` / `canRoll` now factor in `allowlistBlocked` too, so Enter-key submission on the panel is gated identically.

## Why this is in scope for [SWO_CASINO_ALLOWLIST_UI_GATE]
The acceptance criteria from PR #319 ("render 'Allowlist required' with no signing prompt") are satisfied at the container layer, but the panel CTA was the one surface that didn't visually reflect the block. Closing that small UX gap matches the task's stated intent.

## Test plan
- [x] `useAllowlistGate` unit tests (8 tests, all still green)
- [x] `CoinflipPanel.test.tsx` — new test: disabled CTA + `Allowlist required` label when `allowlistBlocked`, click does not fire `onPlaceBet`
- [x] `DicePanel.test.tsx` — same new test for dice
- [x] Full casino vitest suite: 118 tests passing (was 116 + 2 new)
- [x] `npx eslint` clean on changed files
- [x] `npm run type-check` — same 36 pre-existing errors before/after change (all in `game/*` scenes, unrelated)

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS (baseline 36 errors in `game/scenes/*`, `game/v3/scenes/*`; same 36 after overlay — 0 new errors; required overlay of `lib/casino/useAllowlistGate.ts` since PROD is behind PR #319)
- **vitest run --project casino**: pending in mirror (PROD bench is slow); local run is 118/118 passing
Overall: PASS (no new tsc errors introduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)