### PR TITLE
feat(casino): port Ponder indexer to services/casino-indexer (Monad testnet 10143)

### DIFF
--- a/lib/casino/__tests__/recentBetsIndexer.test.ts
+++ b/lib/casino/__tests__/recentBetsIndexer.test.ts
@@ -1,0 +1,167 @@
+// Coverage for the Ponder GraphQL client that feeds `RecentBets`.
+//
+// Verifies: (1) fetchRecentBets unions across the three game tables and
+// emits newest-first; (2) mapRecentBetsToWallet adapts to the WalletBet
+// shape `components/casino/RecentBets` already renders.
+
+import { describe, expect, test, vi } from 'vitest';
+
+import {
+  fetchRecentBets,
+  mapRecentBetsToWallet,
+  type IndexerRecentBetRow,
+} from '@/lib/casino/recentBetsIndexer';
+
+const ALICE = '0x000000000000000000000000000000000000a11c';
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('fetchRecentBets', () => {
+  test('unions the three game tables newest-first', async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse({
+        data: {
+          bets: {
+            items: [
+              {
+                id: '1',
+                player: ALICE,
+                status: 'won',
+                stake: '1000',
+                payout: '2000',
+                blockPlaced: '100',
+                settledAt: '101',
+              },
+            ],
+          },
+          diceBets: {
+            items: [
+              {
+                id: '2',
+                player: ALICE,
+                status: 'lost',
+                stake: '1000',
+                payout: '0',
+                blockPlaced: '200',
+                settledAt: '201',
+              },
+            ],
+          },
+          hiloSessions: {
+            items: [
+              {
+                id: '3',
+                player: ALICE,
+                status: 'cashed',
+                stake: '1000',
+                payout: '3500',
+                blockOpened: '300',
+                settledAt: '301',
+              },
+            ],
+          },
+        },
+      }),
+    );
+
+    const rows = await fetchRecentBets({
+      endpoint: 'https://indexer.example/graphql',
+      player: ALICE,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(rows.map((r) => r.game)).toEqual(['hilo', 'dice', 'coinflip']);
+    expect(rows[0].id).toBe('3');
+    expect(rows[0].blockPlaced).toBe('300');
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const call = fetchImpl.mock.calls[0] as unknown as
+      | [string, RequestInit]
+      | undefined;
+    const init = call?.[1];
+    expect(init?.method).toBe('POST');
+    expect(JSON.parse(String(init?.body))).toMatchObject({
+      variables: { player: ALICE, limit: 24 },
+    });
+  });
+
+  test('surfaces non-OK responses as a thrown error', async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response('boom', { status: 502, statusText: 'Bad Gateway' }),
+    );
+    await expect(
+      fetchRecentBets({
+        endpoint: 'https://indexer.example/graphql',
+        player: ALICE,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      }),
+    ).rejects.toThrow(/502/);
+  });
+
+  test('surfaces GraphQL errors', async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse({ errors: [{ message: 'no such field' }] }),
+    );
+    await expect(
+      fetchRecentBets({
+        endpoint: 'https://indexer.example/graphql',
+        player: ALICE,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      }),
+    ).rejects.toThrow(/no such field/);
+  });
+});
+
+describe('mapRecentBetsToWallet', () => {
+  test('adapts indexer rows into the WalletBet shape', () => {
+    const rows: IndexerRecentBetRow[] = [
+      {
+        game: 'coinflip',
+        id: '7',
+        player: ALICE,
+        status: 'won',
+        stake: '1000000000000000',
+        payout: '1960000000000000',
+        blockPlaced: '120',
+        settledAt: '121',
+        txHash: '0xabc',
+      },
+      {
+        game: 'hilo',
+        id: '3',
+        player: ALICE,
+        status: 'cashed',
+        stake: '1',
+        payout: '5',
+        blockPlaced: '300',
+        settledAt: '301',
+      },
+    ];
+    const wallet = mapRecentBetsToWallet(rows);
+    expect(wallet).toEqual([
+      {
+        game: 'coinflip',
+        betId: '7',
+        stakeWei: '1000000000000000',
+        payoutWei: '1960000000000000',
+        outcome: 'won',
+        blockNumber: '120',
+        txHash: '0xabc',
+      },
+      {
+        game: 'hilo',
+        betId: '3',
+        stakeWei: '1',
+        payoutWei: '5',
+        outcome: 'cashed',
+        blockNumber: '300',
+        txHash: null,
+      },
+    ]);
+  });
+});

--- a/lib/casino/recentBetsIndexer.ts
+++ b/lib/casino/recentBetsIndexer.ts
@@ -1,0 +1,181 @@
+// GraphQL client adapter that connects the SWO casino-indexer Ponder
+// endpoint to the `RecentBets` wallet-sheet component.
+//
+// Two responsibilities:
+//
+//   1. `fetchRecentBets(endpoint, player, limit, fetchImpl?)` — POST a small
+//      GraphQL query to the indexer's `/graphql` endpoint, unioning bets
+//      across the three game tables (`bets`, `diceBets`, `hiloSessions`).
+//      The fetch impl is injectable so tests can drive without network.
+//
+//   2. `mapRecentBetsToWallet(rows)` — adapter that turns the cross-game
+//      indexer rows into the `WalletBet` shape `components/casino/RecentBets`
+//      already consumes (game, betId, stakeWei, payoutWei, outcome,
+//      blockNumber, txHash). The component then renders verify links + an
+//      explorer link without knowing anything about the indexer.
+
+import type { WalletBet, WalletGame } from '@/components/casino/RecentBets';
+
+/** Mirrors `services/casino-indexer/src/recent-bets.ts#RecentBet`. */
+export interface IndexerRecentBetRow {
+  game: WalletGame;
+  id: string;
+  player: string;
+  status: string;
+  stake: string;
+  payout: string | null;
+  blockPlaced: string;
+  settledAt: string | null;
+  txHash?: string | null;
+}
+
+export interface FetchRecentBetsOptions {
+  endpoint: string;
+  player: string;
+  limit?: number;
+  fetchImpl?: typeof fetch;
+  signal?: AbortSignal;
+}
+
+const RECENT_BETS_QUERY = `
+  query RecentBets($player: String!, $limit: Int!) {
+    bets(
+      where: { player: $player, status_in: ["won", "lost", "refunded"] }
+      orderBy: "blockPlaced"
+      orderDirection: "desc"
+      limit: $limit
+    ) {
+      items {
+        id
+        player
+        status
+        stake
+        payout
+        blockPlaced
+        settledAt
+      }
+    }
+    diceBets(
+      where: { player: $player, status_in: ["won", "lost", "refunded"] }
+      orderBy: "blockPlaced"
+      orderDirection: "desc"
+      limit: $limit
+    ) {
+      items {
+        id
+        player
+        status
+        stake
+        payout
+        blockPlaced
+        settledAt
+      }
+    }
+    hiloSessions(
+      where: { player: $player, status_in: ["cashed", "lost", "refunded", "pushed"] }
+      orderBy: "blockOpened"
+      orderDirection: "desc"
+      limit: $limit
+    ) {
+      items {
+        id
+        player
+        status
+        stake
+        payout
+        blockOpened
+        settledAt
+      }
+    }
+  }
+`.trim();
+
+interface GraphQLEnvelope {
+  data?: {
+    bets?: { items?: Array<Omit<IndexerRecentBetRow, 'game'>> };
+    diceBets?: { items?: Array<Omit<IndexerRecentBetRow, 'game'>> };
+    hiloSessions?: {
+      items?: Array<
+        Omit<IndexerRecentBetRow, 'game' | 'blockPlaced'> & {
+          blockOpened: string;
+        }
+      >;
+    };
+  };
+  errors?: Array<{ message: string }>;
+}
+
+function compareNewestFirst(
+  a: IndexerRecentBetRow,
+  b: IndexerRecentBetRow,
+): number {
+  const aBlk = BigInt(a.blockPlaced);
+  const bBlk = BigInt(b.blockPlaced);
+  if (aBlk !== bBlk) return aBlk > bBlk ? -1 : 1;
+  try {
+    const aId = BigInt(a.id);
+    const bId = BigInt(b.id);
+    return aId > bId ? -1 : aId < bId ? 1 : 0;
+  } catch {
+    return a.id < b.id ? 1 : a.id > b.id ? -1 : 0;
+  }
+}
+
+export async function fetchRecentBets(
+  opts: FetchRecentBetsOptions,
+): Promise<IndexerRecentBetRow[]> {
+  const { endpoint, player, limit = 24, fetchImpl, signal } = opts;
+  const f = fetchImpl ?? (globalThis.fetch as typeof fetch | undefined);
+  if (!f) throw new Error('fetchRecentBets: no fetch implementation available');
+
+  const res = await f(endpoint, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      query: RECENT_BETS_QUERY,
+      variables: { player: player.toLowerCase(), limit },
+    }),
+    signal,
+  });
+  if (!res.ok) {
+    throw new Error(`indexer returned ${res.status} ${res.statusText}`);
+  }
+  const json = (await res.json()) as GraphQLEnvelope;
+  if (json.errors && json.errors.length > 0) {
+    throw new Error(json.errors.map((e) => e.message).join('; '));
+  }
+  const data = json.data ?? {};
+  const merged: IndexerRecentBetRow[] = [];
+
+  for (const r of data.bets?.items ?? []) {
+    merged.push({ ...r, game: 'coinflip' });
+  }
+  for (const r of data.diceBets?.items ?? []) {
+    merged.push({ ...r, game: 'dice' });
+  }
+  for (const r of data.hiloSessions?.items ?? []) {
+    const { blockOpened, ...rest } = r;
+    merged.push({ ...rest, game: 'hilo', blockPlaced: blockOpened });
+  }
+
+  merged.sort(compareNewestFirst);
+  return merged.slice(0, limit);
+}
+
+/**
+ * Adapt indexer rows into the `WalletBet` shape that
+ * `components/casino/RecentBets` already renders.
+ */
+export function mapRecentBetsToWallet(
+  rows: IndexerRecentBetRow[],
+): WalletBet[] {
+  return rows.map((r) => ({
+    game: r.game,
+    betId: r.id,
+    stakeWei: r.stake,
+    payoutWei: r.payout,
+    outcome: r.status,
+    blockNumber: r.blockPlaced,
+    txHash: r.txHash ?? null,
+  }));
+}

--- a/services/casino-indexer/README.md
+++ b/services/casino-indexer/README.md
@@ -1,0 +1,74 @@
+# `@swo/casino-indexer`
+
+Ponder indexer for the Star World Order (SWO) Cosmic Casino contracts on
+**Monad testnet** (chainId `10143`).
+
+Ported from `mega-house/apps/indexer` and retargeted from MegaETH testnet to
+Monad testnet. Handlers, stores, and the cross-game aggregator are pure
+TypeScript so vitest can drive them without a live RPC or Ponder install.
+
+## Layout
+
+| Path               | Purpose                                                                    |
+| ------------------ | -------------------------------------------------------------------------- |
+| `ponder.config.ts` | Network + contracts config. Reads chain id / RPC / addresses from env.     |
+| `schema.graphql`   | Ponder entity schema (`Bet`, `DiceBet`, `HiLoSession`, `HiLoStep`).        |
+| `abis/`            | Hand-curated event ABIs for the three indexed contracts.                   |
+| `src/`             | Pure handlers + in-memory stores + Ponder context adapter (`index.ts`).    |
+| `__tests__/`       | Vitest coverage for each game's handlers + cross-game aggregation + config. |
+
+## Indexed contracts (events)
+
+- **CasinoCoinflip** — `BetPlaced`, `BetSettled`, `BetRefunded`
+- **CasinoDice** — `BetPlaced`, `BetSettled`, `BetRefunded`
+- **CasinoHiLo** — `SessionOpened`, `StepPlayed`, `SessionCashedOut`,
+  `SessionRefunded`, `SessionPushed`
+
+A fourth contract (slots) is a planned follow-up — slots placement is still
+out-of-protocol, so its handler set will land alongside the on-chain slots
+contract.
+
+## Environment
+
+```
+# Required for ponder dev on a non-default RPC
+SWO_INDEXER_RPC_URL=https://testnet-rpc.monad.xyz     # or MONAD_TESTNET_RPC_URL
+SWO_CHAIN_ID=10143                                     # default; override for anvil fork
+
+# Deployed addresses — fall through to BUNNYBAGZ_* legacy aliases.
+SWO_COINFLIP_ADDRESS=0x...
+SWO_DICE_ADDRESS=0x...
+SWO_HILO_ADDRESS=0x...
+
+# Optional — speed up reindex on a fresh DB.
+SWO_INDEXER_FROM_BLOCK=0
+```
+
+## Commands
+
+```sh
+# Run the indexer locally (requires `ponder` installed in this workspace).
+npm run dev --workspace=@swo/casino-indexer
+
+# Pure-handler vitest coverage — no RPC required.
+npx vitest run services/casino-indexer/__tests__
+```
+
+## Hosting
+
+Operator picks one of:
+
+- **Ponder Cloud** — point `ponder.config.ts` at the deployed addresses, set
+  the Monad testnet RPC, push.
+- **Goldsky** — wrap the same handlers behind a Goldsky subgraph.
+- **Self-host** — run `ponder start` on a Vercel cron / Fly machine.
+
+The handlers are runtime-agnostic; only `ponder.config.ts` + the runtime
+adapter in `src/index.ts` know about Ponder specifically.
+
+## GraphQL consumers
+
+The `RecentBets` component in `components/casino/RecentBets.tsx` is the
+canonical consumer for the per-wallet ticker; the client adapter in
+`lib/casino/recentBetsIndexer.ts` queries the Ponder GraphQL endpoint and
+maps `RecentBet` rows into the `WalletBet` shape `RecentBets` accepts.

--- a/services/casino-indexer/__tests__/dice-handlers.test.ts
+++ b/services/casino-indexer/__tests__/dice-handlers.test.ts
@@ -1,0 +1,109 @@
+// Coverage for the CasinoDice event handlers.
+// Mirrors handlers.test.ts but uses the rollUnder/roll shape.
+
+import { describe, expect, test } from 'vitest';
+
+import { inMemoryDiceBetStore } from '../src/dice-store';
+import {
+  onDiceBetPlaced,
+  onDiceBetSettled,
+  onDiceBetRefunded,
+} from '../src/dice-handlers';
+
+const ALICE = '0x000000000000000000000000000000000000a11c' as const;
+const SEED = ('0x' + 'ab'.repeat(32)) as `0x${string}`;
+const COMMIT = ('0x' + '11'.repeat(32)) as `0x${string}`;
+const REVEAL = ('0x' + 'ce'.repeat(32)) as `0x${string}`;
+
+describe('CasinoDice handlers', () => {
+  test('BetPlaced creates a pending row with rollUnder + null roll', async () => {
+    const store = inMemoryDiceBetStore();
+    await onDiceBetPlaced(
+      store,
+      {
+        betId: 7n,
+        player: ALICE,
+        rollUnder: 49,
+        stake: 1_000_000_000_000_000n,
+        clientSeed: SEED,
+        serverCommit: COMMIT,
+        nonce: 3n,
+        blockPlaced: 300n,
+      },
+      { blockNumber: 300n },
+    );
+    const row = await store.get('7');
+    expect(row?.status).toBe('pending');
+    expect(row?.rollUnder).toBe(49);
+    expect(row?.roll).toBeNull();
+    expect(row?.payout).toBeNull();
+    expect(row?.serverReveal).toBeNull();
+    expect(row?.settledAt).toBeNull();
+    expect(row?.stake).toBe('1000000000000000');
+  });
+
+  test('BetSettled fills in the rolled face + payout + settledAt', async () => {
+    const store = inMemoryDiceBetStore();
+    await onDiceBetPlaced(
+      store,
+      {
+        betId: 1n,
+        player: ALICE,
+        rollUnder: 50,
+        stake: 2n,
+        clientSeed: SEED,
+        serverCommit: COMMIT,
+        nonce: 0n,
+        blockPlaced: 10n,
+      },
+      { blockNumber: 10n },
+    );
+    await onDiceBetSettled(
+      store,
+      {
+        betId: 1n,
+        player: ALICE,
+        rollUnder: 50,
+        roll: 17,
+        won: true,
+        payout: 3_960_000_000_000_000n,
+        serverReveal: REVEAL,
+      },
+      { blockNumber: 12n },
+    );
+    const row = await store.get('1');
+    expect(row?.status).toBe('won');
+    expect(row?.roll).toBe(17);
+    expect(row?.payout).toBe('3960000000000000');
+    expect(row?.serverReveal).toBe(REVEAL);
+    expect(row?.settledAt).toBe('12');
+  });
+
+  test('BetRefunded leaves roll null and sets refunded status', async () => {
+    const store = inMemoryDiceBetStore();
+    await onDiceBetPlaced(
+      store,
+      {
+        betId: 99n,
+        player: ALICE,
+        rollUnder: 50,
+        stake: 5n,
+        clientSeed: SEED,
+        serverCommit: COMMIT,
+        nonce: 0n,
+        blockPlaced: 20n,
+      },
+      { blockNumber: 20n },
+    );
+    await onDiceBetRefunded(
+      store,
+      { betId: 99n, player: ALICE, stake: 5n },
+      { blockNumber: 555n },
+    );
+    const row = await store.get('99');
+    expect(row?.status).toBe('refunded');
+    expect(row?.roll).toBeNull();
+    expect(row?.payout).toBe('0');
+    expect(row?.settledAt).toBe('555');
+  });
+});

--- a/services/casino-indexer/__tests__/handlers.test.ts
+++ b/services/casino-indexer/__tests__/handlers.test.ts
@@ -1,0 +1,141 @@
+// Coverage for the CasinoCoinflip event handlers.
+//
+// Drives the in-memory mock RPC fixture through the runtime-agnostic
+// handlers (src/handlers.ts) and asserts the resulting `bets` rows. This
+// is the test that backs the "writes ≥1 bets row" acceptance criterion —
+// `npx vitest run services/casino-indexer` exercises it without needing
+// Ponder + a real RPC.
+
+import { describe, expect, test } from 'vitest';
+
+import { inMemoryBetStore } from '../src/bet-store';
+import {
+  bootstrapWithFixture,
+  buildMockRpcFixture,
+} from '../src/index';
+import {
+  onBetPlaced,
+  onBetSettled,
+  onBetRefunded,
+} from '../src/handlers';
+
+const ALICE = '0x000000000000000000000000000000000000a11c' as const;
+const SEED = ('0x' + 'ab'.repeat(32)) as `0x${string}`;
+const COMMIT = ('0x' + '11'.repeat(32)) as `0x${string}`;
+const REVEAL = ('0x' + 'ce'.repeat(32)) as `0x${string}`;
+
+describe('CasinoCoinflip handlers', () => {
+  test('fixture writes ≥1 bets row (acceptance: dev --once)', async () => {
+    const { store } = await bootstrapWithFixture();
+    const total = await store.count();
+    expect(total).toBeGreaterThanOrEqual(1);
+    expect(total).toBe(3);
+  });
+
+  test('BetPlaced creates a pending row with the correct shape', async () => {
+    const store = inMemoryBetStore();
+    await onBetPlaced(
+      store,
+      {
+        betId: 42n,
+        player: ALICE,
+        side: 0,
+        stake: 1_000_000_000_000_000n,
+        clientSeed: SEED,
+        serverCommit: COMMIT,
+        nonce: 7n,
+        blockPlaced: 200n,
+      },
+      { blockNumber: 200n },
+    );
+    const row = await store.get('42');
+    expect(row).not.toBeNull();
+    expect(row?.status).toBe('pending');
+    expect(row?.side).toBe('heads');
+    expect(row?.outcome).toBeNull();
+    expect(row?.payout).toBeNull();
+    expect(row?.serverReveal).toBeNull();
+    expect(row?.settledAt).toBeNull();
+    expect(row?.player).toBe(ALICE);
+    expect(row?.stake).toBe('1000000000000000');
+    expect(row?.nonce).toBe('7');
+    expect(row?.blockPlaced).toBe('200');
+  });
+
+  test('BetSettled upgrades the row with rolled outcome + payout + settledAt', async () => {
+    const store = inMemoryBetStore();
+    await onBetPlaced(
+      store,
+      {
+        betId: 1n,
+        player: ALICE,
+        side: 0,
+        stake: 1n,
+        clientSeed: SEED,
+        serverCommit: COMMIT,
+        nonce: 0n,
+        blockPlaced: 100n,
+      },
+      { blockNumber: 100n },
+    );
+    await onBetSettled(
+      store,
+      {
+        betId: 1n,
+        player: ALICE,
+        outcome: 1,
+        won: false,
+        payout: 0n,
+        serverReveal: REVEAL,
+      },
+      { blockNumber: 105n },
+    );
+    const row = await store.get('1');
+    expect(row?.status).toBe('lost');
+    expect(row?.outcome).toBe('tails');
+    expect(row?.payout).toBe('0');
+    expect(row?.serverReveal).toBe(REVEAL);
+    expect(row?.settledAt).toBe('105');
+  });
+
+  test('BetRefunded marks the row refunded with settledAt = refund block', async () => {
+    const store = inMemoryBetStore();
+    await onBetPlaced(
+      store,
+      {
+        betId: 9n,
+        player: ALICE,
+        side: 1,
+        stake: 1n,
+        clientSeed: SEED,
+        serverCommit: COMMIT,
+        nonce: 0n,
+        blockPlaced: 50n,
+      },
+      { blockNumber: 50n },
+    );
+    await onBetRefunded(
+      store,
+      { betId: 9n, player: ALICE, stake: 1n },
+      { blockNumber: 9999n },
+    );
+    const row = await store.get('9');
+    expect(row?.status).toBe('refunded');
+    expect(row?.payout).toBe('0');
+    expect(row?.outcome).toBeNull();
+    expect(row?.settledAt).toBe('9999');
+  });
+
+  test('fixture deterministically replays in event order', () => {
+    const fixture = buildMockRpcFixture();
+    const kinds = fixture.events.map((e) => e.kind);
+    expect(kinds).toEqual([
+      'BetPlaced',
+      'BetSettled',
+      'BetPlaced',
+      'BetSettled',
+      'BetPlaced',
+      'BetRefunded',
+    ]);
+  });
+});

--- a/services/casino-indexer/__tests__/hilo-handlers.test.ts
+++ b/services/casino-indexer/__tests__/hilo-handlers.test.ts
@@ -1,0 +1,260 @@
+// Coverage for the CasinoHiLo event handlers.
+// Exercises the session lifecycle: opened → step → step → cashed.
+// Also covers refunded, pushed, and bust-on-step.
+
+import { describe, expect, test } from 'vitest';
+
+import {
+  inMemoryHiLoSessionStore,
+  inMemoryHiLoStepStore,
+} from '../src/hilo-store';
+import {
+  onHiLoSessionOpened,
+  onHiLoStepPlayed,
+  onHiLoSessionCashed,
+  onHiLoSessionRefunded,
+  onHiLoSessionPushed,
+} from '../src/hilo-handlers';
+
+const ALICE = '0x000000000000000000000000000000000000a11c' as const;
+const SEED = ('0x' + 'ab'.repeat(32)) as `0x${string}`;
+const COMMIT = ('0x' + '11'.repeat(32)) as `0x${string}`;
+const NEXT_COMMIT = ('0x' + '22'.repeat(32)) as `0x${string}`;
+const REVEAL = ('0x' + 'ce'.repeat(32)) as `0x${string}`;
+
+const ONE_E18 = 1_000_000_000_000_000_000n;
+
+describe('CasinoHiLo handlers', () => {
+  test('SessionOpened creates an open session at 1.0x', async () => {
+    const sessions = inMemoryHiLoSessionStore();
+    await onHiLoSessionOpened(
+      sessions,
+      {
+        sessionId: 1n,
+        player: ALICE,
+        stake: 1_000_000_000_000_000n,
+        clientSeed: SEED,
+        serverCommit: COMMIT,
+        initialCard: 7,
+        nonce: 0n,
+        blockOpened: 100n,
+      },
+      { blockNumber: 100n },
+    );
+    const row = await sessions.get('1');
+    expect(row?.status).toBe('open');
+    expect(row?.initialCard).toBe(7);
+    expect(row?.currentCard).toBe(7);
+    expect(row?.multiplier).toBe(ONE_E18.toString());
+    expect(row?.finalMultiplier).toBeNull();
+    expect(row?.payout).toBeNull();
+    expect(row?.stepCount).toBe(0);
+    expect(row?.settledAt).toBeNull();
+  });
+
+  test('StepPlayed (won) advances multiplier + nextCommit + stepCount', async () => {
+    const sessions = inMemoryHiLoSessionStore();
+    const steps = inMemoryHiLoStepStore();
+    await onHiLoSessionOpened(
+      sessions,
+      {
+        sessionId: 1n,
+        player: ALICE,
+        stake: 1n,
+        clientSeed: SEED,
+        serverCommit: COMMIT,
+        initialCard: 7,
+        nonce: 0n,
+        blockOpened: 100n,
+      },
+      { blockNumber: 100n },
+    );
+    const newMultiplier = 1_500_000_000_000_000_000n;
+    await onHiLoStepPlayed(
+      sessions,
+      steps,
+      {
+        sessionId: 1n,
+        player: ALICE,
+        direction: 'higher',
+        prevCard: 7,
+        newCard: 10,
+        won: true,
+        newMultiplier,
+        serverReveal: REVEAL,
+        nextCommit: NEXT_COMMIT,
+      },
+      { blockNumber: 101n },
+    );
+    const session = await sessions.get('1');
+    expect(session?.status).toBe('open');
+    expect(session?.currentCard).toBe(10);
+    expect(session?.multiplier).toBe(newMultiplier.toString());
+    expect(session?.stepCount).toBe(1);
+    expect(session?.serverCommit).toBe(NEXT_COMMIT);
+
+    const stepRows = await steps.findBySession('1');
+    expect(stepRows.length).toBe(1);
+    expect(stepRows[0].id).toBe('1-0');
+    expect(stepRows[0].direction).toBe('higher');
+    expect(stepRows[0].won).toBe(true);
+    expect(stepRows[0].newMultiplier).toBe(newMultiplier.toString());
+  });
+
+  test('StepPlayed (lost) busts the session — status flips to lost', async () => {
+    const sessions = inMemoryHiLoSessionStore();
+    const steps = inMemoryHiLoStepStore();
+    await onHiLoSessionOpened(
+      sessions,
+      {
+        sessionId: 2n,
+        player: ALICE,
+        stake: 1n,
+        clientSeed: SEED,
+        serverCommit: COMMIT,
+        initialCard: 5,
+        nonce: 0n,
+        blockOpened: 200n,
+      },
+      { blockNumber: 200n },
+    );
+    await onHiLoStepPlayed(
+      sessions,
+      steps,
+      {
+        sessionId: 2n,
+        player: ALICE,
+        direction: 'lower',
+        prevCard: 5,
+        newCard: 9,
+        won: false,
+        newMultiplier: 0n,
+        serverReveal: REVEAL,
+        nextCommit: NEXT_COMMIT,
+      },
+      { blockNumber: 201n },
+    );
+    const session = await sessions.get('2');
+    expect(session?.status).toBe('lost');
+    expect(session?.currentCard).toBe(9);
+    expect(session?.finalMultiplier).toBe('0');
+    expect(session?.settledAt).toBe('201');
+  });
+
+  test('StepPlayed before SessionOpened throws', async () => {
+    const sessions = inMemoryHiLoSessionStore();
+    const steps = inMemoryHiLoStepStore();
+    await expect(
+      onHiLoStepPlayed(
+        sessions,
+        steps,
+        {
+          sessionId: 99n,
+          player: ALICE,
+          direction: 'higher',
+          prevCard: 7,
+          newCard: 10,
+          won: true,
+          newMultiplier: ONE_E18,
+          serverReveal: REVEAL,
+          nextCommit: NEXT_COMMIT,
+        },
+        { blockNumber: 300n },
+      ),
+    ).rejects.toThrow(/hilo step before session opened/);
+  });
+
+  test('SessionCashedOut sets cashed status + payout + finalMultiplier', async () => {
+    const sessions = inMemoryHiLoSessionStore();
+    await onHiLoSessionOpened(
+      sessions,
+      {
+        sessionId: 3n,
+        player: ALICE,
+        stake: 100n,
+        clientSeed: SEED,
+        serverCommit: COMMIT,
+        initialCard: 7,
+        nonce: 0n,
+        blockOpened: 100n,
+      },
+      { blockNumber: 100n },
+    );
+    await onHiLoSessionCashed(
+      sessions,
+      {
+        sessionId: 3n,
+        player: ALICE,
+        payout: 250n,
+        finalMultiplier: 2_500_000_000_000_000_000n,
+      },
+      { blockNumber: 150n },
+    );
+    const session = await sessions.get('3');
+    expect(session?.status).toBe('cashed');
+    expect(session?.payout).toBe('250');
+    expect(session?.finalMultiplier).toBe('2500000000000000000');
+    expect(session?.settledAt).toBe('150');
+  });
+
+  test('SessionRefunded pays the stake back', async () => {
+    const sessions = inMemoryHiLoSessionStore();
+    await onHiLoSessionOpened(
+      sessions,
+      {
+        sessionId: 4n,
+        player: ALICE,
+        stake: 77n,
+        clientSeed: SEED,
+        serverCommit: COMMIT,
+        initialCard: 7,
+        nonce: 0n,
+        blockOpened: 100n,
+      },
+      { blockNumber: 100n },
+    );
+    await onHiLoSessionRefunded(
+      sessions,
+      { sessionId: 4n, player: ALICE, stake: 77n },
+      { blockNumber: 9999n },
+    );
+    const session = await sessions.get('4');
+    expect(session?.status).toBe('refunded');
+    expect(session?.payout).toBe('77');
+    expect(session?.settledAt).toBe('9999');
+  });
+
+  test('SessionPushed sets pushed status with captured multiplier', async () => {
+    const sessions = inMemoryHiLoSessionStore();
+    await onHiLoSessionOpened(
+      sessions,
+      {
+        sessionId: 5n,
+        player: ALICE,
+        stake: 50n,
+        clientSeed: SEED,
+        serverCommit: COMMIT,
+        initialCard: 7,
+        nonce: 0n,
+        blockOpened: 100n,
+      },
+      { blockNumber: 100n },
+    );
+    await onHiLoSessionPushed(
+      sessions,
+      {
+        sessionId: 5n,
+        player: ALICE,
+        stake: 50n,
+        card: 7,
+        multiplier: 1_750_000_000_000_000_000n,
+      },
+      { blockNumber: 175n },
+    );
+    const session = await sessions.get('5');
+    expect(session?.status).toBe('pushed');
+    expect(session?.payout).toBe('50');
+    expect(session?.finalMultiplier).toBe('1750000000000000000');
+    expect(session?.settledAt).toBe('175');
+  });
+});

--- a/services/casino-indexer/__tests__/ponder-config.test.ts
+++ b/services/casino-indexer/__tests__/ponder-config.test.ts
@@ -1,0 +1,63 @@
+// Smoke tests for ponder.config.ts — pins the Monad testnet retarget.
+//
+// Acceptance bullet (b) requires `ponder dev` to index against Monad
+// testnet (chainId 10143). These tests pin the chain id + RPC defaults so
+// a regression that quietly retargets the indexer fails CI.
+
+import { describe, expect, test } from 'vitest';
+
+import indexerConfig, {
+  MONAD_TESTNET_CHAIN_ID,
+  MONAD_TESTNET_DEFAULT_RPC,
+  resolveChainId,
+  resolveRpcUrl,
+  resolveStartBlock,
+} from '../ponder.config';
+
+describe('ponder.config (Monad testnet retarget)', () => {
+  test('Monad testnet chain id is 10143', () => {
+    expect(MONAD_TESTNET_CHAIN_ID).toBe(10143);
+  });
+
+  test('default chain id falls through to Monad testnet', () => {
+    expect(resolveChainId({})).toBe(10143);
+  });
+
+  test('SWO_CHAIN_ID env override wins', () => {
+    expect(resolveChainId({ SWO_CHAIN_ID: '31337' })).toBe(31337);
+  });
+
+  test('default RPC is the Monad testnet endpoint', () => {
+    expect(resolveRpcUrl({})).toBe(MONAD_TESTNET_DEFAULT_RPC);
+  });
+
+  test('RPC env overrides cascade in priority order', () => {
+    expect(
+      resolveRpcUrl({ MONAD_TESTNET_RPC_URL: 'https://mon.example/rpc' }),
+    ).toBe('https://mon.example/rpc');
+    expect(
+      resolveRpcUrl({
+        SWO_INDEXER_RPC_URL: 'https://swo.example/rpc',
+        MONAD_TESTNET_RPC_URL: 'https://mon.example/rpc',
+      }),
+    ).toBe('https://swo.example/rpc');
+  });
+
+  test('startBlock defaults to 0 and accepts override', () => {
+    expect(resolveStartBlock({})).toBe(0);
+    expect(resolveStartBlock({ SWO_INDEXER_FROM_BLOCK: '1234' })).toBe(1234);
+  });
+
+  test('config exposes the four casino contracts on monadTestnet', () => {
+    expect(Object.keys(indexerConfig.networks)).toEqual(['monadTestnet']);
+    expect(indexerConfig.networks.monadTestnet.chainId).toBe(10143);
+    expect(Object.keys(indexerConfig.contracts).sort()).toEqual([
+      'CasinoCoinflip',
+      'CasinoDice',
+      'CasinoHiLo',
+    ]);
+    for (const c of Object.values(indexerConfig.contracts)) {
+      expect(c.network).toBe('monadTestnet');
+    }
+  });
+});

--- a/services/casino-indexer/__tests__/recent-bets.test.ts
+++ b/services/casino-indexer/__tests__/recent-bets.test.ts
@@ -1,0 +1,158 @@
+// Cross-game recent-bets aggregation: smoke + sort-order coverage.
+
+import { describe, expect, test } from 'vitest';
+
+import { inMemoryBetStore } from '../src/bet-store';
+import { inMemoryDiceBetStore } from '../src/dice-store';
+import { inMemoryHiLoSessionStore } from '../src/hilo-store';
+import { recentBetsForPlayer } from '../src/recent-bets';
+import { onBetPlaced, onBetSettled } from '../src/handlers';
+import { onDiceBetPlaced, onDiceBetSettled } from '../src/dice-handlers';
+import {
+  onHiLoSessionOpened,
+  onHiLoSessionCashed,
+} from '../src/hilo-handlers';
+
+const ALICE = '0x000000000000000000000000000000000000a11c' as const;
+const SEED = ('0x' + 'ab'.repeat(32)) as `0x${string}`;
+const COMMIT = ('0x' + '11'.repeat(32)) as `0x${string}`;
+const REVEAL = ('0x' + 'ce'.repeat(32)) as `0x${string}`;
+
+describe('recentBetsForPlayer', () => {
+  test('merges settled rows from all three games newest-first', async () => {
+    const coinflip = inMemoryBetStore();
+    const dice = inMemoryDiceBetStore();
+    const hilo = inMemoryHiLoSessionStore();
+
+    await onBetPlaced(
+      coinflip,
+      {
+        betId: 1n,
+        player: ALICE,
+        side: 0,
+        stake: 1n,
+        clientSeed: SEED,
+        serverCommit: COMMIT,
+        nonce: 0n,
+        blockPlaced: 100n,
+      },
+      { blockNumber: 100n },
+    );
+    await onBetSettled(
+      coinflip,
+      {
+        betId: 1n,
+        player: ALICE,
+        outcome: 0,
+        won: true,
+        payout: 2n,
+        serverReveal: REVEAL,
+      },
+      { blockNumber: 101n },
+    );
+
+    await onDiceBetPlaced(
+      dice,
+      {
+        betId: 2n,
+        player: ALICE,
+        rollUnder: 50,
+        stake: 1n,
+        clientSeed: SEED,
+        serverCommit: COMMIT,
+        nonce: 0n,
+        blockPlaced: 200n,
+      },
+      { blockNumber: 200n },
+    );
+    await onDiceBetSettled(
+      dice,
+      {
+        betId: 2n,
+        player: ALICE,
+        rollUnder: 50,
+        roll: 17,
+        won: true,
+        payout: 4n,
+        serverReveal: REVEAL,
+      },
+      { blockNumber: 201n },
+    );
+
+    await onHiLoSessionOpened(
+      hilo,
+      {
+        sessionId: 3n,
+        player: ALICE,
+        stake: 1n,
+        clientSeed: SEED,
+        serverCommit: COMMIT,
+        initialCard: 7,
+        nonce: 0n,
+        blockOpened: 300n,
+      },
+      { blockNumber: 300n },
+    );
+    await onHiLoSessionCashed(
+      hilo,
+      {
+        sessionId: 3n,
+        player: ALICE,
+        payout: 5n,
+        finalMultiplier: 2_500_000_000_000_000_000n,
+      },
+      { blockNumber: 301n },
+    );
+
+    const rows = await recentBetsForPlayer({ coinflip, dice, hilo }, ALICE);
+    expect(rows.map((r) => r.game)).toEqual(['hilo', 'dice', 'coinflip']);
+    expect(rows[0].id).toBe('3');
+    expect(rows[0].status).toBe('cashed');
+    expect(rows[2].id).toBe('1');
+    expect(rows[2].status).toBe('won');
+  });
+
+  test('limit clamps the merged result', async () => {
+    const coinflip = inMemoryBetStore();
+    const dice = inMemoryDiceBetStore();
+    const hilo = inMemoryHiLoSessionStore();
+
+    for (let i = 1; i <= 5; i++) {
+      await onBetPlaced(
+        coinflip,
+        {
+          betId: BigInt(i),
+          player: ALICE,
+          side: 0,
+          stake: 1n,
+          clientSeed: SEED,
+          serverCommit: COMMIT,
+          nonce: 0n,
+          blockPlaced: BigInt(100 + i),
+        },
+        { blockNumber: BigInt(100 + i) },
+      );
+      await onBetSettled(
+        coinflip,
+        {
+          betId: BigInt(i),
+          player: ALICE,
+          outcome: 0,
+          won: true,
+          payout: 2n,
+          serverReveal: REVEAL,
+        },
+        { blockNumber: BigInt(100 + i + 1) },
+      );
+    }
+
+    const rows = await recentBetsForPlayer(
+      { coinflip, dice, hilo },
+      ALICE,
+      2,
+    );
+    expect(rows.length).toBe(2);
+    expect(rows[0].id).toBe('5');
+    expect(rows[1].id).toBe('4');
+  });
+});

--- a/services/casino-indexer/abis/CasinoCoinflip.ts
+++ b/services/casino-indexer/abis/CasinoCoinflip.ts
@@ -1,0 +1,43 @@
+// Minimal ABI for the SWO casino coinflip events the indexer cares about.
+// Hand-curated rather than codegen'd so the indexer can boot without Foundry
+// in the build path. Source contract:
+// contracts/casino/src/CasinoCoinflip.sol (event surface mirrors BunnyBagz
+// upstream).
+
+export const COINFLIP_EVENT_ABI = [
+  {
+    type: 'event',
+    name: 'BetPlaced',
+    inputs: [
+      { name: 'betId', type: 'uint256', indexed: true },
+      { name: 'player', type: 'address', indexed: true },
+      { name: 'side', type: 'uint8', indexed: false },
+      { name: 'stake', type: 'uint256', indexed: false },
+      { name: 'clientSeed', type: 'bytes32', indexed: false },
+      { name: 'serverCommit', type: 'bytes32', indexed: false },
+      { name: 'nonce', type: 'uint256', indexed: false },
+      { name: 'blockPlaced', type: 'uint64', indexed: false },
+    ],
+  },
+  {
+    type: 'event',
+    name: 'BetSettled',
+    inputs: [
+      { name: 'betId', type: 'uint256', indexed: true },
+      { name: 'player', type: 'address', indexed: true },
+      { name: 'outcome', type: 'uint8', indexed: false },
+      { name: 'won', type: 'bool', indexed: false },
+      { name: 'payout', type: 'uint256', indexed: false },
+      { name: 'serverReveal', type: 'bytes32', indexed: false },
+    ],
+  },
+  {
+    type: 'event',
+    name: 'BetRefunded',
+    inputs: [
+      { name: 'betId', type: 'uint256', indexed: true },
+      { name: 'player', type: 'address', indexed: true },
+      { name: 'stake', type: 'uint256', indexed: false },
+    ],
+  },
+] as const;

--- a/services/casino-indexer/abis/CasinoDice.ts
+++ b/services/casino-indexer/abis/CasinoDice.ts
@@ -1,0 +1,41 @@
+// Minimal ABI for the SWO casino dice events the indexer cares about.
+// See CasinoCoinflip.ts for the codegen-vs-hand-curated rationale.
+
+export const DICE_EVENT_ABI = [
+  {
+    type: 'event',
+    name: 'BetPlaced',
+    inputs: [
+      { name: 'betId', type: 'uint256', indexed: true },
+      { name: 'player', type: 'address', indexed: true },
+      { name: 'rollUnder', type: 'uint8', indexed: false },
+      { name: 'stake', type: 'uint256', indexed: false },
+      { name: 'clientSeed', type: 'bytes32', indexed: false },
+      { name: 'serverCommit', type: 'bytes32', indexed: false },
+      { name: 'nonce', type: 'uint256', indexed: false },
+      { name: 'blockPlaced', type: 'uint64', indexed: false },
+    ],
+  },
+  {
+    type: 'event',
+    name: 'BetSettled',
+    inputs: [
+      { name: 'betId', type: 'uint256', indexed: true },
+      { name: 'player', type: 'address', indexed: true },
+      { name: 'rollUnder', type: 'uint8', indexed: false },
+      { name: 'roll', type: 'uint8', indexed: false },
+      { name: 'won', type: 'bool', indexed: false },
+      { name: 'payout', type: 'uint256', indexed: false },
+      { name: 'serverReveal', type: 'bytes32', indexed: false },
+    ],
+  },
+  {
+    type: 'event',
+    name: 'BetRefunded',
+    inputs: [
+      { name: 'betId', type: 'uint256', indexed: true },
+      { name: 'player', type: 'address', indexed: true },
+      { name: 'stake', type: 'uint256', indexed: false },
+    ],
+  },
+] as const;

--- a/services/casino-indexer/abis/CasinoHiLo.ts
+++ b/services/casino-indexer/abis/CasinoHiLo.ts
@@ -1,0 +1,64 @@
+// Minimal ABI for the SWO casino HiLo events the indexer cares about.
+// Direction enum: 0 = Higher, 1 = Lower (mapped via `directionFromUint`).
+
+export const HILO_EVENT_ABI = [
+  {
+    type: 'event',
+    name: 'SessionOpened',
+    inputs: [
+      { name: 'sessionId', type: 'uint256', indexed: true },
+      { name: 'player', type: 'address', indexed: true },
+      { name: 'stake', type: 'uint256', indexed: false },
+      { name: 'clientSeed', type: 'bytes32', indexed: false },
+      { name: 'serverCommit', type: 'bytes32', indexed: false },
+      { name: 'initialCard', type: 'uint8', indexed: false },
+      { name: 'nonce', type: 'uint256', indexed: false },
+      { name: 'blockOpened', type: 'uint64', indexed: false },
+    ],
+  },
+  {
+    type: 'event',
+    name: 'StepPlayed',
+    inputs: [
+      { name: 'sessionId', type: 'uint256', indexed: true },
+      { name: 'player', type: 'address', indexed: true },
+      { name: 'direction', type: 'uint8', indexed: false },
+      { name: 'prevCard', type: 'uint8', indexed: false },
+      { name: 'newCard', type: 'uint8', indexed: false },
+      { name: 'won', type: 'bool', indexed: false },
+      { name: 'newMultiplier', type: 'uint256', indexed: false },
+      { name: 'serverReveal', type: 'bytes32', indexed: false },
+      { name: 'nextCommit', type: 'bytes32', indexed: false },
+    ],
+  },
+  {
+    type: 'event',
+    name: 'SessionCashedOut',
+    inputs: [
+      { name: 'sessionId', type: 'uint256', indexed: true },
+      { name: 'player', type: 'address', indexed: true },
+      { name: 'payout', type: 'uint256', indexed: false },
+      { name: 'finalMultiplier', type: 'uint256', indexed: false },
+    ],
+  },
+  {
+    type: 'event',
+    name: 'SessionRefunded',
+    inputs: [
+      { name: 'sessionId', type: 'uint256', indexed: true },
+      { name: 'player', type: 'address', indexed: true },
+      { name: 'stake', type: 'uint256', indexed: false },
+    ],
+  },
+  {
+    type: 'event',
+    name: 'SessionPushed',
+    inputs: [
+      { name: 'sessionId', type: 'uint256', indexed: true },
+      { name: 'player', type: 'address', indexed: true },
+      { name: 'stake', type: 'uint256', indexed: false },
+      { name: 'card', type: 'uint8', indexed: false },
+      { name: 'multiplier', type: 'uint256', indexed: false },
+    ],
+  },
+] as const;

--- a/services/casino-indexer/package.json
+++ b/services/casino-indexer/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@swo/casino-indexer",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Ponder indexer for the SWO Cosmic Casino contracts (Monad testnet, chainId 10143).",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run __tests__",
+    "dev": "ponder dev",
+    "start": "ponder start"
+  },
+  "dependencies": {
+    "viem": "^2.21.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "ponder": "^0.16.6",
+    "typescript": "^5.6.0",
+    "vitest": "^4.0.16"
+  }
+}

--- a/services/casino-indexer/ponder.config.ts
+++ b/services/casino-indexer/ponder.config.ts
@@ -1,0 +1,123 @@
+// Ponder runtime config for the SWO Cosmic Casino bet-history indexer.
+//
+// Targets Monad testnet (chainId 10143). Contract addresses come from env
+// vars so the indexer stays decoupled from the deploy-address book — set
+// `SWO_<GAME>_ADDRESS` (or the `BUNNYBAGZ_*` legacy aliases used by anvil
+// fork scripts) to point at the live deployment.
+//
+// Ponder reads this file via dynamic import; the runtime is *not* required
+// for vitest (tests target the pure handlers). When Ponder is added to the
+// workspace, `createConfig` will resolve from `ponder` and `ponder dev`
+// boots normally. Until then, the export is a plain config object that
+// typechecks without the Ponder package installed.
+
+import type { Address } from 'viem';
+
+import { COINFLIP_EVENT_ABI } from './abis/CasinoCoinflip';
+import { DICE_EVENT_ABI } from './abis/CasinoDice';
+import { HILO_EVENT_ABI } from './abis/CasinoHiLo';
+
+/** Monad testnet chain id. Source of truth: https://docs.monad.xyz */
+export const MONAD_TESTNET_CHAIN_ID = 10143;
+
+/** Default RPC for Monad testnet — override with `MONAD_TESTNET_RPC_URL`. */
+export const MONAD_TESTNET_DEFAULT_RPC = 'https://testnet-rpc.monad.xyz';
+
+const PLACEHOLDER: Address = '0x000000000000000000000000000000000000dEaD';
+
+/** Loose env-bag — accepts both NodeJS.ProcessEnv and arbitrary test stubs. */
+export type EnvBag = Record<string, string | undefined>;
+
+export function resolveChainId(env: EnvBag = process.env): number {
+  if (env.SWO_CHAIN_ID) {
+    const id = Number(env.SWO_CHAIN_ID);
+    if (Number.isFinite(id)) return id;
+  }
+  return MONAD_TESTNET_CHAIN_ID;
+}
+
+export function resolveRpcUrl(env: EnvBag = process.env): string {
+  return (
+    env.SWO_INDEXER_RPC_URL ??
+    env.MONAD_TESTNET_RPC_URL ??
+    env.PONDER_RPC_URL_MONAD_TESTNET ??
+    MONAD_TESTNET_DEFAULT_RPC
+  );
+}
+
+export function resolveStartBlock(env: EnvBag = process.env): number {
+  if (env.SWO_INDEXER_FROM_BLOCK) {
+    const n = Number(env.SWO_INDEXER_FROM_BLOCK);
+    if (Number.isFinite(n)) return n;
+  }
+  return 0;
+}
+
+export function resolveCoinflipAddress(env: EnvBag = process.env): Address {
+  return (env.SWO_COINFLIP_ADDRESS ??
+    env.BUNNYBAGZ_COINFLIP_ADDRESS ??
+    PLACEHOLDER) as Address;
+}
+
+export function resolveDiceAddress(env: EnvBag = process.env): Address {
+  return (env.SWO_DICE_ADDRESS ??
+    env.BUNNYBAGZ_DICE_ADDRESS ??
+    PLACEHOLDER) as Address;
+}
+
+export function resolveHiLoAddress(env: EnvBag = process.env): Address {
+  return (env.SWO_HILO_ADDRESS ??
+    env.BUNNYBAGZ_HILO_ADDRESS ??
+    PLACEHOLDER) as Address;
+}
+
+// Plain config object — keeps the file consumable without a Ponder install.
+// When Ponder is added, `ponder.schema.ts` + `createConfig` can wrap this
+// directly: `export default createConfig(indexerConfig)`.
+export const indexerConfig = {
+  networks: {
+    monadTestnet: {
+      chainId: resolveChainId(),
+      transport: { kind: 'http' as const, url: resolveRpcUrl() },
+    },
+  },
+  contracts: {
+    CasinoCoinflip: {
+      network: 'monadTestnet' as const,
+      abi: COINFLIP_EVENT_ABI,
+      address: resolveCoinflipAddress(),
+      startBlock: resolveStartBlock(),
+      filter: [
+        { event: 'BetPlaced' },
+        { event: 'BetSettled' },
+        { event: 'BetRefunded' },
+      ],
+    },
+    CasinoDice: {
+      network: 'monadTestnet' as const,
+      abi: DICE_EVENT_ABI,
+      address: resolveDiceAddress(),
+      startBlock: resolveStartBlock(),
+      filter: [
+        { event: 'BetPlaced' },
+        { event: 'BetSettled' },
+        { event: 'BetRefunded' },
+      ],
+    },
+    CasinoHiLo: {
+      network: 'monadTestnet' as const,
+      abi: HILO_EVENT_ABI,
+      address: resolveHiLoAddress(),
+      startBlock: resolveStartBlock(),
+      filter: [
+        { event: 'SessionOpened' },
+        { event: 'StepPlayed' },
+        { event: 'SessionCashedOut' },
+        { event: 'SessionRefunded' },
+        { event: 'SessionPushed' },
+      ],
+    },
+  },
+} as const;
+
+export default indexerConfig;

--- a/services/casino-indexer/schema.graphql
+++ b/services/casino-indexer/schema.graphql
@@ -1,0 +1,113 @@
+# SWO Cosmic Casino indexer GraphQL schema (Ponder).
+#
+# Three game tables (Bet/DiceBet/HiLoSession) + HiLoStep for the append-only
+# per-step records. Each game keeps its own table because the placement /
+# settlement payloads diverge enough (rollUnder + roll on dice; per-step +
+# multiplier on hilo) that a single union row would force half the columns
+# nullable. Cross-game aggregation is done at query time on
+# (player, blockPlaced / blockOpened) — see `src/recent-bets.ts`.
+#
+# bigints (stake, payout, nonce, blockPlaced, settledAt, multiplier) are
+# exposed as `BigInt` (decimal string in JSON). Hex fields are `Bytes`.
+# `player` is a 0x-lowercase address scalar. Card and rollUnder are u8 values.
+
+type Bet @entity {
+  # Primary key — coinflip betId, stringified (forward-compat with non-numeric).
+  id: String!
+
+  # Game discriminator — always "coinflip" on this entity. Kept for parity
+  # with cross-game aggregation queries that union over all three tables.
+  game: String!
+
+  player: String!         # 0x-lowercase address (filterable for /api/history)
+  side: String!           # "heads" | "tails" — picked side at placement
+  outcome: String         # "heads" | "tails" — rolled outcome (null until settle)
+  stake: BigInt!          # wei
+
+  clientSeed: Bytes!      # bytes32
+  serverCommit: Bytes!    # bytes32 — keccak(serverReveal)
+  nonce: BigInt!
+
+  status: String!         # "pending" | "won" | "lost" | "refunded"
+  payout: BigInt          # wei — null while pending
+  serverReveal: Bytes     # bytes32 — null until settle
+  blockPlaced: BigInt!
+  settledAt: BigInt       # block number of BetSettled / BetRefunded
+}
+
+# Dice mirrors `Bet` but stores the on-chain numeric inputs instead of
+# heads/tails strings: rollUnder is the threshold (player wins if roll <
+# rollUnder), and roll is the rolled face (1-100). game is always "dice".
+type DiceBet @entity {
+  id: String!             # dice betId, stringified
+
+  game: String!           # always "dice"
+  player: String!
+  rollUnder: Int!         # threshold u8
+  roll: Int               # rolled face u8 (null until settle)
+  stake: BigInt!
+
+  clientSeed: Bytes!
+  serverCommit: Bytes!
+  nonce: BigInt!
+
+  status: String!         # "pending" | "won" | "lost" | "refunded"
+  payout: BigInt
+  serverReveal: Bytes
+  blockPlaced: BigInt!
+  settledAt: BigInt
+}
+
+# HiLo persists one session row plus N step rows. The session row carries
+# the running state (currentCard, multiplier) and the resolution status; the
+# step rows are append-only event records used by /verify/[sessionId] to
+# reconstruct each playStep.
+type HiLoSession @entity {
+  id: String!             # hilo sessionId, stringified
+
+  game: String!           # always "hilo"
+  player: String!
+  stake: BigInt!
+
+  clientSeed: Bytes!
+  serverCommit: Bytes!    # bytes32 of the *initial* commit; nextCommit advances per step
+  initialCard: Int!       # u8 1-13
+  currentCard: Int!       # u8 1-13 — updated on every StepPlayed
+  nonce: BigInt!
+
+  # "open" | "cashed" | "refunded" | "pushed" | "lost"
+  # `lost` arrives implicitly when StepPlayed.won == false and the session
+  # is bust (stake forfeited; no further steps possible).
+  status: String!
+
+  # Running multiplier (1e18-scaled like the contract). Updated on each
+  # StepPlayed; finalMultiplier is set on cashOut/push/lost.
+  multiplier: BigInt!
+  finalMultiplier: BigInt
+  payout: BigInt          # wei — set on CashedOut/Pushed/Refunded; null on lost/open
+
+  blockOpened: BigInt!
+  settledAt: BigInt       # block of CashedOut / Refunded / Pushed / final lose Step
+
+  stepCount: Int!         # number of StepPlayed events for this session
+}
+
+# Append-only StepPlayed records. `id` is the composite "<sessionId>-<stepIdx>"
+# so the verifier can replay deterministically.
+type HiLoStep @entity {
+  id: String!             # "<sessionId>-<stepIdx>"
+
+  sessionId: String!      # parent HiLoSession.id
+  stepIdx: Int!           # 0-based index within the session
+  player: String!
+
+  direction: String!      # "higher" | "lower"
+  prevCard: Int!          # u8
+  newCard: Int!           # u8
+  won: Boolean!
+  newMultiplier: BigInt!
+  serverReveal: Bytes!
+  nextCommit: Bytes!
+
+  blockNumber: BigInt!
+}

--- a/services/casino-indexer/src/bet-store.ts
+++ b/services/casino-indexer/src/bet-store.ts
@@ -1,0 +1,85 @@
+// Persistence abstraction for the coinflip `bets` table.
+//
+// Two implementations:
+//   - `inMemoryBetStore` — used by tests + the `dev --once` smoke harness.
+//     Backs a Map keyed by betId; identical surface to the Ponder runtime
+//     entity API so the handlers can target one abstraction.
+//   - The Ponder context (provided at runtime via `context.db.Bet.create/update`)
+//     is adapted by `ponderBetStore()` in src/index.ts.
+//
+// Schema-of-record: matches `schema.graphql` `Bet` entity.
+// bigint fields are persisted as decimal strings — the GraphQL schema uses
+// `BigInt` scalar (which Ponder serializes as a string).
+
+import type { Address, Hex } from 'viem';
+
+export type Side = 'heads' | 'tails';
+export type BetStatus = 'pending' | 'won' | 'lost' | 'refunded';
+
+export interface BetRow {
+  betId: string;
+  player: Address;
+  side: Side;
+  outcome: Side | null;
+  stake: string;
+  clientSeed: Hex;
+  serverCommit: Hex;
+  nonce: string;
+  status: BetStatus;
+  payout: string | null;
+  serverReveal: Hex | null;
+  blockPlaced: string;
+  settledAt: string | null;
+}
+
+export interface BetStore {
+  create(row: BetRow): Promise<void>;
+  update(betId: string, patch: Partial<BetRow>): Promise<BetRow>;
+  findByPlayer(player: Address, limit: number): Promise<BetRow[]>;
+  get(betId: string): Promise<BetRow | null>;
+  count(): Promise<number>;
+}
+
+export function sideFromUint(u: number | bigint): Side {
+  const n = typeof u === 'bigint' ? Number(u) : u;
+  return n === 0 ? 'heads' : 'tails';
+}
+
+export function inMemoryBetStore(): BetStore {
+  const rows = new Map<string, BetRow>();
+  return {
+    async create(row) {
+      if (rows.has(row.betId)) {
+        throw new Error(`bet ${row.betId} already exists`);
+      }
+      rows.set(row.betId, { ...row });
+    },
+    async update(betId, patch) {
+      const cur = rows.get(betId);
+      if (!cur) throw new Error(`bet ${betId} not found`);
+      const next: BetRow = { ...cur, ...patch };
+      rows.set(betId, next);
+      return next;
+    },
+    async findByPlayer(player, limit) {
+      const lower = player.toLowerCase();
+      const matches: BetRow[] = [];
+      for (const row of rows.values()) {
+        if (row.player.toLowerCase() === lower) matches.push(row);
+      }
+      matches.sort((a, b) => {
+        const aBlk = BigInt(a.blockPlaced);
+        const bBlk = BigInt(b.blockPlaced);
+        if (aBlk !== bBlk) return aBlk > bBlk ? -1 : 1;
+        return BigInt(b.betId) > BigInt(a.betId) ? 1 : -1;
+      });
+      return matches.slice(0, limit);
+    },
+    async get(betId) {
+      return rows.get(betId) ?? null;
+    },
+    async count() {
+      return rows.size;
+    },
+  };
+}

--- a/services/casino-indexer/src/dice-handlers.ts
+++ b/services/casino-indexer/src/dice-handlers.ts
@@ -1,0 +1,87 @@
+// Pure event handlers for CasinoDice.
+//
+// Mirrors `handlers.ts` (coinflip): runtime-agnostic, takes a `DiceBetStore`
+// instead of binding to Ponder's `context.db.*` directly.
+
+import type { Address, Hex } from 'viem';
+
+import type { DiceBetStore } from './dice-store';
+
+export interface DicePlacedArgs {
+  betId: bigint;
+  player: Address;
+  rollUnder: number;
+  stake: bigint;
+  clientSeed: Hex;
+  serverCommit: Hex;
+  nonce: bigint;
+  blockPlaced: bigint;
+}
+
+export interface DiceSettledArgs {
+  betId: bigint;
+  player: Address;
+  rollUnder: number;
+  roll: number;
+  won: boolean;
+  payout: bigint;
+  serverReveal: Hex;
+}
+
+export interface DiceRefundedArgs {
+  betId: bigint;
+  player: Address;
+  stake: bigint;
+}
+
+export interface EventEnvelope {
+  blockNumber: bigint;
+}
+
+export async function onDiceBetPlaced(
+  store: DiceBetStore,
+  args: DicePlacedArgs,
+  _ev: EventEnvelope,
+): Promise<void> {
+  await store.create({
+    betId: args.betId.toString(),
+    player: args.player,
+    rollUnder: args.rollUnder,
+    roll: null,
+    stake: args.stake.toString(),
+    clientSeed: args.clientSeed,
+    serverCommit: args.serverCommit,
+    nonce: args.nonce.toString(),
+    status: 'pending',
+    payout: null,
+    serverReveal: null,
+    blockPlaced: args.blockPlaced.toString(),
+    settledAt: null,
+  });
+}
+
+export async function onDiceBetSettled(
+  store: DiceBetStore,
+  args: DiceSettledArgs,
+  ev: EventEnvelope,
+): Promise<void> {
+  await store.update(args.betId.toString(), {
+    status: args.won ? 'won' : 'lost',
+    roll: args.roll,
+    payout: args.payout.toString(),
+    serverReveal: args.serverReveal,
+    settledAt: ev.blockNumber.toString(),
+  });
+}
+
+export async function onDiceBetRefunded(
+  store: DiceBetStore,
+  args: DiceRefundedArgs,
+  ev: EventEnvelope,
+): Promise<void> {
+  await store.update(args.betId.toString(), {
+    status: 'refunded',
+    payout: '0',
+    settledAt: ev.blockNumber.toString(),
+  });
+}

--- a/services/casino-indexer/src/dice-store.ts
+++ b/services/casino-indexer/src/dice-store.ts
@@ -1,0 +1,75 @@
+// Persistence abstraction for the `dice_bets` table.
+//
+// Same pattern as `bet-store.ts` (the coinflip equivalent): a small interface
+// + an InMemory implementation used by tests + dev-once.
+//
+// Schema-of-record: `DiceBet` in `schema.graphql`.
+
+import type { Address, Hex } from 'viem';
+
+export type DiceBetStatus = 'pending' | 'won' | 'lost' | 'refunded';
+
+export interface DiceBetRow {
+  betId: string;
+  player: Address;
+  /** Win threshold (1-95). Player wins when roll < rollUnder. */
+  rollUnder: number;
+  /** Rolled face 1-100. Null while pending or on refund. */
+  roll: number | null;
+  stake: string;
+  clientSeed: Hex;
+  serverCommit: Hex;
+  nonce: string;
+  status: DiceBetStatus;
+  payout: string | null;
+  serverReveal: Hex | null;
+  blockPlaced: string;
+  settledAt: string | null;
+}
+
+export interface DiceBetStore {
+  create(row: DiceBetRow): Promise<void>;
+  update(betId: string, patch: Partial<DiceBetRow>): Promise<DiceBetRow>;
+  findByPlayer(player: Address, limit: number): Promise<DiceBetRow[]>;
+  get(betId: string): Promise<DiceBetRow | null>;
+  count(): Promise<number>;
+}
+
+export function inMemoryDiceBetStore(): DiceBetStore {
+  const rows = new Map<string, DiceBetRow>();
+  return {
+    async create(row) {
+      if (rows.has(row.betId)) {
+        throw new Error(`dice bet ${row.betId} already exists`);
+      }
+      rows.set(row.betId, { ...row });
+    },
+    async update(betId, patch) {
+      const cur = rows.get(betId);
+      if (!cur) throw new Error(`dice bet ${betId} not found`);
+      const next: DiceBetRow = { ...cur, ...patch };
+      rows.set(betId, next);
+      return next;
+    },
+    async findByPlayer(player, limit) {
+      const lower = player.toLowerCase();
+      const matches: DiceBetRow[] = [];
+      for (const row of rows.values()) {
+        if (row.player.toLowerCase() === lower) matches.push(row);
+      }
+      matches.sort((a, b) => {
+        const aBlk = BigInt(a.blockPlaced);
+        const bBlk = BigInt(b.blockPlaced);
+        if (aBlk !== bBlk) return aBlk > bBlk ? -1 : 1;
+        return BigInt(b.betId) > BigInt(a.betId) ? 1 : -1;
+      });
+      return matches.slice(0, limit);
+    },
+    async get(betId) {
+      return rows.get(betId) ?? null;
+    },
+    async count() {
+      return rows.size;
+    },
+  };
+}

--- a/services/casino-indexer/src/handlers.ts
+++ b/services/casino-indexer/src/handlers.ts
@@ -1,0 +1,90 @@
+// Pure event handlers for CasinoCoinflip.
+//
+// Designed to be runtime-agnostic: the handlers take a `BetStore` instance
+// instead of binding to Ponder's `context.db.*` directly, so we can drive
+// them from vitest against an in-memory store. `src/index.ts` adapts these
+// handlers to the Ponder runtime by wrapping the context entity API.
+
+import type { Address, Hex } from 'viem';
+
+import type { BetStore } from './bet-store';
+import { sideFromUint } from './bet-store';
+
+export interface PlacedArgs {
+  betId: bigint;
+  player: Address;
+  side: number;
+  stake: bigint;
+  clientSeed: Hex;
+  serverCommit: Hex;
+  nonce: bigint;
+  blockPlaced: bigint;
+}
+
+export interface SettledArgs {
+  betId: bigint;
+  player: Address;
+  outcome: number;
+  won: boolean;
+  payout: bigint;
+  serverReveal: Hex;
+}
+
+export interface RefundedArgs {
+  betId: bigint;
+  player: Address;
+  stake: bigint;
+}
+
+export interface EventEnvelope {
+  /** Block number the log was mined in. Settled-at uses this. */
+  blockNumber: bigint;
+}
+
+export async function onBetPlaced(
+  store: BetStore,
+  args: PlacedArgs,
+  _ev: EventEnvelope,
+): Promise<void> {
+  await store.create({
+    betId: args.betId.toString(),
+    player: args.player,
+    side: sideFromUint(args.side),
+    outcome: null,
+    stake: args.stake.toString(),
+    clientSeed: args.clientSeed,
+    serverCommit: args.serverCommit,
+    nonce: args.nonce.toString(),
+    status: 'pending',
+    payout: null,
+    serverReveal: null,
+    blockPlaced: args.blockPlaced.toString(),
+    settledAt: null,
+  });
+}
+
+export async function onBetSettled(
+  store: BetStore,
+  args: SettledArgs,
+  ev: EventEnvelope,
+): Promise<void> {
+  await store.update(args.betId.toString(), {
+    status: args.won ? 'won' : 'lost',
+    outcome: sideFromUint(args.outcome),
+    payout: args.payout.toString(),
+    serverReveal: args.serverReveal,
+    settledAt: ev.blockNumber.toString(),
+  });
+}
+
+export async function onBetRefunded(
+  store: BetStore,
+  args: RefundedArgs,
+  ev: EventEnvelope,
+): Promise<void> {
+  await store.update(args.betId.toString(), {
+    status: 'refunded',
+    payout: '0',
+    settledAt: ev.blockNumber.toString(),
+  });
+}

--- a/services/casino-indexer/src/hilo-handlers.ts
+++ b/services/casino-indexer/src/hilo-handlers.ts
@@ -1,0 +1,175 @@
+// Pure event handlers for CasinoHiLo.
+//
+// HiLo splits state across two tables: a mutable `HiLoSession` row plus
+// append-only `HiLoStep` rows. The handlers take both stores and keep them
+// in sync — `onHiLoSessionOpened` creates the session, `onHiLoStepPlayed`
+// appends a step + updates the session's running multiplier/currentCard
+// (and flips status to "lost" when the player busts), and the close
+// handlers (cashed/refunded/pushed) terminate the session.
+
+import type { Address, Hex } from 'viem';
+
+import type {
+  HiLoSessionStore,
+  HiLoStepStore,
+  HiLoDirection,
+} from './hilo-store';
+
+export interface HiLoSessionOpenedArgs {
+  sessionId: bigint;
+  player: Address;
+  stake: bigint;
+  clientSeed: Hex;
+  serverCommit: Hex;
+  initialCard: number;
+  nonce: bigint;
+  blockOpened: bigint;
+}
+
+export interface HiLoStepPlayedArgs {
+  sessionId: bigint;
+  player: Address;
+  direction: HiLoDirection;
+  prevCard: number;
+  newCard: number;
+  won: boolean;
+  newMultiplier: bigint;
+  serverReveal: Hex;
+  nextCommit: Hex;
+}
+
+export interface HiLoSessionCashedArgs {
+  sessionId: bigint;
+  player: Address;
+  payout: bigint;
+  finalMultiplier: bigint;
+}
+
+export interface HiLoSessionRefundedArgs {
+  sessionId: bigint;
+  player: Address;
+  stake: bigint;
+}
+
+export interface HiLoSessionPushedArgs {
+  sessionId: bigint;
+  player: Address;
+  stake: bigint;
+  card: number;
+  multiplier: bigint;
+}
+
+export interface EventEnvelope {
+  blockNumber: bigint;
+}
+
+const ONE_E18 = 1_000_000_000_000_000_000n;
+
+export async function onHiLoSessionOpened(
+  sessions: HiLoSessionStore,
+  args: HiLoSessionOpenedArgs,
+  _ev: EventEnvelope,
+): Promise<void> {
+  await sessions.create({
+    sessionId: args.sessionId.toString(),
+    player: args.player,
+    stake: args.stake.toString(),
+    clientSeed: args.clientSeed,
+    serverCommit: args.serverCommit,
+    initialCard: args.initialCard,
+    currentCard: args.initialCard,
+    nonce: args.nonce.toString(),
+    status: 'open',
+    multiplier: ONE_E18.toString(),
+    finalMultiplier: null,
+    payout: null,
+    blockOpened: args.blockOpened.toString(),
+    settledAt: null,
+    stepCount: 0,
+  });
+}
+
+export async function onHiLoStepPlayed(
+  sessions: HiLoSessionStore,
+  steps: HiLoStepStore,
+  args: HiLoStepPlayedArgs,
+  ev: EventEnvelope,
+): Promise<void> {
+  const sessionId = args.sessionId.toString();
+  const cur = await sessions.get(sessionId);
+  if (!cur) {
+    throw new Error(`hilo step before session opened (${sessionId})`);
+  }
+  const stepIdx = cur.stepCount;
+
+  await steps.append({
+    id: `${sessionId}-${stepIdx}`,
+    sessionId,
+    stepIdx,
+    player: args.player,
+    direction: args.direction,
+    prevCard: args.prevCard,
+    newCard: args.newCard,
+    won: args.won,
+    newMultiplier: args.newMultiplier.toString(),
+    serverReveal: args.serverReveal,
+    nextCommit: args.nextCommit,
+    blockNumber: ev.blockNumber.toString(),
+  });
+
+  if (!args.won) {
+    await sessions.update(sessionId, {
+      currentCard: args.newCard,
+      multiplier: args.newMultiplier.toString(),
+      stepCount: stepIdx + 1,
+      status: 'lost',
+      finalMultiplier: args.newMultiplier.toString(),
+      settledAt: ev.blockNumber.toString(),
+    });
+  } else {
+    await sessions.update(sessionId, {
+      currentCard: args.newCard,
+      multiplier: args.newMultiplier.toString(),
+      stepCount: stepIdx + 1,
+      serverCommit: args.nextCommit,
+    });
+  }
+}
+
+export async function onHiLoSessionCashed(
+  sessions: HiLoSessionStore,
+  args: HiLoSessionCashedArgs,
+  ev: EventEnvelope,
+): Promise<void> {
+  await sessions.update(args.sessionId.toString(), {
+    status: 'cashed',
+    payout: args.payout.toString(),
+    finalMultiplier: args.finalMultiplier.toString(),
+    settledAt: ev.blockNumber.toString(),
+  });
+}
+
+export async function onHiLoSessionRefunded(
+  sessions: HiLoSessionStore,
+  args: HiLoSessionRefundedArgs,
+  ev: EventEnvelope,
+): Promise<void> {
+  await sessions.update(args.sessionId.toString(), {
+    status: 'refunded',
+    payout: args.stake.toString(),
+    settledAt: ev.blockNumber.toString(),
+  });
+}
+
+export async function onHiLoSessionPushed(
+  sessions: HiLoSessionStore,
+  args: HiLoSessionPushedArgs,
+  ev: EventEnvelope,
+): Promise<void> {
+  await sessions.update(args.sessionId.toString(), {
+    status: 'pushed',
+    payout: args.stake.toString(),
+    finalMultiplier: args.multiplier.toString(),
+    settledAt: ev.blockNumber.toString(),
+  });
+}

--- a/services/casino-indexer/src/hilo-store.ts
+++ b/services/casino-indexer/src/hilo-store.ts
@@ -1,0 +1,131 @@
+// Persistence abstractions for the HiLo `sessions` + `steps` tables.
+//
+// HiLo splits state across two entities: one mutable session row that
+// tracks running state (currentCard, multiplier, status) and N append-only
+// step rows. Both stores follow the same pattern as `bet-store.ts`.
+//
+// Schema-of-record: `HiLoSession` + `HiLoStep` in `schema.graphql`.
+
+import type { Address, Hex } from 'viem';
+
+export type HiLoStatus = 'open' | 'cashed' | 'refunded' | 'pushed' | 'lost';
+export type HiLoDirection = 'higher' | 'lower';
+
+export interface HiLoSessionRow {
+  sessionId: string;
+  player: Address;
+  stake: string;
+  clientSeed: Hex;
+  serverCommit: Hex;
+  initialCard: number;
+  currentCard: number;
+  nonce: string;
+  status: HiLoStatus;
+  /** 1e18-scaled running multiplier (matches the contract). */
+  multiplier: string;
+  finalMultiplier: string | null;
+  payout: string | null;
+  blockOpened: string;
+  settledAt: string | null;
+  stepCount: number;
+}
+
+export interface HiLoStepRow {
+  /** Composite "<sessionId>-<stepIdx>" — primary key. */
+  id: string;
+  sessionId: string;
+  stepIdx: number;
+  player: Address;
+  direction: HiLoDirection;
+  prevCard: number;
+  newCard: number;
+  won: boolean;
+  newMultiplier: string;
+  serverReveal: Hex;
+  nextCommit: Hex;
+  blockNumber: string;
+}
+
+export interface HiLoSessionStore {
+  create(row: HiLoSessionRow): Promise<void>;
+  update(
+    sessionId: string,
+    patch: Partial<HiLoSessionRow>,
+  ): Promise<HiLoSessionRow>;
+  get(sessionId: string): Promise<HiLoSessionRow | null>;
+  findByPlayer(player: Address, limit: number): Promise<HiLoSessionRow[]>;
+  count(): Promise<number>;
+}
+
+export interface HiLoStepStore {
+  append(row: HiLoStepRow): Promise<void>;
+  findBySession(sessionId: string): Promise<HiLoStepRow[]>;
+  count(): Promise<number>;
+}
+
+export function directionFromUint(u: number | bigint): HiLoDirection {
+  const n = typeof u === 'bigint' ? Number(u) : u;
+  return n === 0 ? 'higher' : 'lower';
+}
+
+export function inMemoryHiLoSessionStore(): HiLoSessionStore {
+  const rows = new Map<string, HiLoSessionRow>();
+  return {
+    async create(row) {
+      if (rows.has(row.sessionId)) {
+        throw new Error(`hilo session ${row.sessionId} already exists`);
+      }
+      rows.set(row.sessionId, { ...row });
+    },
+    async update(sessionId, patch) {
+      const cur = rows.get(sessionId);
+      if (!cur) throw new Error(`hilo session ${sessionId} not found`);
+      const next: HiLoSessionRow = { ...cur, ...patch };
+      rows.set(sessionId, next);
+      return next;
+    },
+    async get(sessionId) {
+      return rows.get(sessionId) ?? null;
+    },
+    async findByPlayer(player, limit) {
+      const lower = player.toLowerCase();
+      const matches: HiLoSessionRow[] = [];
+      for (const row of rows.values()) {
+        if (row.player.toLowerCase() === lower) matches.push(row);
+      }
+      matches.sort((a, b) => {
+        const aBlk = BigInt(a.blockOpened);
+        const bBlk = BigInt(b.blockOpened);
+        if (aBlk !== bBlk) return aBlk > bBlk ? -1 : 1;
+        return BigInt(b.sessionId) > BigInt(a.sessionId) ? 1 : -1;
+      });
+      return matches.slice(0, limit);
+    },
+    async count() {
+      return rows.size;
+    },
+  };
+}
+
+export function inMemoryHiLoStepStore(): HiLoStepStore {
+  const rows = new Map<string, HiLoStepRow>();
+  return {
+    async append(row) {
+      if (rows.has(row.id)) {
+        throw new Error(`hilo step ${row.id} already exists`);
+      }
+      rows.set(row.id, { ...row });
+    },
+    async findBySession(sessionId) {
+      const matches: HiLoStepRow[] = [];
+      for (const row of rows.values()) {
+        if (row.sessionId === sessionId) matches.push(row);
+      }
+      matches.sort((a, b) => a.stepIdx - b.stepIdx);
+      return matches;
+    },
+    async count() {
+      return rows.size;
+    },
+  };
+}

--- a/services/casino-indexer/src/index.ts
+++ b/services/casino-indexer/src/index.ts
@@ -1,0 +1,204 @@
+// Ponder runtime entry — wires the runtime-agnostic handlers in
+// `src/handlers.ts` to Ponder's context.db.* entity API.
+//
+// At runtime (with Ponder installed), `ponder` exports the `ponder` object
+// with `on(eventName, handler)`. We register one handler per event the ABI
+// declares; each adapts Ponder's `event.args` shape into the typed args our
+// pure handlers expect, and adapts `context.db.*` into the store abstraction.
+//
+// Until `ponder` is added to the workspace, this module is dormant — it only
+// imports `ponder` lazily inside `bootstrap()` so vitest/`tsc --noEmit`
+// against this file resolve cleanly without the runtime in node_modules.
+//
+// `bootstrapWithFixture()` is the test seam: pass an in-memory store and a
+// synthetic event stream and verify rows land in the table. `scripts/dev-once.ts`
+// uses exactly this entry point against a static fixture.
+
+import type { Address, Hex } from 'viem';
+
+import type { BetStore, BetRow } from './bet-store';
+import { inMemoryBetStore } from './bet-store';
+import {
+  onBetPlaced,
+  onBetSettled,
+  onBetRefunded,
+  type EventEnvelope,
+  type PlacedArgs,
+  type SettledArgs,
+  type RefundedArgs,
+} from './handlers';
+
+// ---------------------------------------------------------------------------
+// Mock RPC fixture (used by tests + `dev --once`).
+// ---------------------------------------------------------------------------
+
+export type MockEvent =
+  | { kind: 'BetPlaced'; args: PlacedArgs; envelope: EventEnvelope }
+  | { kind: 'BetSettled'; args: SettledArgs; envelope: EventEnvelope }
+  | { kind: 'BetRefunded'; args: RefundedArgs; envelope: EventEnvelope };
+
+export interface MockRpcFixture {
+  /** Replay a deterministic event stream into the supplied BetStore. */
+  drain(store: BetStore): Promise<void>;
+  events: MockEvent[];
+}
+
+const ADDR_ALICE: Address = '0x000000000000000000000000000000000000A11C';
+const ADDR_BOB: Address = '0x000000000000000000000000000000000000b0B0';
+const SEED: Hex = ('0x' + 'ab'.repeat(32)) as Hex;
+const COMMIT: Hex = ('0x' + '11'.repeat(32)) as Hex;
+const REVEAL: Hex = ('0x' + 'ce'.repeat(32)) as Hex;
+
+export function buildMockRpcFixture(): MockRpcFixture {
+  const events: MockEvent[] = [
+    {
+      kind: 'BetPlaced',
+      args: {
+        betId: 1n,
+        player: ADDR_ALICE,
+        side: 0,
+        stake: 1_000_000_000_000_000n,
+        clientSeed: SEED,
+        serverCommit: COMMIT,
+        nonce: 0n,
+        blockPlaced: 100n,
+      },
+      envelope: { blockNumber: 100n },
+    },
+    {
+      kind: 'BetSettled',
+      args: {
+        betId: 1n,
+        player: ADDR_ALICE,
+        outcome: 0,
+        won: true,
+        payout: 1_960_000_000_000_000n,
+        serverReveal: REVEAL,
+      },
+      envelope: { blockNumber: 102n },
+    },
+    {
+      kind: 'BetPlaced',
+      args: {
+        betId: 2n,
+        player: ADDR_ALICE,
+        side: 1,
+        stake: 2_000_000_000_000_000n,
+        clientSeed: SEED,
+        serverCommit: COMMIT,
+        nonce: 1n,
+        blockPlaced: 110n,
+      },
+      envelope: { blockNumber: 110n },
+    },
+    {
+      kind: 'BetSettled',
+      args: {
+        betId: 2n,
+        player: ADDR_ALICE,
+        outcome: 0,
+        won: false,
+        payout: 0n,
+        serverReveal: REVEAL,
+      },
+      envelope: { blockNumber: 112n },
+    },
+    {
+      kind: 'BetPlaced',
+      args: {
+        betId: 3n,
+        player: ADDR_BOB,
+        side: 0,
+        stake: 500_000_000_000_000n,
+        clientSeed: SEED,
+        serverCommit: COMMIT,
+        nonce: 0n,
+        blockPlaced: 120n,
+      },
+      envelope: { blockNumber: 120n },
+    },
+    {
+      kind: 'BetRefunded',
+      args: { betId: 3n, player: ADDR_BOB, stake: 500_000_000_000_000n },
+      envelope: { blockNumber: 9999n },
+    },
+  ];
+
+  return {
+    events,
+    async drain(store) {
+      for (const ev of events) {
+        if (ev.kind === 'BetPlaced') {
+          await onBetPlaced(store, ev.args, ev.envelope);
+        } else if (ev.kind === 'BetSettled') {
+          await onBetSettled(store, ev.args, ev.envelope);
+        } else {
+          await onBetRefunded(store, ev.args, ev.envelope);
+        }
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Ponder context adapter (lazy — only used when Ponder is installed).
+// ---------------------------------------------------------------------------
+
+export interface PonderEntityApi {
+  create(args: { id: string; data: Omit<BetRow, 'betId'> }): Promise<BetRow>;
+  update(args: { id: string; data: Partial<BetRow> }): Promise<BetRow>;
+  findMany(args: {
+    where?: { player?: string; status?: { in?: string[] } };
+    limit?: number;
+    orderBy?: { blockPlaced?: 'desc' | 'asc' };
+  }): Promise<BetRow[]>;
+  findUnique(args: { id: string }): Promise<BetRow | null>;
+}
+
+/**
+ * Adapt the Ponder context entity API into the runtime-agnostic BetStore.
+ * Lets `src/handlers.ts` stay pure while still feeding the production runtime.
+ */
+export function ponderBetStore(api: PonderEntityApi): BetStore {
+  return {
+    async create(row) {
+      const { betId, ...rest } = row;
+      await api.create({
+        id: betId,
+        data: { ...rest, betId } as Omit<BetRow, 'betId'>,
+      });
+    },
+    async update(betId, patch) {
+      return api.update({ id: betId, data: patch });
+    },
+    async findByPlayer(player, limit) {
+      const rows = await api.findMany({
+        where: { player: player.toLowerCase() },
+        limit,
+        orderBy: { blockPlaced: 'desc' },
+      });
+      return rows;
+    },
+    async get(betId) {
+      return api.findUnique({ id: betId });
+    },
+    async count() {
+      const rows = await api.findMany({ limit: 10_000 });
+      return rows.length;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// `dev --once` smoke harness.
+// ---------------------------------------------------------------------------
+
+export async function bootstrapWithFixture(): Promise<{
+  store: BetStore;
+  fixture: MockRpcFixture;
+}> {
+  const store = inMemoryBetStore();
+  const fixture = buildMockRpcFixture();
+  await fixture.drain(store);
+  return { store, fixture };
+}

--- a/services/casino-indexer/src/recent-bets.ts
+++ b/services/casino-indexer/src/recent-bets.ts
@@ -1,0 +1,109 @@
+// Cross-game recent-bets aggregation.
+//
+// Pulls settled rows from each game's store, normalises them to a shared
+// `RecentBet` shape, and merges newest-first by block number. Used by the
+// per-wallet recent-outcomes ticker. Per-game endpoints keep returning their
+// typed rows; this helper is the cross-game union.
+
+import type { Address } from 'viem';
+
+import type { BetStore } from './bet-store';
+import type { DiceBetStore } from './dice-store';
+import type { HiLoSessionStore } from './hilo-store';
+
+export type RecentGame = 'coinflip' | 'dice' | 'hilo';
+
+export interface RecentBet {
+  game: RecentGame;
+  /** Coinflip/dice betId or hilo sessionId, stringified. */
+  id: string;
+  player: string;
+  status: string;
+  stake: string;
+  payout: string | null;
+  /** Block the bet was placed (or hilo session opened) in — sort key. */
+  blockPlaced: string;
+  settledAt: string | null;
+}
+
+export interface RecentBetsDeps {
+  coinflip: BetStore;
+  dice: DiceBetStore;
+  hilo: HiLoSessionStore;
+}
+
+const TERMINAL_COINFLIP = new Set(['won', 'lost', 'refunded']);
+const TERMINAL_DICE = new Set(['won', 'lost', 'refunded']);
+const TERMINAL_HILO = new Set(['cashed', 'lost', 'refunded', 'pushed']);
+
+function compareNewestFirst(a: RecentBet, b: RecentBet): number {
+  const aBlk = BigInt(a.blockPlaced);
+  const bBlk = BigInt(b.blockPlaced);
+  if (aBlk !== bBlk) return aBlk > bBlk ? -1 : 1;
+  try {
+    const aId = BigInt(a.id);
+    const bId = BigInt(b.id);
+    return aId > bId ? -1 : aId < bId ? 1 : 0;
+  } catch {
+    return a.id < b.id ? 1 : a.id > b.id ? -1 : 0;
+  }
+}
+
+export async function recentBetsForPlayer(
+  deps: RecentBetsDeps,
+  player: Address,
+  limit: number = 24,
+): Promise<RecentBet[]> {
+  const cap = Math.max(1, Math.floor(limit));
+  const perGame = Math.min(cap * 3, 200);
+
+  const [coinflipRows, diceRows, hiloRows] = await Promise.all([
+    deps.coinflip.findByPlayer(player, perGame),
+    deps.dice.findByPlayer(player, perGame),
+    deps.hilo.findByPlayer(player, perGame),
+  ]);
+
+  const merged: RecentBet[] = [];
+  for (const r of coinflipRows) {
+    if (!TERMINAL_COINFLIP.has(r.status)) continue;
+    merged.push({
+      game: 'coinflip',
+      id: r.betId,
+      player: r.player,
+      status: r.status,
+      stake: r.stake,
+      payout: r.payout,
+      blockPlaced: r.blockPlaced,
+      settledAt: r.settledAt,
+    });
+  }
+  for (const r of diceRows) {
+    if (!TERMINAL_DICE.has(r.status)) continue;
+    merged.push({
+      game: 'dice',
+      id: r.betId,
+      player: r.player,
+      status: r.status,
+      stake: r.stake,
+      payout: r.payout,
+      blockPlaced: r.blockPlaced,
+      settledAt: r.settledAt,
+    });
+  }
+  for (const r of hiloRows) {
+    if (!TERMINAL_HILO.has(r.status)) continue;
+    merged.push({
+      game: 'hilo',
+      id: r.sessionId,
+      player: r.player,
+      status: r.status,
+      stake: r.stake,
+      payout: r.payout,
+      blockPlaced: r.blockOpened,
+      settledAt: r.settledAt,
+    });
+  }
+
+  merged.sort(compareNewestFirst);
+  return merged.slice(0, cap);
+}

--- a/services/casino-indexer/tsconfig.json
+++ b/services/casino-indexer/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*", "abis/**/*", "ponder.config.ts", "__tests__/**/*"]
+}


### PR DESCRIPTION
## Summary

Stay-in-place port of `mega-house/apps/indexer/{ponder.config.ts, schema.graphql, abis/, src/}` to **`services/casino-indexer/`**, retargeted to **Monad testnet (chainId 10143)**. Adds a typed GraphQL client at `lib/casino/recentBetsIndexer.ts` so `components/casino/RecentBets.tsx` has a defined consumer path for the new endpoint.

Task: `[SWO_CASINO_INDEXER_PORT]` (PROJECT:SWO, P2). PR class: **B** — handler suite, cross-game aggregator, GraphQL client, and Monad retarget are all shipped and unit-tested. The runtime acceptance bullet (`ponder dev` actually indexing live Monad testnet against deployed contract addresses) requires deploy-time env wiring + a Ponder Cloud / Goldsky / Vercel host pick and cannot be verified from this run — see Follow-ups.

### What's in this PR

- **`services/casino-indexer/ponder.config.ts`** — single `monadTestnet` network at chainId 10143; address resolvers read `SWO_<GAME>_ADDRESS` with `BUNNYBAGZ_*` fall-through aliases for the anvil-fork dev scripts. RPC defaults to `https://testnet-rpc.monad.xyz` with `SWO_INDEXER_RPC_URL` / `MONAD_TESTNET_RPC_URL` / `PONDER_RPC_URL_MONAD_TESTNET` cascade.
- **`schema.graphql`** — `Bet`, `DiceBet`, `HiLoSession`, `HiLoStep` (unchanged from upstream).
- **`abis/Casino{Coinflip,Dice,HiLo}.ts`** — hand-curated event ABIs.
- **`src/`** — pure handlers + in-memory stores + cross-game `recentBetsForPlayer` aggregator + a Ponder context adapter (`ponderBetStore`).
- **`__tests__/`** — 5 vitest suites:
  - `handlers.test.ts` — coinflip BetPlaced/Settled/Refunded
  - `dice-handlers.test.ts` — dice BetPlaced/Settled/Refunded
  - `hilo-handlers.test.ts` — HiLo Session{Opened,Cashed,Refunded,Pushed}, StepPlayed (won/lost/before-open guard)
  - `recent-bets.test.ts` — cross-game aggregation + limit clamping
  - `ponder-config.test.ts` — pins chainId 10143 + RPC cascade
- **`lib/casino/recentBetsIndexer.ts`** — `fetchRecentBets()` GraphQL client + `mapRecentBetsToWallet()` adapter into the `WalletBet` shape that `components/casino/RecentBets.tsx` already renders. Backed by `lib/casino/__tests__/recentBetsIndexer.test.ts` (mocked-fetch coverage of the union query + error paths + WalletBet mapping).

### Acceptance bullets

- (a) **Directory exists** — `services/casino-indexer/` is in place. ✅
- (b) **`ponder dev` against Monad testnet RPC** — config retargeted to 10143; `ponder` itself is listed as a devDep but not yet installed, and a live test requires deployed addresses + an environment that can reach `testnet-rpc.monad.xyz`. ⚠️ verifiable post-deploy (see Follow-ups).
- (c) **Vitest in `__tests__/` covers each event handler** — 28 new tests, all passing. ✅
- (d) **`RecentBets` consumes the indexer GraphQL endpoint** — wiring shipped via `lib/casino/recentBetsIndexer.ts`; component-level wrapper is one short follow-up. ✅ (data path) / ⚠️ (UI wrapper)

The 4th-contract mention in the task brief is not present in the upstream port (mega-house ships three: Coinflip, Dice, HiLo). Documented in the README under "Indexed contracts" with the slots plan as a follow-up.

### Test plan

- [x] `npx vitest run services/casino-indexer/__tests__ lib/casino/__tests__/recentBetsIndexer.test.ts` — 28 passed
- [x] `npm run test` — 956 passed (no regressions to the existing 928)
- [x] `npm run type-check` — no new errors (pre-existing `game/scenes/**` and `game/v3/scenes/**` Phaser-signature errors only)
- [x] `npx eslint services/casino-indexer lib/casino/recentBetsIndexer.ts lib/casino/__tests__/recentBetsIndexer.test.ts` — 0 errors (3 `_ev` warnings on the handler hooks; kept for parity with the runtime signature)

### Follow-ups (Class B gap)

1. Add `ponder` + `@ponder/graphql` to the workspace and verify `ponder dev` boots against Monad testnet. Requires real-deploy addresses for `SWO_COINFLIP_ADDRESS` / `SWO_DICE_ADDRESS` / `SWO_HILO_ADDRESS` — not yet on this branch.
2. Pick a host (Ponder Cloud / Goldsky / Vercel cron) and add `services/casino-indexer/.env.example` with the deploy-time vars.
3. Add a thin `<RecentBetsLive />` component that wires `fetchRecentBets()` + `mapRecentBetsToWallet()` into the existing `RecentBets` surface inside the wallet sheet.
4. Once the on-chain slots contract lands, add `CasinoSlots` to the indexer (4th-contract slot from the task brief).

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS (36 pre-existing errors unchanged; 0 new)
- **vitest run**: PASS (baseline 41 files / 819 tests / 11 errors; after overlay 47 files / 847 tests / 11 errors — 0 new errors, +6 files / +28 tests)

Overall: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)