### PR TITLE
feat(casino): useAccessGate hook — chainId-aware testnet-open gate

### DIFF
--- a/lib/casino/__tests__/useAccessGate.test.tsx
+++ b/lib/casino/__tests__/useAccessGate.test.tsx
@@ -1,0 +1,228 @@
+// @vitest-environment happy-dom
+//
+// useAccessGate — acceptance contract for [SWO_CASINO_TESTNET_OPEN_ACCESS]
+// (PROJECT:SWO, P0). The decision matrix:
+//
+//   chainId        holder snapshot              expected reason / allowed
+//   ─────────────  ───────────────────────────  ─────────────────────────
+//   10143          (irrelevant — never read)    testnet-open      / true
+//   143            { isLoading: true }          mainnet-loading   / false
+//   143            disconnected                 mainnet-disconnected / false
+//   143            connected, !hasAccess        mainnet-no-holder / false
+//   143            connected, hasAccess         mainnet-holder    / true
+//   1, 137, undef  (irrelevant)                 wrong-chain       / false
+//
+// The hook reads `DAOAccessContext` via `useContext` (NOT the throwing
+// `useDAOAccess` wrapper) so testnet pages can bypass the gate without
+// mounting `DAOAccessProvider`. Tests inject the holder snapshot via the
+// `holderOverride` prop so we don't need to stand up the full provider
+// surface.
+
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+} from 'vitest';
+import { act, useEffect } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import {
+  useAccessGate,
+  MONAD_MAINNET_CHAIN_ID,
+  MONAD_TESTNET_CHAIN_ID,
+  type AccessGateState,
+  type HolderSnapshot,
+} from '../useAccessGate';
+
+(
+  globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+const sink: { value: AccessGateState | null } = { value: null };
+
+function Probe(props: {
+  chainId: number;
+  holderOverride?: HolderSnapshot;
+}) {
+  const state = useAccessGate(props);
+  useEffect(() => {
+    sink.value = state;
+  }, [state]);
+  return null;
+}
+
+function render(node: React.ReactElement) {
+  act(() => {
+    root.render(node);
+  });
+}
+
+beforeEach(() => {
+  sink.value = null;
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+describe('useAccessGate — Monad testnet bypass (10143)', () => {
+  it('returns { allowed: true, reason: "testnet-open" } on chain 10143', () => {
+    render(<Probe chainId={MONAD_TESTNET_CHAIN_ID} />);
+    expect(sink.value?.allowed).toBe(true);
+    expect(sink.value?.reason).toBe('testnet-open');
+    expect(sink.value?.copy).toMatch(/testnet/i);
+  });
+
+  it('bypass ignores the holder snapshot entirely on testnet', () => {
+    // Even an explicit "no holder, disconnected" holder snapshot must
+    // NOT down-rank the testnet bypass — that is the whole point of
+    // [SWO_CASINO_TESTNET_OPEN_ACCESS]: QA can play without a wallet
+    // that holds a Star Skrumpey.
+    render(
+      <Probe
+        chainId={MONAD_TESTNET_CHAIN_ID}
+        holderOverride={{
+          hasAccess: false,
+          isLoading: false,
+          isConnected: false,
+        }}
+      />,
+    );
+    expect(sink.value?.allowed).toBe(true);
+    expect(sink.value?.reason).toBe('testnet-open');
+  });
+
+  it('bypass works without a DAOAccessProvider mounted', () => {
+    // `<Probe>` is mounted directly into the body, NOT wrapped in
+    // `<DAOAccessProvider>`. The hook must still resolve cleanly for
+    // testnet — i.e. `useContext(DAOAccessContext)` returning undefined
+    // is fine on the testnet branch (the holder snapshot is never
+    // consulted there).
+    render(<Probe chainId={MONAD_TESTNET_CHAIN_ID} />);
+    expect(sink.value?.allowed).toBe(true);
+    expect(sink.value?.reason).toBe('testnet-open');
+  });
+});
+
+describe('useAccessGate — Monad mainnet enforcement (143)', () => {
+  it('gates on holder check: connected + hasAccess → allowed', () => {
+    render(
+      <Probe
+        chainId={MONAD_MAINNET_CHAIN_ID}
+        holderOverride={{
+          hasAccess: true,
+          isLoading: false,
+          isConnected: true,
+        }}
+      />,
+    );
+    expect(sink.value?.allowed).toBe(true);
+    expect(sink.value?.reason).toBe('mainnet-holder');
+  });
+
+  it('gates on holder check: connected, !hasAccess → blocked (no-holder)', () => {
+    render(
+      <Probe
+        chainId={MONAD_MAINNET_CHAIN_ID}
+        holderOverride={{
+          hasAccess: false,
+          isLoading: false,
+          isConnected: true,
+        }}
+      />,
+    );
+    expect(sink.value?.allowed).toBe(false);
+    expect(sink.value?.reason).toBe('mainnet-no-holder');
+    expect(sink.value?.copy).toMatch(/Star Skrumpey/);
+  });
+
+  it('disconnected → blocked with mainnet-disconnected reason', () => {
+    render(
+      <Probe
+        chainId={MONAD_MAINNET_CHAIN_ID}
+        holderOverride={{
+          hasAccess: false,
+          isLoading: false,
+          isConnected: false,
+        }}
+      />,
+    );
+    expect(sink.value?.allowed).toBe(false);
+    expect(sink.value?.reason).toBe('mainnet-disconnected');
+    expect(sink.value?.copy).toMatch(/Connect a wallet/i);
+  });
+
+  it('isLoading → blocked with mainnet-loading reason', () => {
+    render(
+      <Probe
+        chainId={MONAD_MAINNET_CHAIN_ID}
+        holderOverride={{
+          hasAccess: false,
+          isLoading: true,
+          isConnected: true,
+        }}
+      />,
+    );
+    expect(sink.value?.allowed).toBe(false);
+    expect(sink.value?.reason).toBe('mainnet-loading');
+  });
+
+  it('mainnet without provider AND without override → loading (safe)', () => {
+    // No DAOAccessProvider mounted, no holderOverride passed. The hook
+    // should default to a "loading" state rather than locking the user
+    // out — this is the right behaviour for the mount-transition window
+    // before the provider has wired up.
+    render(<Probe chainId={MONAD_MAINNET_CHAIN_ID} />);
+    expect(sink.value?.allowed).toBe(false);
+    expect(sink.value?.reason).toBe('mainnet-loading');
+  });
+});
+
+describe('useAccessGate — wrong chain (anything outside {143, 10143})', () => {
+  it('Ethereum mainnet (1) → blocked with wrong-chain + explanatory copy', () => {
+    render(<Probe chainId={1} />);
+    expect(sink.value?.allowed).toBe(false);
+    expect(sink.value?.reason).toBe('wrong-chain');
+    expect(sink.value?.copy).toMatch(/Monad mainnet/);
+  });
+
+  it('Polygon (137) → wrong-chain', () => {
+    render(<Probe chainId={137} />);
+    expect(sink.value?.allowed).toBe(false);
+    expect(sink.value?.reason).toBe('wrong-chain');
+  });
+
+  it('unknown chain id (0) → wrong-chain', () => {
+    render(<Probe chainId={0} />);
+    expect(sink.value?.allowed).toBe(false);
+    expect(sink.value?.reason).toBe('wrong-chain');
+  });
+
+  it('wrong chain does NOT consult holder snapshot', () => {
+    // Even a fully-valid holder snapshot must NOT flip the gate to
+    // allowed on the wrong chain — the user has to pick the right
+    // network first.
+    render(
+      <Probe
+        chainId={1}
+        holderOverride={{
+          hasAccess: true,
+          isLoading: false,
+          isConnected: true,
+        }}
+      />,
+    );
+    expect(sink.value?.allowed).toBe(false);
+    expect(sink.value?.reason).toBe('wrong-chain');
+  });
+});

--- a/lib/casino/useAccessGate.ts
+++ b/lib/casino/useAccessGate.ts
@@ -1,0 +1,177 @@
+// useAccessGate — chain-aware access decision for the SWO Cosmic Casino.
+//
+// Acceptance contract for [SWO_CASINO_TESTNET_OPEN_ACCESS] (PROJECT:SWO, P0):
+//
+//   chainId === 10143 (Monad testnet)
+//       → { allowed: true, reason: 'testnet-open', copy: ... }
+//       The Skrumpey ownership requirement is BYPASSED so QA + operator
+//       smoke flows can place bets without a holder wallet. We do NOT
+//       consult the holder snapshot on this branch — even an outright
+//       error from `useDAOAccess` must not down-rank a testnet caller.
+//
+//   chainId === 143 (Monad mainnet)
+//       → branches on the holder snapshot (`useDAOAccess` by default,
+//         injectable via `holderOverride` for unit tests):
+//           - isLoading        → { allowed:false, reason:'mainnet-loading'    }
+//           - !isConnected     → { allowed:false, reason:'mainnet-disconnected' }
+//           - !hasAccess       → { allowed:false, reason:'mainnet-no-holder'  }
+//           - hasAccess        → { allowed:true,  reason:'mainnet-holder'    }
+//
+//   anything else (Ethereum mainnet 1, Polygon 137, undefined, …)
+//       → { allowed: false, reason: 'wrong-chain', copy: ... }
+//
+// The hook is pure with respect to its inputs: identical
+// `{ chainId, holderOverride }` always produces the same state, so the
+// upstream `CasinoAccessGate` wrapper can rely on referential stability
+// of the `reason` discriminator for testid / data-attribute wiring.
+//
+// `holderOverride` is a test hook so unit tests can drive the mainnet
+// branch without standing up `DAOAccessProvider` + `WagmiProvider`.
+// Production callers should leave it undefined; the hook then reads
+// `DAOAccessContext` via a context-safe variant that does not throw
+// when the provider is absent (testnet pages that bypass the gate
+// entirely should not be forced to mount the holder context).
+
+'use client';
+
+import { useContext } from 'react';
+import { DAOAccessContext } from '@/lib/contexts/DAOAccessContext';
+
+export const MONAD_MAINNET_CHAIN_ID = 143;
+export const MONAD_TESTNET_CHAIN_ID = 10143;
+
+export type AccessGateReason =
+  | 'testnet-open'
+  | 'mainnet-holder'
+  | 'mainnet-no-holder'
+  | 'mainnet-disconnected'
+  | 'mainnet-loading'
+  | 'wrong-chain';
+
+export interface AccessGateState {
+  /** Final decision: should protected children render? */
+  allowed: boolean;
+  /** Discriminator — useful for telemetry, data-attrs, and test assertions. */
+  reason: AccessGateReason;
+  /** Human-readable explanatory copy for the locked / loading screen. */
+  copy: string;
+}
+
+/**
+ * Minimal slice of `DAOAccessContext` the gate cares about. The mainnet
+ * branch only needs three booleans; full token lists / refresh handles
+ * stay out of this surface so tests can inject a tiny literal.
+ */
+export interface HolderSnapshot {
+  hasAccess: boolean;
+  isLoading: boolean;
+  isConnected: boolean;
+}
+
+export interface UseAccessGateOptions {
+  /** Active EVM chain id (e.g. from `wagmi.useChainId()`). */
+  chainId: number;
+  /**
+   * Test-only injection. When set, the hook uses this snapshot for the
+   * mainnet branch INSTEAD of reading `DAOAccessContext`. Production
+   * callers should leave this undefined.
+   */
+  holderOverride?: HolderSnapshot;
+}
+
+const COPY_TESTNET_OPEN =
+  'Testnet open access — Skrumpey ownership is not required on Monad testnet.';
+const COPY_MAINNET_LOADING = 'Verifying Star Skrumpey ownership…';
+const COPY_MAINNET_DISCONNECTED =
+  'Connect a wallet that holds a Star Skrumpey to enter the Cosmic Casino.';
+const COPY_MAINNET_NO_HOLDER =
+  'Only Star Skrumpey holders may enter the Cosmic Casino.';
+const COPY_MAINNET_HOLDER = 'Star Skrumpey detected — welcome to the casino.';
+const COPY_WRONG_CHAIN =
+  'Wrong network — switch to Monad mainnet to access the casino.';
+
+/**
+ * Chain-aware access decision. See file header for the per-branch
+ * contract and the rationale behind the testnet bypass.
+ */
+export function useAccessGate(
+  opts: UseAccessGateOptions,
+): AccessGateState {
+  const { chainId, holderOverride } = opts;
+
+  // Read context UNCONDITIONALLY to satisfy the rules of hooks. We use
+  // `useContext` directly (not the throwing `useDAOAccess` wrapper) so
+  // callers that bypass the gate entirely — e.g. testnet smoke pages —
+  // are not forced to mount `DAOAccessProvider`.
+  const daoCtx = useContext(DAOAccessContext);
+
+  // (1) Testnet bypass — short-circuit BEFORE consulting any holder
+  // signal. The bypass must hold even if the holder check is broken.
+  if (chainId === MONAD_TESTNET_CHAIN_ID) {
+    return {
+      allowed: true,
+      reason: 'testnet-open',
+      copy: COPY_TESTNET_OPEN,
+    };
+  }
+
+  // (2) Mainnet — branch on the holder snapshot.
+  if (chainId === MONAD_MAINNET_CHAIN_ID) {
+    const holder: HolderSnapshot | undefined =
+      holderOverride ??
+      (daoCtx
+        ? {
+            hasAccess: daoCtx.hasAccess,
+            isLoading: daoCtx.isLoading,
+            isConnected: daoCtx.isConnected,
+          }
+        : undefined);
+
+    if (!holder) {
+      // No provider AND no override — treat as still resolving so the
+      // caller renders the loading state instead of locking the user
+      // out. This is the safest behaviour for mid-mount transitions.
+      return {
+        allowed: false,
+        reason: 'mainnet-loading',
+        copy: COPY_MAINNET_LOADING,
+      };
+    }
+
+    if (holder.isLoading) {
+      return {
+        allowed: false,
+        reason: 'mainnet-loading',
+        copy: COPY_MAINNET_LOADING,
+      };
+    }
+    if (!holder.isConnected) {
+      return {
+        allowed: false,
+        reason: 'mainnet-disconnected',
+        copy: COPY_MAINNET_DISCONNECTED,
+      };
+    }
+    if (!holder.hasAccess) {
+      return {
+        allowed: false,
+        reason: 'mainnet-no-holder',
+        copy: COPY_MAINNET_NO_HOLDER,
+      };
+    }
+    return {
+      allowed: true,
+      reason: 'mainnet-holder',
+      copy: COPY_MAINNET_HOLDER,
+    };
+  }
+
+  // (3) Any other chain — wrong network. We deliberately do NOT
+  // consult the holder snapshot here: the user has to pick the right
+  // network before a holder check can mean anything.
+  return {
+    allowed: false,
+    reason: 'wrong-chain',
+    copy: COPY_WRONG_CHAIN,
+  };
+}


### PR DESCRIPTION
## Summary

Adds `useAccessGate({ chainId })`, the hook surface specified in the [SWO_CASINO_TESTNET_OPEN_ACCESS] acceptance criteria. Complements the existing `CasinoAccessGate` component (PR #316) so callers can read the access decision as a single `{ allowed, reason, copy }` state object instead of re-implementing the chain branch.

- `chainId === 10143` → `{ allowed: true, reason: 'testnet-open' }` — Skrumpey holder check **bypassed** for QA + operator smoke flows. The holder snapshot is never consulted on this branch.
- `chainId === 143` → branches on the holder snapshot read from `DAOAccessContext`: `loading` / `disconnected` / `no-holder` / `holder` reasons.
- any other chain → `{ allowed: false, reason: 'wrong-chain', copy: 'Switch to Monad mainnet …' }`.

The hook reads `DAOAccessContext` via `useContext` (not the throwing `useDAOAccess` wrapper) so testnet pages bypassing the gate don't have to mount the holder context. The mainnet branch accepts an optional `holderOverride` test injection so unit tests can drive the decision matrix without a provider.

## Acceptance criteria coverage

| Criterion | Where |
| --- | --- |
| (a) `useAccessGate({ chainId })` → `{ allowed: true, reason: 'testnet-open' }` on chain 10143 | `lib/casino/useAccessGate.ts` |
| (b) Vitest: 10143 passthrough, 143 holder check, unknown chain blocked + copy | `lib/casino/__tests__/useAccessGate.test.tsx` (12 cases) |
| (c) Playwright bypass on `/casino/*` | Existing CasinoAccessGate wrapper (PR #316) — the new hook is decision-only |
| (d) Page renders without holder wallet on chain 10143 | CasinoAccessGate continues to short-circuit children on 10143 (PR #316) |

## Test plan

- [x] `npx vitest run --project casino` — 14 files, **128 passed** (incl. 12 new useAccessGate cases)
- [x] `npx eslint lib/casino/useAccessGate.ts lib/casino/__tests__/useAccessGate.test.tsx` — clean
- [x] `npm run type-check` — only pre-existing `game/v3/scenes/WorldSceneV3.ts` errors (confirmed identical on `git stash`)
- [ ] Smoke `/casino/*` on Monad testnet (10143) — gate bypasses without holder wallet

## Mirror Validation (PROD)

- **tsc --noEmit**: PASS — baseline 36 errors, post-overlay 36 errors, **zero new** errors (`diff` empty).
- **vitest run --project casino**: PRE-EXISTING — `happy-dom` missing in `/opt/star_world_order/PROD/node_modules` causes ALL `@vitest-environment happy-dom` files to fail at module-resolution time (confirmed against the unchanged `components/casino/__tests__/CasinoAccessGate.test.tsx`). Not introduced by this PR.

Overall: **PASS** (no new errors vs. baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)