### PR TITLE
docs(casino): monadscan verify commands + flattened sources fallback [SWO_CASINO_MONADSCAN_VERIFY]

### DIFF
--- a/contracts/casino/README.md
+++ b/contracts/casino/README.md
@@ -89,6 +89,147 @@ RPCs (`MONAD_TESTNET_RPC`, `MONAD_MAINNET_RPC`, `ANVIL_RPC`,
 the same invariant so the prediction can never silently drift away from the
 deployed address book.
 
+## Verification
+
+Source code for the four contracts deployed on Monad testnet (chain `10143`)
+is published two ways:
+
+1. **Monadscan (Etherscan-compatible).** When a Monadscan API key is available,
+   verify against the live explorer with `forge verify-contract`.
+2. **Flattened sources.** Committed under `contracts/casino/flattened/` as a
+   permanent fallback (and for any explorer that prefers a single-file
+   submission). One `.flat.sol` per deployed contract, produced by
+   `forge flatten` against the same `solc 0.8.24` + `optimizer_runs = 200`
+   profile used at deploy time. These are the canonical artifacts to upload
+   when the Monadscan API is unavailable, rejects the v2 endpoint, or when no
+   API key has been provisioned for the deployer.
+
+### Deployed addresses (chain `10143`)
+
+| Contract              | Address                                      |
+|-----------------------|----------------------------------------------|
+| `CasinoBankroll`      | `0x33C5B6a95e71611F5dC821A74DDAD0F746fF2dFf` |
+| `CosmicFlip`          | `0x064b8bfc03b23D2b525deD9d3969090347A21983` |
+| `GravityDice`         | `0xAC023542A8168465EE4A1b3e8Ae0f58F36A6d84B` |
+| `ConstellationClimb`  | `0xd9B9b6c37ad4f3D5b07ae76dE261c5C865600d6e` |
+
+Authoritative list: `deployments/10143.json`.
+
+### Verifying against Monadscan
+
+The `[etherscan]` block in `foundry.toml` already pins the Monadscan endpoint
+for both networks. Run the following from `contracts/casino/` with
+`MONAD_ETHERSCAN_KEY` exported. Forge's chain alias uses a hyphen
+(`monad-testnet`), not the underscore form (`monad_testnet`) used elsewhere in
+the etherscan config table — pass the alias on the CLI exactly as below:
+
+The constructor signatures and the values used at deploy time on chain
+`10143` (taken from `script/Deploy.s.sol` + the `CASINO_*` env defaults in
+`script/deploy-testnet.sh`) are:
+
+| Contract              | Signature                                                                 | Args (in order)                                                                                                                                  |
+|-----------------------|---------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
+| `CasinoBankroll`      | `constructor(address initialOwner)`                                       | `0xb29e6735629539cEd64F0d6f0c476Fe92539fD7B`                                                                                                     |
+| `CosmicFlip`          | `constructor(address initialOwner, address bankroll, uint256 minBet, uint256 maxBet)` | `0xb29e…fD7B`, `0x33C5…2dFf`, `1000000000000000` (1e15 = 0.001), `2000000000000000` (2e15 = 0.002)                                                |
+| `GravityDice`         | `constructor(address initialOwner, address bankroll, uint256 minBet, uint256 maxBet)` | `0xb29e…fD7B`, `0x33C5…2dFf`, `1000000000000000`, `2000000000000000`                                                                              |
+| `ConstellationClimb`  | `constructor(address initialOwner, address bankroll, uint256 minBet, uint256 maxBet, uint256 maxPayout)` | `0xb29e…fD7B`, `0x33C5…2dFf`, `1000000000000000`, `2000000000000000`, `1000000000000000000` (1e18 = 1 MON, the `Deploy.s.sol` default for `climbMaxPayout`) |
+
+`maxDrawdown24hWei` on `CasinoBankroll` is configured **after** deploy via
+`setMaxDrawdown24hWei(1e16)` (see `script/Deploy.s.sol` lines 131–140) — it is
+not a constructor arg, so it is **not** part of the verification calldata.
+
+```bash
+export MONAD_ETHERSCAN_KEY=<your monadscan api key>
+DEPLOYER=0xb29e6735629539cEd64F0d6f0c476Fe92539fD7B
+BANKROLL=0x33C5B6a95e71611F5dC821A74DDAD0F746fF2dFf
+MINBET=1000000000000000
+MAXBET=2000000000000000
+CLIMB_MAX_PAYOUT=1000000000000000000
+
+# CasinoBankroll
+forge verify-contract \
+  --chain monad-testnet \
+  --etherscan-api-key "$MONAD_ETHERSCAN_KEY" \
+  --watch \
+  --constructor-args "$(cast abi-encode 'constructor(address)' "$DEPLOYER")" \
+  "$BANKROLL" \
+  src/CasinoBankroll.sol:CasinoBankroll
+
+# CosmicFlip
+forge verify-contract \
+  --chain monad-testnet \
+  --etherscan-api-key "$MONAD_ETHERSCAN_KEY" \
+  --watch \
+  --constructor-args "$(cast abi-encode 'constructor(address,address,uint256,uint256)' \
+      "$DEPLOYER" "$BANKROLL" "$MINBET" "$MAXBET")" \
+  0x064b8bfc03b23D2b525deD9d3969090347A21983 \
+  src/CosmicFlip.sol:CosmicFlip
+
+# GravityDice
+forge verify-contract \
+  --chain monad-testnet \
+  --etherscan-api-key "$MONAD_ETHERSCAN_KEY" \
+  --watch \
+  --constructor-args "$(cast abi-encode 'constructor(address,address,uint256,uint256)' \
+      "$DEPLOYER" "$BANKROLL" "$MINBET" "$MAXBET")" \
+  0xAC023542A8168465EE4A1b3e8Ae0f58F36A6d84B \
+  src/GravityDice.sol:GravityDice
+
+# ConstellationClimb
+forge verify-contract \
+  --chain monad-testnet \
+  --etherscan-api-key "$MONAD_ETHERSCAN_KEY" \
+  --watch \
+  --constructor-args "$(cast abi-encode 'constructor(address,address,uint256,uint256,uint256)' \
+      "$DEPLOYER" "$BANKROLL" "$MINBET" "$MAXBET" "$CLIMB_MAX_PAYOUT")" \
+  0xd9B9b6c37ad4f3D5b07ae76dE261c5C865600d6e \
+  src/ConstellationClimb.sol:ConstellationClimb
+```
+
+`--watch` blocks until Monadscan returns "Pass — Verified" or rejects the
+submission; expected verified URLs:
+
+- https://testnet.monadscan.com/address/0x33C5B6a95e71611F5dC821A74DDAD0F746fF2dFf#code
+- https://testnet.monadscan.com/address/0x064b8bfc03b23D2b525deD9d3969090347A21983#code
+- https://testnet.monadscan.com/address/0xAC023542A8168465EE4A1b3e8Ae0f58F36A6d84B#code
+- https://testnet.monadscan.com/address/0xd9B9b6c37ad4f3D5b07ae76dE261c5C865600d6e#code
+
+If any of the `CASINO_*` env vars were overridden in a particular broadcast
+(re-deploys or operator forks), recover the as-deployed constructor calldata
+straight from the deploy transaction instead: read the `input` field of the
+CREATE3-deployer call (e.g. `cast tx --rpc-url $MONAD_TESTNET_RPC <txhash>`),
+strip the contract creation code prefix, and pass the trailing ABI-encoded
+tail as `--constructor-args`.
+
+### Flattened sources fallback
+
+Run from `contracts/casino/`:
+
+```bash
+mkdir -p flattened
+forge flatten src/CasinoBankroll.sol     --output flattened/CasinoBankroll.flat.sol
+forge flatten src/CosmicFlip.sol         --output flattened/CosmicFlip.flat.sol
+forge flatten src/GravityDice.sol        --output flattened/GravityDice.flat.sol
+forge flatten src/ConstellationClimb.sol --output flattened/ConstellationClimb.flat.sol
+```
+
+The committed copies under `flattened/` were produced with `forge 1.6.0`
+against `solc 0.8.24` (the version pinned in `foundry.toml`). Upload them as
+"single file" submissions on the explorer's manual verification UI with the
+same compiler version, EVM target `cancun`, optimizer enabled, runs `200`,
+and the constructor-args bytes from the verify commands above.
+
+#### Why ship flattened sources now
+
+At the time `10143.json` was deployed, attempting to run the verify commands
+above without a provisioned `MONAD_ETHERSCAN_KEY` returns
+`Invalid API Key` from the Monadscan endpoint (the testnet explorer's API
+gate rejects unauthenticated submissions). The flattened sources let any
+third party reproduce and audit the deployed bytecode without depending on
+the explorer's API at all — drop the corresponding `.flat.sol` into Remix or
+`solc --standard-json` with the pinned compiler settings to reproduce the
+on-chain bytecode.
+
 ## Heritage
 
 The 8-contract BunnyBagz suite (Foundry, Halmos, Medusa, OpenZeppelin Defender

--- a/contracts/casino/flattened/CasinoBankroll.flat.sol
+++ b/contracts/casino/flattened/CasinoBankroll.flat.sol
@@ -1,0 +1,673 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20 ^0.8.24;
+
+// lib/openzeppelin-contracts/contracts/utils/Context.sol
+
+// OpenZeppelin Contracts (last updated v5.0.1) (utils/Context.sol)
+
+/**
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes calldata) {
+        return msg.data;
+    }
+
+    function _contextSuffixLength() internal view virtual returns (uint256) {
+        return 0;
+    }
+}
+
+// lib/openzeppelin-contracts/contracts/utils/ReentrancyGuard.sol
+
+// OpenZeppelin Contracts (last updated v5.0.0) (utils/ReentrancyGuard.sol)
+
+/**
+ * @dev Contract module that helps prevent reentrant calls to a function.
+ *
+ * Inheriting from `ReentrancyGuard` will make the {nonReentrant} modifier
+ * available, which can be applied to functions to make sure there are no nested
+ * (reentrant) calls to them.
+ *
+ * Note that because there is a single `nonReentrant` guard, functions marked as
+ * `nonReentrant` may not call one another. This can be worked around by making
+ * those functions `private`, and then adding `external` `nonReentrant` entry
+ * points to them.
+ *
+ * TIP: If you would like to learn more about reentrancy and alternative ways
+ * to protect against it, check out our blog post
+ * https://blog.openzeppelin.com/reentrancy-after-istanbul/[Reentrancy After Istanbul].
+ */
+abstract contract ReentrancyGuard {
+    // Booleans are more expensive than uint256 or any type that takes up a full
+    // word because each write operation emits an extra SLOAD to first read the
+    // slot's contents, replace the bits taken up by the boolean, and then write
+    // back. This is the compiler's defense against contract upgrades and
+    // pointer aliasing, and it cannot be disabled.
+
+    // The values being non-zero value makes deployment a bit more expensive,
+    // but in exchange the refund on every call to nonReentrant will be lower in
+    // amount. Since refunds are capped to a percentage of the total
+    // transaction's gas, it is best to keep them low in cases like this one, to
+    // increase the likelihood of the full refund coming into effect.
+    uint256 private constant NOT_ENTERED = 1;
+    uint256 private constant ENTERED = 2;
+
+    uint256 private _status;
+
+    /**
+     * @dev Unauthorized reentrant call.
+     */
+    error ReentrancyGuardReentrantCall();
+
+    constructor() {
+        _status = NOT_ENTERED;
+    }
+
+    /**
+     * @dev Prevents a contract from calling itself, directly or indirectly.
+     * Calling a `nonReentrant` function from another `nonReentrant`
+     * function is not supported. It is possible to prevent this from happening
+     * by making the `nonReentrant` function external, and making it call a
+     * `private` function that does the actual work.
+     */
+    modifier nonReentrant() {
+        _nonReentrantBefore();
+        _;
+        _nonReentrantAfter();
+    }
+
+    function _nonReentrantBefore() private {
+        // On the first call to nonReentrant, _status will be NOT_ENTERED
+        if (_status == ENTERED) {
+            revert ReentrancyGuardReentrantCall();
+        }
+
+        // Any calls to nonReentrant after this point will fail
+        _status = ENTERED;
+    }
+
+    function _nonReentrantAfter() private {
+        // By storing the original value once again, a refund is triggered (see
+        // https://eips.ethereum.org/EIPS/eip-2200)
+        _status = NOT_ENTERED;
+    }
+
+    /**
+     * @dev Returns true if the reentrancy guard is currently set to "entered", which indicates there is a
+     * `nonReentrant` function in the call stack.
+     */
+    function _reentrancyGuardEntered() internal view returns (bool) {
+        return _status == ENTERED;
+    }
+}
+
+// lib/openzeppelin-contracts/contracts/access/Ownable.sol
+
+// OpenZeppelin Contracts (last updated v5.0.0) (access/Ownable.sol)
+
+/**
+ * @dev Contract module which provides a basic access control mechanism, where
+ * there is an account (an owner) that can be granted exclusive access to
+ * specific functions.
+ *
+ * The initial owner is set to the address provided by the deployer. This can
+ * later be changed with {transferOwnership}.
+ *
+ * This module is used through inheritance. It will make available the modifier
+ * `onlyOwner`, which can be applied to your functions to restrict their use to
+ * the owner.
+ */
+abstract contract Ownable is Context {
+    address private _owner;
+
+    /**
+     * @dev The caller account is not authorized to perform an operation.
+     */
+    error OwnableUnauthorizedAccount(address account);
+
+    /**
+     * @dev The owner is not a valid owner account. (eg. `address(0)`)
+     */
+    error OwnableInvalidOwner(address owner);
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev Initializes the contract setting the address provided by the deployer as the initial owner.
+     */
+    constructor(address initialOwner) {
+        if (initialOwner == address(0)) {
+            revert OwnableInvalidOwner(address(0));
+        }
+        _transferOwnership(initialOwner);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        _checkOwner();
+        _;
+    }
+
+    /**
+     * @dev Returns the address of the current owner.
+     */
+    function owner() public view virtual returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Throws if the sender is not the owner.
+     */
+    function _checkOwner() internal view virtual {
+        if (owner() != _msgSender()) {
+            revert OwnableUnauthorizedAccount(_msgSender());
+        }
+    }
+
+    /**
+     * @dev Leaves the contract without owner. It will not be possible to call
+     * `onlyOwner` functions. Can only be called by the current owner.
+     *
+     * NOTE: Renouncing ownership will leave the contract without an owner,
+     * thereby disabling any functionality that is only available to the owner.
+     */
+    function renounceOwnership() public virtual onlyOwner {
+        _transferOwnership(address(0));
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Can only be called by the current owner.
+     */
+    function transferOwnership(address newOwner) public virtual onlyOwner {
+        if (newOwner == address(0)) {
+            revert OwnableInvalidOwner(address(0));
+        }
+        _transferOwnership(newOwner);
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Internal function without access restriction.
+     */
+    function _transferOwnership(address newOwner) internal virtual {
+        address oldOwner = _owner;
+        _owner = newOwner;
+        emit OwnershipTransferred(oldOwner, newOwner);
+    }
+}
+
+// lib/openzeppelin-contracts/contracts/utils/Pausable.sol
+
+// OpenZeppelin Contracts (last updated v5.0.0) (utils/Pausable.sol)
+
+/**
+ * @dev Contract module which allows children to implement an emergency stop
+ * mechanism that can be triggered by an authorized account.
+ *
+ * This module is used through inheritance. It will make available the
+ * modifiers `whenNotPaused` and `whenPaused`, which can be applied to
+ * the functions of your contract. Note that they will not be pausable by
+ * simply including this module, only once the modifiers are put in place.
+ */
+abstract contract Pausable is Context {
+    bool private _paused;
+
+    /**
+     * @dev Emitted when the pause is triggered by `account`.
+     */
+    event Paused(address account);
+
+    /**
+     * @dev Emitted when the pause is lifted by `account`.
+     */
+    event Unpaused(address account);
+
+    /**
+     * @dev The operation failed because the contract is paused.
+     */
+    error EnforcedPause();
+
+    /**
+     * @dev The operation failed because the contract is not paused.
+     */
+    error ExpectedPause();
+
+    /**
+     * @dev Initializes the contract in unpaused state.
+     */
+    constructor() {
+        _paused = false;
+    }
+
+    /**
+     * @dev Modifier to make a function callable only when the contract is not paused.
+     *
+     * Requirements:
+     *
+     * - The contract must not be paused.
+     */
+    modifier whenNotPaused() {
+        _requireNotPaused();
+        _;
+    }
+
+    /**
+     * @dev Modifier to make a function callable only when the contract is paused.
+     *
+     * Requirements:
+     *
+     * - The contract must be paused.
+     */
+    modifier whenPaused() {
+        _requirePaused();
+        _;
+    }
+
+    /**
+     * @dev Returns true if the contract is paused, and false otherwise.
+     */
+    function paused() public view virtual returns (bool) {
+        return _paused;
+    }
+
+    /**
+     * @dev Throws if the contract is paused.
+     */
+    function _requireNotPaused() internal view virtual {
+        if (paused()) {
+            revert EnforcedPause();
+        }
+    }
+
+    /**
+     * @dev Throws if the contract is not paused.
+     */
+    function _requirePaused() internal view virtual {
+        if (!paused()) {
+            revert ExpectedPause();
+        }
+    }
+
+    /**
+     * @dev Triggers stopped state.
+     *
+     * Requirements:
+     *
+     * - The contract must not be paused.
+     */
+    function _pause() internal virtual whenNotPaused {
+        _paused = true;
+        emit Paused(_msgSender());
+    }
+
+    /**
+     * @dev Returns to normal state.
+     *
+     * Requirements:
+     *
+     * - The contract must be paused.
+     */
+    function _unpause() internal virtual whenPaused {
+        _paused = false;
+        emit Unpaused(_msgSender());
+    }
+}
+
+// src/CasinoBankroll.sol
+
+/// @title CasinoBankroll
+/// @notice Single shared liquidity pool for every Cosmic Casino game contract.
+/// @dev    Phase 0–2: 1/1 owner. Phase 3 migrates owner to a 3-of-5 multisig.
+///         Per-game allowance prevents one buggy game from draining the rest.
+///         Native MON only in Phase 1; ERC-20 layouts can mirror this per-token.
+///
+///         Phase 3 layers a *drawdown* circuit-breaker on top of the simple
+///         `Pausable` switch. The breaker tracks a rolling 24h window: the
+///         balance at window-start is recorded, and any net outflow ≥
+///         `maxDrawdown24hWei` within that window auto-trips `halted = true`.
+///         While halted, `payout()` reverts with `CircuitBreakerHalted`. The
+///         `settle()` path stays open so games can still credit losses to the
+///         bankroll. The breaker can be tripped manually by the owner and
+///         auto-resets after `CIRCUIT_BREAKER_COOLDOWN`.
+contract CasinoBankroll is Ownable, Pausable, ReentrancyGuard {
+    /// @dev Per-game native-token allowance (in wei). Game contracts can only
+    ///      pull payouts up to this value; refilled by the owner.
+    mapping(address => uint256) public allowanceOf;
+
+    /// @dev Set true once a game is registered; allows quick membership checks
+    ///      without ambiguity at allowance == 0.
+    mapping(address => bool) public isGame;
+
+    /// @notice 24h rolling window for drawdown tracking and post-trip cooldown.
+    uint256 public constant CIRCUIT_BREAKER_COOLDOWN = 24 hours;
+
+    /// @notice Drawdown circuit-breaker state. `maxDrawdown24hWei == 0` means
+    ///         the breaker is disabled (auto-trip skipped); manual `tripCircuitBreaker`
+    ///         still works regardless of the threshold.
+    struct CircuitBreaker {
+        uint256 maxDrawdown24hWei;
+        uint256 windowStartBalance;
+        uint256 windowStartedAt;
+        uint256 drawdownStartedAt;
+        bool halted;
+    }
+
+    CircuitBreaker public circuitBreaker;
+
+    event GameRegistered(address indexed game, uint256 allowance);
+    event GameAllowanceSet(address indexed game, uint256 allowance);
+    event GameRevoked(address indexed game);
+
+    event Deposited(address indexed from, uint256 amount);
+    event Withdrawn(address indexed to, uint256 amount);
+
+    /// @notice Game pulled `amount` to fund a payout to `recipient`.
+    event GamePayout(address indexed game, address indexed recipient, uint256 amount);
+    /// @notice Game returned a stake (loss / refund credit) of `amount`.
+    event GameSettled(address indexed game, uint256 amount);
+
+    /// @notice Circuit-breaker tripped (manually or by drawdown threshold).
+    event CircuitBreakerTripped(
+        uint256 windowStartBalance,
+        uint256 currentBalance,
+        uint256 maxDrawdown24hWei,
+        uint256 timestamp
+    );
+    /// @notice Circuit-breaker reset (cooldown elapsed or owner-driven).
+    event CircuitBreakerReset(uint256 currentBalance, uint256 timestamp);
+    /// @notice Drawdown threshold updated.
+    event CircuitBreakerThresholdSet(uint256 maxDrawdown24hWei);
+    /// @notice Rolling 24h window rolled forward.
+    event CircuitBreakerWindowRolled(uint256 newWindowStartBalance, uint256 timestamp);
+
+    error NotGame();
+    error AllowanceExceeded(uint256 requested, uint256 available);
+    error ZeroAddress();
+    error ZeroAmount();
+    error TransferFailed();
+    error CircuitBreakerHalted();
+    error CircuitBreakerNotHalted();
+    error CooldownNotElapsed(uint256 readyAt);
+
+    modifier onlyGame() {
+        if (!isGame[msg.sender]) revert NotGame();
+        _;
+    }
+
+    /// @notice Reverts when the drawdown breaker is currently tripped. Performs
+    ///         a best-effort auto-reset (cooldown elapsed) and window-roll
+    ///         beforehand so callers don't have to.
+    modifier whenNotHalted() {
+        _maybeAutoReset();
+        _maybeRollWindow();
+        if (circuitBreaker.halted) revert CircuitBreakerHalted();
+        _;
+    }
+
+    constructor(address initialOwner) Ownable(initialOwner) {
+        circuitBreaker.windowStartedAt = block.timestamp;
+    }
+
+    // ---- Owner: lifecycle ----
+
+    /// @notice Register a new game contract with an initial native allowance.
+    function registerGame(address game, uint256 initialAllowance) external onlyOwner {
+        if (game == address(0)) revert ZeroAddress();
+        isGame[game] = true;
+        allowanceOf[game] = initialAllowance;
+        emit GameRegistered(game, initialAllowance);
+    }
+
+    /// @notice Set the native allowance for an existing game.
+    function setGameAllowance(address game, uint256 newAllowance) external onlyOwner {
+        if (!isGame[game]) revert NotGame();
+        allowanceOf[game] = newAllowance;
+        emit GameAllowanceSet(game, newAllowance);
+    }
+
+    /// @notice Revoke a game's ability to pull from the bankroll.
+    function revokeGame(address game) external onlyOwner {
+        if (!isGame[game]) revert NotGame();
+        isGame[game] = false;
+        allowanceOf[game] = 0;
+        emit GameRevoked(game);
+    }
+
+    /// @notice Owner pause (legacy circuit-breaker / emergency stop). Distinct
+    ///         from the drawdown circuit-breaker; both gate `payout()` and
+    ///         either alone is sufficient to block outflows.
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    function unpause() external onlyOwner {
+        _unpause();
+    }
+
+    // ---- Owner: drawdown circuit-breaker ----
+
+    /// @notice Set the 24h drawdown threshold (in wei). `0` disables auto-trip.
+    function setMaxDrawdown24hWei(uint256 newMax) external onlyOwner {
+        circuitBreaker.maxDrawdown24hWei = newMax;
+        emit CircuitBreakerThresholdSet(newMax);
+    }
+
+    /// @notice Manually trip the drawdown circuit-breaker. No-op if already halted.
+    function tripCircuitBreaker() external onlyOwner {
+        _trip();
+    }
+
+    /// @notice Force-reset the breaker even if the cooldown has not elapsed.
+    ///         Intended for the operator playbook on intentional false-positive
+    ///         trips (e.g. a planned high-roller payout that pierces the cap).
+    function resetCircuitBreaker() external onlyOwner {
+        if (!circuitBreaker.halted) revert CircuitBreakerNotHalted();
+        _reset();
+    }
+
+    /// @notice Permissionless cooldown poke — callable by anyone after the
+    ///         24h cooldown to clear the halt without the owner re-arming.
+    function pokeCircuitBreaker() external {
+        if (!circuitBreaker.halted) revert CircuitBreakerNotHalted();
+        uint256 readyAt = circuitBreaker.drawdownStartedAt + CIRCUIT_BREAKER_COOLDOWN;
+        if (block.timestamp < readyAt) revert CooldownNotElapsed(readyAt);
+        _reset();
+    }
+
+    /// @notice Bundled view of breaker state for indexers / monitors.
+    function circuitBreakerState()
+        external
+        view
+        returns (
+            uint256 maxDrawdown24hWei,
+            uint256 windowStartBalance,
+            uint256 windowStartedAt,
+            uint256 drawdownStartedAt,
+            bool halted,
+            uint256 currentBalance
+        )
+    {
+        CircuitBreaker memory c = circuitBreaker;
+        return (
+            c.maxDrawdown24hWei,
+            c.windowStartBalance,
+            c.windowStartedAt,
+            c.drawdownStartedAt,
+            c.halted,
+            address(this).balance
+        );
+    }
+
+    // ---- Owner: liquidity ----
+
+    /// @notice Deposit native token into the bankroll.
+    function deposit() external payable {
+        if (msg.value == 0) revert ZeroAmount();
+        _bumpWindowStartIfFirst();
+        emit Deposited(msg.sender, msg.value);
+    }
+
+    /// @notice Owner withdraws native from the bankroll (e.g. seed adjustment).
+    function withdraw(address to, uint256 amount) external onlyOwner nonReentrant {
+        if (to == address(0)) revert ZeroAddress();
+        if (amount == 0) revert ZeroAmount();
+        (bool ok,) = to.call{value: amount}("");
+        if (!ok) revert TransferFailed();
+        emit Withdrawn(to, amount);
+    }
+
+    // ---- Game-only: payout / settle ----
+
+    /// @notice Pay `amount` to `recipient`, decrementing the caller's allowance.
+    /// @dev    Pausable: blocks payouts during a circuit-breaker; existing
+    ///         player refund paths remain on the game contract. The drawdown
+    ///         breaker is checked *before* the transfer (via `whenNotHalted`)
+    ///         and re-evaluated *predictively* against the post-payout balance
+    ///         — also before the external call — so a payout that crosses the
+    ///         threshold trips the breaker for the next caller. Trip-before-
+    ///         transfer preserves Checks-Effects-Interactions and closes any
+    ///         cross-function reentrancy surface around the breaker state.
+    function payout(address recipient, uint256 amount)
+        external
+        onlyGame
+        whenNotPaused
+        whenNotHalted
+        nonReentrant
+    {
+        if (recipient == address(0)) revert ZeroAddress();
+        if (amount == 0) revert ZeroAmount();
+        uint256 cur = allowanceOf[msg.sender];
+        if (amount > cur) revert AllowanceExceeded(amount, cur);
+        unchecked {
+            allowanceOf[msg.sender] = cur - amount;
+        }
+        // CEI: trip the breaker before the external transfer using the
+        // predicted post-payout balance. If the call reverts, the entire
+        // tx reverts and the trip unwinds.
+        _maybeAutoTrip(amount);
+        (bool ok,) = recipient.call{value: amount}("");
+        if (!ok) revert TransferFailed();
+        emit GamePayout(msg.sender, recipient, amount);
+    }
+
+    /// @notice Game forwards a settled stake (loss credit) into the bankroll.
+    /// @dev    Increases the caller's allowance by `msg.value` so wins/losses
+    ///         net within the per-game cap; bankroll grows on net player loss.
+    ///         Always open — the breaker stops outflows, not inflows.
+    function settle() external payable onlyGame {
+        if (msg.value == 0) revert ZeroAmount();
+        allowanceOf[msg.sender] += msg.value;
+        _bumpWindowStartIfFirst();
+        emit GameSettled(msg.sender, msg.value);
+    }
+
+    /// @notice Total native held in the bankroll.
+    function balance() external view returns (uint256) {
+        return address(this).balance;
+    }
+
+    /// @notice Plain receive accepts native and emits `Deposited` so direct sends
+    ///         are visible to the indexer (matches `deposit()` semantics).
+    receive() external payable {
+        _bumpWindowStartIfFirst();
+        emit Deposited(msg.sender, msg.value);
+    }
+
+    // ---- internal: circuit-breaker helpers ----
+
+    /// @dev If the rolling window has expired and the breaker is *not* halted,
+    ///      snapshot the current balance as the new window start. Halted
+    ///      windows freeze until `_reset()` to preserve the trip context.
+    function _maybeRollWindow() internal {
+        if (circuitBreaker.halted) return;
+        if (block.timestamp >= circuitBreaker.windowStartedAt + CIRCUIT_BREAKER_COOLDOWN) {
+            circuitBreaker.windowStartBalance = address(this).balance;
+            circuitBreaker.windowStartedAt = block.timestamp;
+            emit CircuitBreakerWindowRolled(circuitBreaker.windowStartBalance, block.timestamp);
+        }
+    }
+
+    /// @dev Auto-reset if the cooldown since trip has elapsed.
+    function _maybeAutoReset() internal {
+        if (!circuitBreaker.halted) return;
+        if (block.timestamp >= circuitBreaker.drawdownStartedAt + CIRCUIT_BREAKER_COOLDOWN) {
+            _reset();
+        }
+    }
+
+    /// @dev Common reset path: clears halt, re-anchors the rolling window at
+    ///      the current balance/timestamp.
+    function _reset() internal {
+        circuitBreaker.halted = false;
+        circuitBreaker.drawdownStartedAt = 0;
+        circuitBreaker.windowStartBalance = address(this).balance;
+        circuitBreaker.windowStartedAt = block.timestamp;
+        emit CircuitBreakerReset(circuitBreaker.windowStartBalance, block.timestamp);
+    }
+
+    /// @dev Trip the breaker. Idempotent: if already halted, just emit nothing.
+    ///      Manual entry-point reads the live balance.
+    function _trip() internal {
+        _trip(address(this).balance);
+    }
+
+    /// @dev Trip the breaker reporting `currentBalance` in the event payload.
+    ///      Used by the predictive auto-trip path so the event reflects the
+    ///      post-payout balance even when called *before* the external send.
+    function _trip(uint256 currentBalance) internal {
+        if (circuitBreaker.halted) return;
+        circuitBreaker.halted = true;
+        circuitBreaker.drawdownStartedAt = block.timestamp;
+        emit CircuitBreakerTripped(
+            circuitBreaker.windowStartBalance,
+            currentBalance,
+            circuitBreaker.maxDrawdown24hWei,
+            block.timestamp
+        );
+    }
+
+    /// @dev Auto-trip if the drawdown that *would* result from a pending
+    ///      outflow of `pendingOutflow` wei has crossed the configured
+    ///      threshold within the current 24h window. Called BEFORE the
+    ///      external transfer so the breaker is set without violating CEI.
+    ///      Skipped when the threshold is 0 (disabled) or the predicted
+    ///      post-outflow balance would still be ≥ window-start.
+    function _maybeAutoTrip(uint256 pendingOutflow) internal {
+        uint256 max = circuitBreaker.maxDrawdown24hWei;
+        if (max == 0) return;
+        uint256 startBal = circuitBreaker.windowStartBalance;
+        uint256 cur = address(this).balance;
+        if (cur < pendingOutflow) return;
+        uint256 postBal = cur - pendingOutflow;
+        if (startBal <= postBal) return;
+        uint256 drop = startBal - postBal;
+        if (drop >= max) _trip(postBal);
+    }
+
+    /// @dev Capture the first non-zero balance as the window-start baseline so
+    ///      the breaker has something to compare against on the very first
+    ///      payout. Cheap no-op once anchored.
+    function _bumpWindowStartIfFirst() internal {
+        if (circuitBreaker.windowStartBalance == 0 && !circuitBreaker.halted) {
+            circuitBreaker.windowStartBalance = address(this).balance;
+            if (circuitBreaker.windowStartedAt == 0) {
+                circuitBreaker.windowStartedAt = block.timestamp;
+            }
+        }
+    }
+}

--- a/contracts/casino/flattened/ConstellationClimb.flat.sol
+++ b/contracts/casino/flattened/ConstellationClimb.flat.sol
@@ -1,0 +1,761 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20 ^0.8.24;
+
+// src/CommitRevealRandomness.sol
+
+/// @title CommitRevealRandomness
+/// @notice Stateless commit-reveal helpers shared by every Cosmic Casino game.
+/// @dev    Mirrors the off-chain verify layer byte-for-byte. Test vectors in
+///         both layers MUST agree, or settlement is broken. No state, no
+///         events, no external calls — just three pure functions.
+///
+///         Hash schema (also enforced off-chain):
+///             outcomeHash = keccak256(abi.encodePacked(serverSeed, clientSeed, nonce))
+///             commit      = keccak256(abi.encodePacked(serverSeed))
+library CommitRevealRandomness {
+    /// @notice Compute the raw outcome hash for a single bet/step.
+    function outcomeHash(bytes32 serverSeed, bytes32 clientSeed, uint256 nonce)
+        internal
+        pure
+        returns (bytes32)
+    {
+        return keccak256(abi.encodePacked(serverSeed, clientSeed, nonce));
+    }
+
+    /// @notice Reduce an outcome hash to a uniform integer in [0, mod).
+    /// @dev    Modulo bias is negligible while `mod` ≪ 2^256.
+    function outcomeFromHash(bytes32 hash, uint256 mod) internal pure returns (uint256) {
+        require(mod > 0, "CommitRevealRandomness: mod=0");
+        return uint256(hash) % mod;
+    }
+
+    /// @notice Verify that `serverSeed` matches a previously published `commit`.
+    function verifyCommit(bytes32 serverSeed, bytes32 commit) internal pure returns (bool) {
+        return keccak256(abi.encodePacked(serverSeed)) == commit;
+    }
+
+    /// @notice Convenience: derive a uniform `[0, mod)` outcome end-to-end.
+    function rollOutcome(bytes32 serverSeed, bytes32 clientSeed, uint256 nonce, uint256 mod)
+        internal
+        pure
+        returns (uint256)
+    {
+        return outcomeFromHash(outcomeHash(serverSeed, clientSeed, nonce), mod);
+    }
+}
+
+// lib/openzeppelin-contracts/contracts/utils/Context.sol
+
+// OpenZeppelin Contracts (last updated v5.0.1) (utils/Context.sol)
+
+/**
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes calldata) {
+        return msg.data;
+    }
+
+    function _contextSuffixLength() internal view virtual returns (uint256) {
+        return 0;
+    }
+}
+
+// lib/openzeppelin-contracts/contracts/utils/ReentrancyGuard.sol
+
+// OpenZeppelin Contracts (last updated v5.0.0) (utils/ReentrancyGuard.sol)
+
+/**
+ * @dev Contract module that helps prevent reentrant calls to a function.
+ *
+ * Inheriting from `ReentrancyGuard` will make the {nonReentrant} modifier
+ * available, which can be applied to functions to make sure there are no nested
+ * (reentrant) calls to them.
+ *
+ * Note that because there is a single `nonReentrant` guard, functions marked as
+ * `nonReentrant` may not call one another. This can be worked around by making
+ * those functions `private`, and then adding `external` `nonReentrant` entry
+ * points to them.
+ *
+ * TIP: If you would like to learn more about reentrancy and alternative ways
+ * to protect against it, check out our blog post
+ * https://blog.openzeppelin.com/reentrancy-after-istanbul/[Reentrancy After Istanbul].
+ */
+abstract contract ReentrancyGuard {
+    // Booleans are more expensive than uint256 or any type that takes up a full
+    // word because each write operation emits an extra SLOAD to first read the
+    // slot's contents, replace the bits taken up by the boolean, and then write
+    // back. This is the compiler's defense against contract upgrades and
+    // pointer aliasing, and it cannot be disabled.
+
+    // The values being non-zero value makes deployment a bit more expensive,
+    // but in exchange the refund on every call to nonReentrant will be lower in
+    // amount. Since refunds are capped to a percentage of the total
+    // transaction's gas, it is best to keep them low in cases like this one, to
+    // increase the likelihood of the full refund coming into effect.
+    uint256 private constant NOT_ENTERED = 1;
+    uint256 private constant ENTERED = 2;
+
+    uint256 private _status;
+
+    /**
+     * @dev Unauthorized reentrant call.
+     */
+    error ReentrancyGuardReentrantCall();
+
+    constructor() {
+        _status = NOT_ENTERED;
+    }
+
+    /**
+     * @dev Prevents a contract from calling itself, directly or indirectly.
+     * Calling a `nonReentrant` function from another `nonReentrant`
+     * function is not supported. It is possible to prevent this from happening
+     * by making the `nonReentrant` function external, and making it call a
+     * `private` function that does the actual work.
+     */
+    modifier nonReentrant() {
+        _nonReentrantBefore();
+        _;
+        _nonReentrantAfter();
+    }
+
+    function _nonReentrantBefore() private {
+        // On the first call to nonReentrant, _status will be NOT_ENTERED
+        if (_status == ENTERED) {
+            revert ReentrancyGuardReentrantCall();
+        }
+
+        // Any calls to nonReentrant after this point will fail
+        _status = ENTERED;
+    }
+
+    function _nonReentrantAfter() private {
+        // By storing the original value once again, a refund is triggered (see
+        // https://eips.ethereum.org/EIPS/eip-2200)
+        _status = NOT_ENTERED;
+    }
+
+    /**
+     * @dev Returns true if the reentrancy guard is currently set to "entered", which indicates there is a
+     * `nonReentrant` function in the call stack.
+     */
+    function _reentrancyGuardEntered() internal view returns (bool) {
+        return _status == ENTERED;
+    }
+}
+
+// lib/openzeppelin-contracts/contracts/access/Ownable.sol
+
+// OpenZeppelin Contracts (last updated v5.0.0) (access/Ownable.sol)
+
+/**
+ * @dev Contract module which provides a basic access control mechanism, where
+ * there is an account (an owner) that can be granted exclusive access to
+ * specific functions.
+ *
+ * The initial owner is set to the address provided by the deployer. This can
+ * later be changed with {transferOwnership}.
+ *
+ * This module is used through inheritance. It will make available the modifier
+ * `onlyOwner`, which can be applied to your functions to restrict their use to
+ * the owner.
+ */
+abstract contract Ownable is Context {
+    address private _owner;
+
+    /**
+     * @dev The caller account is not authorized to perform an operation.
+     */
+    error OwnableUnauthorizedAccount(address account);
+
+    /**
+     * @dev The owner is not a valid owner account. (eg. `address(0)`)
+     */
+    error OwnableInvalidOwner(address owner);
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev Initializes the contract setting the address provided by the deployer as the initial owner.
+     */
+    constructor(address initialOwner) {
+        if (initialOwner == address(0)) {
+            revert OwnableInvalidOwner(address(0));
+        }
+        _transferOwnership(initialOwner);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        _checkOwner();
+        _;
+    }
+
+    /**
+     * @dev Returns the address of the current owner.
+     */
+    function owner() public view virtual returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Throws if the sender is not the owner.
+     */
+    function _checkOwner() internal view virtual {
+        if (owner() != _msgSender()) {
+            revert OwnableUnauthorizedAccount(_msgSender());
+        }
+    }
+
+    /**
+     * @dev Leaves the contract without owner. It will not be possible to call
+     * `onlyOwner` functions. Can only be called by the current owner.
+     *
+     * NOTE: Renouncing ownership will leave the contract without an owner,
+     * thereby disabling any functionality that is only available to the owner.
+     */
+    function renounceOwnership() public virtual onlyOwner {
+        _transferOwnership(address(0));
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Can only be called by the current owner.
+     */
+    function transferOwnership(address newOwner) public virtual onlyOwner {
+        if (newOwner == address(0)) {
+            revert OwnableInvalidOwner(address(0));
+        }
+        _transferOwnership(newOwner);
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Internal function without access restriction.
+     */
+    function _transferOwnership(address newOwner) internal virtual {
+        address oldOwner = _owner;
+        _owner = newOwner;
+        emit OwnershipTransferred(oldOwner, newOwner);
+    }
+}
+
+// lib/openzeppelin-contracts/contracts/utils/Pausable.sol
+
+// OpenZeppelin Contracts (last updated v5.0.0) (utils/Pausable.sol)
+
+/**
+ * @dev Contract module which allows children to implement an emergency stop
+ * mechanism that can be triggered by an authorized account.
+ *
+ * This module is used through inheritance. It will make available the
+ * modifiers `whenNotPaused` and `whenPaused`, which can be applied to
+ * the functions of your contract. Note that they will not be pausable by
+ * simply including this module, only once the modifiers are put in place.
+ */
+abstract contract Pausable is Context {
+    bool private _paused;
+
+    /**
+     * @dev Emitted when the pause is triggered by `account`.
+     */
+    event Paused(address account);
+
+    /**
+     * @dev Emitted when the pause is lifted by `account`.
+     */
+    event Unpaused(address account);
+
+    /**
+     * @dev The operation failed because the contract is paused.
+     */
+    error EnforcedPause();
+
+    /**
+     * @dev The operation failed because the contract is not paused.
+     */
+    error ExpectedPause();
+
+    /**
+     * @dev Initializes the contract in unpaused state.
+     */
+    constructor() {
+        _paused = false;
+    }
+
+    /**
+     * @dev Modifier to make a function callable only when the contract is not paused.
+     *
+     * Requirements:
+     *
+     * - The contract must not be paused.
+     */
+    modifier whenNotPaused() {
+        _requireNotPaused();
+        _;
+    }
+
+    /**
+     * @dev Modifier to make a function callable only when the contract is paused.
+     *
+     * Requirements:
+     *
+     * - The contract must be paused.
+     */
+    modifier whenPaused() {
+        _requirePaused();
+        _;
+    }
+
+    /**
+     * @dev Returns true if the contract is paused, and false otherwise.
+     */
+    function paused() public view virtual returns (bool) {
+        return _paused;
+    }
+
+    /**
+     * @dev Throws if the contract is paused.
+     */
+    function _requireNotPaused() internal view virtual {
+        if (paused()) {
+            revert EnforcedPause();
+        }
+    }
+
+    /**
+     * @dev Throws if the contract is not paused.
+     */
+    function _requirePaused() internal view virtual {
+        if (!paused()) {
+            revert ExpectedPause();
+        }
+    }
+
+    /**
+     * @dev Triggers stopped state.
+     *
+     * Requirements:
+     *
+     * - The contract must not be paused.
+     */
+    function _pause() internal virtual whenNotPaused {
+        _paused = true;
+        emit Paused(_msgSender());
+    }
+
+    /**
+     * @dev Returns to normal state.
+     *
+     * Requirements:
+     *
+     * - The contract must be paused.
+     */
+    function _unpause() internal virtual whenPaused {
+        _paused = false;
+        emit Unpaused(_msgSender());
+    }
+}
+
+// src/ConstellationClimb.sol
+
+interface ICasinoBankroll {
+    function payout(address recipient, uint256 amount) external;
+    function settle() external payable;
+}
+
+interface ICasinoAllowlist {
+    function enforceAccess(address player) external view;
+}
+
+/// @title ConstellationClimb
+/// @notice Phase 2 solo Hi-Lo for the Cosmic Casino, re-themed as climbing
+///         the constellation: each correct call raises the player one rung
+///         up the cosmic ladder, compounding the multiplier. A loss forfeits
+///         the stake; a tie is a "push" — the stake is returned and the
+///         session ends with multiplier-1.0×.
+/// @dev    Lifecycle:
+///           1. Off-chain: seed manager publishes `commit = keccak(serverSeed)`
+///              for the FIRST step. A new commit is supplied at every play step
+///              for the next round.
+///           2. Player calls `openSession(clientSeed, serverCommit)` and locks
+///              stake. Initial card is derived deterministically from
+///              `keccak(clientSeed, INIT_TAG)` — no server seed required for
+///              the open card; the multiplier starts at 1.0× (WAD).
+///           3. Player calls `playStep(direction, serverReveal, nextCommit)`.
+///                - WIN: compounds the multiplier and the session stays Open.
+///                - LOSS: transitions to Lost; stake forwarded to bankroll.
+///                - PUSH (newCard == currentCard): transitions to Pushed; the
+///                  stake is returned to the player; bankroll untouched.
+///           4. Player calls `cashOut` to claim `bet * multiplier`, or
+///              `refundSession` if the keeper stops responding past expiry.
+contract ConstellationClimb is Ownable, Pausable, ReentrancyGuard {
+    enum Direction {
+        Higher, // 0 — bet that next card > currentCard
+        Lower // 1 — bet that next card < currentCard
+    }
+
+    enum Status {
+        None, // 0 — slot empty
+        Open, // 1 — accepting playStep / cashOut
+        CashedOut, // 2 — player cashed out for `bet * multiplier`
+        Lost, // 3 — settled, player forfeited stake (lose path)
+        Refunded, // 4 — expired without resolution; stake returned
+        Pushed // 5 — tie on a playStep; stake returned, session ended
+    }
+
+    struct Session {
+        address player;
+        uint96 bet; // wei locked at open
+        bytes32 clientSeed;
+        bytes32 serverCommit; // rotates per playStep — points at NEXT step's reveal
+        uint64 lastBlock; // last action block (open or step) — basis for expiry
+        uint8 currentCard; // 1..13
+        Status status;
+        uint8 stepCount; // # of completed playSteps
+        uint256 currentMultiplier; // wad-scaled cumulative multiplier (1e18 = 1.0x)
+        uint256 nonce; // per-session nonce mixed into rollOutcome
+    }
+
+    /// @notice Number of blocks after which an idle Open session can be refunded.
+    /// @dev    256 blocks ≈ ~2 min on Monad (~500ms blocks).
+    uint64 public constant EXPIRY_BLOCKS = 256;
+
+    /// @notice Wad scale for `currentMultiplier`. 1e18 == 1.0×.
+    uint256 public constant WAD = 1e18;
+
+    /// @notice Card domain — one standard 13-rank deck per step, with replacement.
+    uint256 public constant CARD_MOD = 13;
+
+    /// @notice Numerator of the step-multiplier formula: 12 (deck-minus-current)
+    ///         times 99 (1% house multiplier).
+    uint256 public constant STEP_NUM = 12 * 99;
+
+    /// @notice Denominator of the step-multiplier formula: 100.
+    uint256 public constant STEP_DEN = 100;
+
+    /// @notice Domain separator that derives the open card from the clientSeed.
+    bytes32 internal constant INIT_TAG = bytes32(uint256(0xC0DECAFE));
+
+    /// @notice Hard ceiling on per-cashOut payout (wei). Owner-tunable.
+    uint256 public maxPayout;
+
+    /// @notice Minimum / maximum stake at openSession.
+    uint256 public minBet;
+    uint256 public maxBet;
+
+    ICasinoBankroll public immutable bankroll;
+
+    /// @notice Optional soft-launch allowlist.
+    ICasinoAllowlist public allowlist;
+
+    mapping(uint256 => Session) public sessions;
+    uint256 public nextSessionId;
+
+    /// @dev Per-player monotonic nonce.
+    mapping(address => uint256) public playerNonce;
+
+    /// @dev Single-use guard for every server commit ever bound by this game.
+    mapping(bytes32 => bool) public commitUsed;
+
+    event SessionOpened(
+        uint256 indexed sessionId,
+        address indexed player,
+        uint256 stake,
+        bytes32 clientSeed,
+        bytes32 serverCommit,
+        uint8 initialCard,
+        uint256 nonce,
+        uint64 blockOpened
+    );
+    event StepPlayed(
+        uint256 indexed sessionId,
+        address indexed player,
+        Direction direction,
+        uint8 prevCard,
+        uint8 newCard,
+        bool won,
+        uint256 newMultiplier,
+        bytes32 serverReveal,
+        bytes32 nextCommit
+    );
+    event SessionCashedOut(
+        uint256 indexed sessionId, address indexed player, uint256 payout, uint256 finalMultiplier
+    );
+    event SessionRefunded(uint256 indexed sessionId, address indexed player, uint256 stake);
+    event SessionPushed(
+        uint256 indexed sessionId,
+        address indexed player,
+        uint256 stake,
+        uint8 card,
+        uint256 multiplier
+    );
+
+    event MaxBetSet(uint256 oldMax, uint256 newMax);
+    event MinBetSet(uint256 oldMin, uint256 newMin);
+    event MaxPayoutSet(uint256 oldMax, uint256 newMax);
+    event AllowlistSet(address indexed allowlist);
+
+    error SessionNotFound();
+    error SessionNotOpen();
+    error SessionNotExpired();
+    error InvalidReveal();
+    error InvalidDirection();
+    error StakeOutOfBounds();
+    error PayoutExceedsCap();
+    error NotPlayer();
+    error ZeroAddress();
+    error CommitAlreadyUsed();
+    error ZeroCommit();
+    error NotAllowed();
+    error InvalidBetBounds();
+
+    constructor(
+        address initialOwner,
+        address bankrollAddr,
+        uint256 minBet_,
+        uint256 maxBet_,
+        uint256 maxPayout_
+    ) Ownable(initialOwner) {
+        if (bankrollAddr == address(0)) revert ZeroAddress();
+        bankroll = ICasinoBankroll(bankrollAddr);
+        minBet = minBet_;
+        maxBet = maxBet_;
+        maxPayout = maxPayout_;
+    }
+
+    // ---- Owner ----
+
+    function setBetBounds(uint256 newMin, uint256 newMax) external onlyOwner {
+        if (newMax < newMin) revert InvalidBetBounds();
+        if (newMax > type(uint96).max) revert InvalidBetBounds();
+        emit MinBetSet(minBet, newMin);
+        emit MaxBetSet(maxBet, newMax);
+        minBet = newMin;
+        maxBet = newMax;
+    }
+
+    function setMaxPayout(uint256 newMax) external onlyOwner {
+        emit MaxPayoutSet(maxPayout, newMax);
+        maxPayout = newMax;
+    }
+
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    function unpause() external onlyOwner {
+        _unpause();
+    }
+
+    function setAllowlist(address newAllowlist) external onlyOwner {
+        allowlist = ICasinoAllowlist(newAllowlist);
+        emit AllowlistSet(newAllowlist);
+    }
+
+    // ---- Player ----
+
+    function openSession(bytes32 clientSeed, bytes32 serverCommit)
+        external
+        payable
+        whenNotPaused
+        nonReentrant
+        returns (uint256 sessionId)
+    {
+        ICasinoAllowlist al = allowlist;
+        if (address(al) != address(0)) {
+            try al.enforceAccess(msg.sender) {}
+            catch {
+                revert NotAllowed();
+            }
+        }
+        if (msg.value < minBet || msg.value > maxBet) revert StakeOutOfBounds();
+        if (serverCommit == bytes32(0)) revert ZeroCommit();
+        if (commitUsed[serverCommit]) revert CommitAlreadyUsed();
+        commitUsed[serverCommit] = true;
+
+        sessionId = nextSessionId++;
+        uint256 nonce = playerNonce[msg.sender]++;
+
+        // forge-lint: disable-next-line(unsafe-typecast)
+        uint8 initialCard =
+            uint8(uint256(keccak256(abi.encodePacked(clientSeed, INIT_TAG))) % CARD_MOD) + 1;
+
+        sessions[sessionId] = Session({
+            player: msg.sender,
+            bet: uint96(msg.value),
+            clientSeed: clientSeed,
+            serverCommit: serverCommit,
+            lastBlock: uint64(block.number),
+            currentCard: initialCard,
+            status: Status.Open,
+            stepCount: 0,
+            currentMultiplier: WAD,
+            nonce: nonce
+        });
+
+        emit SessionOpened(
+            sessionId,
+            msg.sender,
+            msg.value,
+            clientSeed,
+            serverCommit,
+            initialCard,
+            nonce,
+            uint64(block.number)
+        );
+    }
+
+    function playStep(
+        uint256 sessionId,
+        Direction direction,
+        bytes32 serverReveal,
+        bytes32 nextCommit
+    ) external nonReentrant {
+        Session storage s = sessions[sessionId];
+        if (s.status == Status.None) revert SessionNotFound();
+        if (s.status != Status.Open) revert SessionNotOpen();
+        if (!CommitRevealRandomness.verifyCommit(serverReveal, s.serverCommit)) {
+            revert InvalidReveal();
+        }
+        if (nextCommit == bytes32(0)) revert ZeroCommit();
+        if (commitUsed[nextCommit]) revert CommitAlreadyUsed();
+        commitUsed[nextCommit] = true;
+
+        uint8 cur = s.currentCard;
+        if (direction == Direction.Higher && cur >= 13) revert InvalidDirection();
+        if (direction == Direction.Lower && cur <= 1) revert InvalidDirection();
+
+        uint256 stepNonce = s.nonce + uint256(s.stepCount) + 1;
+        uint8 newCard = uint8(
+            CommitRevealRandomness.rollOutcome(serverReveal, s.clientSeed, stepNonce, CARD_MOD) + 1
+        );
+
+        bool won;
+        uint256 newMult = s.currentMultiplier;
+        if (direction == Direction.Higher) {
+            won = newCard > cur;
+            if (won) {
+                newMult = (newMult * STEP_NUM) / ((CARD_MOD - uint256(cur)) * STEP_DEN);
+            }
+        } else {
+            won = newCard < cur;
+            if (won) {
+                newMult = (newMult * STEP_NUM) / ((uint256(cur) - 1) * STEP_DEN);
+            }
+        }
+
+        s.serverCommit = nextCommit;
+        s.lastBlock = uint64(block.number);
+        s.stepCount += 1;
+
+        emit StepPlayed(
+            sessionId, s.player, direction, cur, newCard, won, newMult, serverReveal, nextCommit
+        );
+
+        if (won) {
+            s.currentCard = newCard;
+            s.currentMultiplier = newMult;
+        } else if (newCard == cur) {
+            _settlePush(s, sessionId, cur, newMult);
+        } else {
+            s.status = Status.Lost;
+            bankroll.settle{value: uint256(s.bet)}();
+        }
+    }
+
+    function _settlePush(Session storage s, uint256 sessionId, uint8 card, uint256 mult) internal {
+        s.status = Status.Pushed;
+        uint256 stake = uint256(s.bet);
+        address payable player = payable(s.player);
+        (bool ok,) = player.call{value: stake}("");
+        if (!ok) revert("ConstellationClimb: push refund failed");
+        emit SessionPushed(sessionId, player, stake, card, mult);
+    }
+
+    function cashOut(uint256 sessionId) external nonReentrant {
+        Session storage s = sessions[sessionId];
+        if (s.status == Status.None) revert SessionNotFound();
+        if (s.status != Status.Open) revert SessionNotOpen();
+        if (msg.sender != s.player) revert NotPlayer();
+
+        uint256 payoutAmt = (uint256(s.bet) * s.currentMultiplier) / WAD;
+        if (maxPayout != 0 && payoutAmt > maxPayout) revert PayoutExceedsCap();
+
+        s.status = Status.CashedOut;
+        bankroll.settle{value: uint256(s.bet)}();
+        if (payoutAmt > 0) {
+            bankroll.payout(s.player, payoutAmt);
+        }
+        emit SessionCashedOut(sessionId, s.player, payoutAmt, s.currentMultiplier);
+    }
+
+    function refundSession(uint256 sessionId) external nonReentrant {
+        Session storage s = sessions[sessionId];
+        if (s.status == Status.None) revert SessionNotFound();
+        if (s.status != Status.Open) revert SessionNotOpen();
+        if (msg.sender != s.player) revert NotPlayer();
+        if (block.number < uint256(s.lastBlock) + EXPIRY_BLOCKS) revert SessionNotExpired();
+
+        uint256 stake = uint256(s.bet);
+        s.status = Status.Refunded;
+        (bool ok,) = s.player.call{value: stake}("");
+        if (!ok) revert("ConstellationClimb: refund failed");
+        emit SessionRefunded(sessionId, s.player, stake);
+    }
+
+    // ---- Read helpers ----
+
+    function previewCard(bytes32 serverReveal, bytes32 clientSeed, uint256 nonce)
+        external
+        pure
+        returns (uint8)
+    {
+        uint256 raw = CommitRevealRandomness.rollOutcome(serverReveal, clientSeed, nonce, CARD_MOD);
+        // forge-lint: disable-next-line(unsafe-typecast)
+        return uint8(raw + 1);
+    }
+
+    function quoteStepMultiplier(uint8 currentCard, Direction direction)
+        external
+        pure
+        returns (uint256)
+    {
+        if (direction == Direction.Higher) {
+            if (currentCard >= 13) revert InvalidDirection();
+            return (WAD * STEP_NUM) / ((CARD_MOD - uint256(currentCard)) * STEP_DEN);
+        } else {
+            if (currentCard <= 1) revert InvalidDirection();
+            return (WAD * STEP_NUM) / ((uint256(currentCard) - 1) * STEP_DEN);
+        }
+    }
+
+    function previewInitialCard(bytes32 clientSeed) external pure returns (uint8) {
+        // forge-lint: disable-next-line(unsafe-typecast)
+        return uint8(uint256(keccak256(abi.encodePacked(clientSeed, INIT_TAG))) % CARD_MOD) + 1;
+    }
+
+    function isExpired(uint256 sessionId) external view returns (bool) {
+        Session storage s = sessions[sessionId];
+        if (s.status != Status.Open) return false;
+        return block.number >= uint256(s.lastBlock) + EXPIRY_BLOCKS;
+    }
+
+    receive() external payable {
+        revert("ConstellationClimb: use openSession");
+    }
+}

--- a/contracts/casino/flattened/CosmicFlip.flat.sol
+++ b/contracts/casino/flattened/CosmicFlip.flat.sol
@@ -1,0 +1,659 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20 ^0.8.24;
+
+// src/CommitRevealRandomness.sol
+
+/// @title CommitRevealRandomness
+/// @notice Stateless commit-reveal helpers shared by every Cosmic Casino game.
+/// @dev    Mirrors the off-chain verify layer byte-for-byte. Test vectors in
+///         both layers MUST agree, or settlement is broken. No state, no
+///         events, no external calls — just three pure functions.
+///
+///         Hash schema (also enforced off-chain):
+///             outcomeHash = keccak256(abi.encodePacked(serverSeed, clientSeed, nonce))
+///             commit      = keccak256(abi.encodePacked(serverSeed))
+library CommitRevealRandomness {
+    /// @notice Compute the raw outcome hash for a single bet/step.
+    function outcomeHash(bytes32 serverSeed, bytes32 clientSeed, uint256 nonce)
+        internal
+        pure
+        returns (bytes32)
+    {
+        return keccak256(abi.encodePacked(serverSeed, clientSeed, nonce));
+    }
+
+    /// @notice Reduce an outcome hash to a uniform integer in [0, mod).
+    /// @dev    Modulo bias is negligible while `mod` ≪ 2^256.
+    function outcomeFromHash(bytes32 hash, uint256 mod) internal pure returns (uint256) {
+        require(mod > 0, "CommitRevealRandomness: mod=0");
+        return uint256(hash) % mod;
+    }
+
+    /// @notice Verify that `serverSeed` matches a previously published `commit`.
+    function verifyCommit(bytes32 serverSeed, bytes32 commit) internal pure returns (bool) {
+        return keccak256(abi.encodePacked(serverSeed)) == commit;
+    }
+
+    /// @notice Convenience: derive a uniform `[0, mod)` outcome end-to-end.
+    function rollOutcome(bytes32 serverSeed, bytes32 clientSeed, uint256 nonce, uint256 mod)
+        internal
+        pure
+        returns (uint256)
+    {
+        return outcomeFromHash(outcomeHash(serverSeed, clientSeed, nonce), mod);
+    }
+}
+
+// lib/openzeppelin-contracts/contracts/utils/Context.sol
+
+// OpenZeppelin Contracts (last updated v5.0.1) (utils/Context.sol)
+
+/**
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes calldata) {
+        return msg.data;
+    }
+
+    function _contextSuffixLength() internal view virtual returns (uint256) {
+        return 0;
+    }
+}
+
+// lib/openzeppelin-contracts/contracts/utils/ReentrancyGuard.sol
+
+// OpenZeppelin Contracts (last updated v5.0.0) (utils/ReentrancyGuard.sol)
+
+/**
+ * @dev Contract module that helps prevent reentrant calls to a function.
+ *
+ * Inheriting from `ReentrancyGuard` will make the {nonReentrant} modifier
+ * available, which can be applied to functions to make sure there are no nested
+ * (reentrant) calls to them.
+ *
+ * Note that because there is a single `nonReentrant` guard, functions marked as
+ * `nonReentrant` may not call one another. This can be worked around by making
+ * those functions `private`, and then adding `external` `nonReentrant` entry
+ * points to them.
+ *
+ * TIP: If you would like to learn more about reentrancy and alternative ways
+ * to protect against it, check out our blog post
+ * https://blog.openzeppelin.com/reentrancy-after-istanbul/[Reentrancy After Istanbul].
+ */
+abstract contract ReentrancyGuard {
+    // Booleans are more expensive than uint256 or any type that takes up a full
+    // word because each write operation emits an extra SLOAD to first read the
+    // slot's contents, replace the bits taken up by the boolean, and then write
+    // back. This is the compiler's defense against contract upgrades and
+    // pointer aliasing, and it cannot be disabled.
+
+    // The values being non-zero value makes deployment a bit more expensive,
+    // but in exchange the refund on every call to nonReentrant will be lower in
+    // amount. Since refunds are capped to a percentage of the total
+    // transaction's gas, it is best to keep them low in cases like this one, to
+    // increase the likelihood of the full refund coming into effect.
+    uint256 private constant NOT_ENTERED = 1;
+    uint256 private constant ENTERED = 2;
+
+    uint256 private _status;
+
+    /**
+     * @dev Unauthorized reentrant call.
+     */
+    error ReentrancyGuardReentrantCall();
+
+    constructor() {
+        _status = NOT_ENTERED;
+    }
+
+    /**
+     * @dev Prevents a contract from calling itself, directly or indirectly.
+     * Calling a `nonReentrant` function from another `nonReentrant`
+     * function is not supported. It is possible to prevent this from happening
+     * by making the `nonReentrant` function external, and making it call a
+     * `private` function that does the actual work.
+     */
+    modifier nonReentrant() {
+        _nonReentrantBefore();
+        _;
+        _nonReentrantAfter();
+    }
+
+    function _nonReentrantBefore() private {
+        // On the first call to nonReentrant, _status will be NOT_ENTERED
+        if (_status == ENTERED) {
+            revert ReentrancyGuardReentrantCall();
+        }
+
+        // Any calls to nonReentrant after this point will fail
+        _status = ENTERED;
+    }
+
+    function _nonReentrantAfter() private {
+        // By storing the original value once again, a refund is triggered (see
+        // https://eips.ethereum.org/EIPS/eip-2200)
+        _status = NOT_ENTERED;
+    }
+
+    /**
+     * @dev Returns true if the reentrancy guard is currently set to "entered", which indicates there is a
+     * `nonReentrant` function in the call stack.
+     */
+    function _reentrancyGuardEntered() internal view returns (bool) {
+        return _status == ENTERED;
+    }
+}
+
+// lib/openzeppelin-contracts/contracts/access/Ownable.sol
+
+// OpenZeppelin Contracts (last updated v5.0.0) (access/Ownable.sol)
+
+/**
+ * @dev Contract module which provides a basic access control mechanism, where
+ * there is an account (an owner) that can be granted exclusive access to
+ * specific functions.
+ *
+ * The initial owner is set to the address provided by the deployer. This can
+ * later be changed with {transferOwnership}.
+ *
+ * This module is used through inheritance. It will make available the modifier
+ * `onlyOwner`, which can be applied to your functions to restrict their use to
+ * the owner.
+ */
+abstract contract Ownable is Context {
+    address private _owner;
+
+    /**
+     * @dev The caller account is not authorized to perform an operation.
+     */
+    error OwnableUnauthorizedAccount(address account);
+
+    /**
+     * @dev The owner is not a valid owner account. (eg. `address(0)`)
+     */
+    error OwnableInvalidOwner(address owner);
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev Initializes the contract setting the address provided by the deployer as the initial owner.
+     */
+    constructor(address initialOwner) {
+        if (initialOwner == address(0)) {
+            revert OwnableInvalidOwner(address(0));
+        }
+        _transferOwnership(initialOwner);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        _checkOwner();
+        _;
+    }
+
+    /**
+     * @dev Returns the address of the current owner.
+     */
+    function owner() public view virtual returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Throws if the sender is not the owner.
+     */
+    function _checkOwner() internal view virtual {
+        if (owner() != _msgSender()) {
+            revert OwnableUnauthorizedAccount(_msgSender());
+        }
+    }
+
+    /**
+     * @dev Leaves the contract without owner. It will not be possible to call
+     * `onlyOwner` functions. Can only be called by the current owner.
+     *
+     * NOTE: Renouncing ownership will leave the contract without an owner,
+     * thereby disabling any functionality that is only available to the owner.
+     */
+    function renounceOwnership() public virtual onlyOwner {
+        _transferOwnership(address(0));
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Can only be called by the current owner.
+     */
+    function transferOwnership(address newOwner) public virtual onlyOwner {
+        if (newOwner == address(0)) {
+            revert OwnableInvalidOwner(address(0));
+        }
+        _transferOwnership(newOwner);
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Internal function without access restriction.
+     */
+    function _transferOwnership(address newOwner) internal virtual {
+        address oldOwner = _owner;
+        _owner = newOwner;
+        emit OwnershipTransferred(oldOwner, newOwner);
+    }
+}
+
+// lib/openzeppelin-contracts/contracts/utils/Pausable.sol
+
+// OpenZeppelin Contracts (last updated v5.0.0) (utils/Pausable.sol)
+
+/**
+ * @dev Contract module which allows children to implement an emergency stop
+ * mechanism that can be triggered by an authorized account.
+ *
+ * This module is used through inheritance. It will make available the
+ * modifiers `whenNotPaused` and `whenPaused`, which can be applied to
+ * the functions of your contract. Note that they will not be pausable by
+ * simply including this module, only once the modifiers are put in place.
+ */
+abstract contract Pausable is Context {
+    bool private _paused;
+
+    /**
+     * @dev Emitted when the pause is triggered by `account`.
+     */
+    event Paused(address account);
+
+    /**
+     * @dev Emitted when the pause is lifted by `account`.
+     */
+    event Unpaused(address account);
+
+    /**
+     * @dev The operation failed because the contract is paused.
+     */
+    error EnforcedPause();
+
+    /**
+     * @dev The operation failed because the contract is not paused.
+     */
+    error ExpectedPause();
+
+    /**
+     * @dev Initializes the contract in unpaused state.
+     */
+    constructor() {
+        _paused = false;
+    }
+
+    /**
+     * @dev Modifier to make a function callable only when the contract is not paused.
+     *
+     * Requirements:
+     *
+     * - The contract must not be paused.
+     */
+    modifier whenNotPaused() {
+        _requireNotPaused();
+        _;
+    }
+
+    /**
+     * @dev Modifier to make a function callable only when the contract is paused.
+     *
+     * Requirements:
+     *
+     * - The contract must be paused.
+     */
+    modifier whenPaused() {
+        _requirePaused();
+        _;
+    }
+
+    /**
+     * @dev Returns true if the contract is paused, and false otherwise.
+     */
+    function paused() public view virtual returns (bool) {
+        return _paused;
+    }
+
+    /**
+     * @dev Throws if the contract is paused.
+     */
+    function _requireNotPaused() internal view virtual {
+        if (paused()) {
+            revert EnforcedPause();
+        }
+    }
+
+    /**
+     * @dev Throws if the contract is not paused.
+     */
+    function _requirePaused() internal view virtual {
+        if (!paused()) {
+            revert ExpectedPause();
+        }
+    }
+
+    /**
+     * @dev Triggers stopped state.
+     *
+     * Requirements:
+     *
+     * - The contract must not be paused.
+     */
+    function _pause() internal virtual whenNotPaused {
+        _paused = true;
+        emit Paused(_msgSender());
+    }
+
+    /**
+     * @dev Returns to normal state.
+     *
+     * Requirements:
+     *
+     * - The contract must be paused.
+     */
+    function _unpause() internal virtual whenPaused {
+        _paused = false;
+        emit Unpaused(_msgSender());
+    }
+}
+
+// src/CosmicFlip.sol
+
+interface ICasinoBankroll {
+    function payout(address recipient, uint256 amount) external;
+    function settle() external payable;
+    function allowanceOf(address game) external view returns (uint256);
+}
+
+interface ICasinoAllowlist {
+    function enforceAccess(address player) external view;
+}
+
+/// @title CosmicFlip
+/// @notice Phase 1 solo coinflip for the Cosmic Casino. Server commit-reveal
+///         randomness; payout routed through the shared bankroll; refund path
+///         on stale settle.
+/// @dev    Lifecycle:
+///           1. Off-chain: seed manager publishes `commit = keccak(serverSeed)`.
+///           2. Player calls `placeBet(side, clientSeed, commit)` and locks stake.
+///           3. Backend calls `settleBet(betId, serverReveal)` within `EXPIRY_BLOCKS`.
+///           4. If backend never settles, player calls `refundBet(betId)`.
+///         Multiplier: 1.98× (1.00% house edge), encoded as `198/100`.
+///         Per-bet cap: 0.5% of bankroll allowance — enforced via the bankroll's
+///         per-game allowance ceiling and `MAX_BET` here as a belt-and-braces.
+contract CosmicFlip is Ownable, Pausable, ReentrancyGuard {
+    using CommitRevealRandomness for bytes32;
+
+    enum Side {
+        Heads,
+        Tails
+    }
+
+    enum Status {
+        None, // 0 — slot empty
+        Pending, // 1 — placed, not yet settled
+        Won, // 2 — settled, player won
+        Lost, // 3 — settled, house won
+        Refunded // 4 — expired, player refunded
+    }
+
+    struct Bet {
+        address player;
+        uint96 stake; // wei, fits 79+ bn tokens; plenty
+        bytes32 clientSeed;
+        bytes32 serverCommit;
+        uint64 blockPlaced;
+        Side side;
+        Status status;
+        bytes32 serverReveal; // populated on settle
+        uint256 nonce; // matches per-bet nonce in randomness scheme
+    }
+
+    /// @notice Number of blocks after which an unsettled bet can be refunded.
+    /// @dev    256 blocks ≈ ~2 min on Monad (~500ms blocks); generous given the
+    ///         seed manager settles within 1 block in the happy path.
+    uint64 public constant EXPIRY_BLOCKS = 256;
+
+    /// @notice Payout numerator/denominator. Multiplier = 198 / 100 = 1.98×.
+    uint256 public constant PAYOUT_NUM = 198;
+    uint256 public constant PAYOUT_DEN = 100;
+
+    /// @notice Hard ceiling per individual bet (in wei). Mirrors the 0.5%-of-
+    ///         bankroll envelope for the small-seed launch. Owner-tunable.
+    uint256 public maxBet;
+
+    /// @notice Minimum bet to keep gas / settlement worthwhile.
+    uint256 public minBet;
+
+    ICasinoBankroll public immutable bankroll;
+
+    /// @notice Optional soft-launch allowlist. When set, every `placeBet` is
+    ///         gated by `allowlist.enforceAccess(msg.sender)`. Owner-clearable
+    ///         (set to address(0)) once the soft-launch window closes; the
+    ///         allowlist contract itself can also be flipped to `enabled=false`.
+    ICasinoAllowlist public allowlist;
+
+    mapping(uint256 => Bet) public bets;
+    uint256 public nextBetId;
+
+    /// @dev Per-player monotonic nonce, mixed into the randomness hash so that
+    ///      reusing a (serverSeed, clientSeed) pair across bets produces
+    ///      different outcomes.
+    mapping(address => uint256) public playerNonce;
+
+    /// @dev Single-use guard for `serverCommit`. Once any bet binds a commit,
+    ///      that commit is consumed forever — a player who later observes the
+    ///      revealed seed cannot re-bet against the same commit and pre-compute
+    ///      the outcome. The off-chain seed manager MUST rotate per bet.
+    mapping(bytes32 => bool) public commitUsed;
+
+    event BetPlaced(
+        uint256 indexed betId,
+        address indexed player,
+        Side side,
+        uint256 stake,
+        bytes32 clientSeed,
+        bytes32 serverCommit,
+        uint256 nonce,
+        uint64 blockPlaced
+    );
+    event BetSettled(
+        uint256 indexed betId,
+        address indexed player,
+        Side outcome,
+        bool won,
+        uint256 payout,
+        bytes32 serverReveal
+    );
+    event BetRefunded(uint256 indexed betId, address indexed player, uint256 stake);
+
+    event MaxBetSet(uint256 oldMax, uint256 newMax);
+    event MinBetSet(uint256 oldMin, uint256 newMin);
+    event AllowlistSet(address indexed allowlist);
+
+    error BetNotFound();
+    error BetNotPending();
+    error BetNotExpired();
+    error InvalidReveal();
+    error StakeOutOfBounds();
+    error NotPlayer();
+    error ZeroAddress();
+    error CommitAlreadyUsed();
+    error ZeroCommit();
+    /// @notice Soft-launch gate: caller is not on the allowlist while it is enabled.
+    error NotAllowed();
+    /// @notice `setBetBounds` rejected: newMax < newMin or newMax overflows uint96.
+    error InvalidBetBounds();
+    /// @notice `setBetBounds` rejected: bankroll allowance for this game can't
+    ///         cover a max-bet WIN. Top up the bankroll first.
+    error BankrollAllowanceTooLow(uint256 required, uint256 available);
+
+    constructor(address initialOwner, address bankrollAddr, uint256 minBet_, uint256 maxBet_)
+        Ownable(initialOwner)
+    {
+        if (bankrollAddr == address(0)) revert ZeroAddress();
+        bankroll = ICasinoBankroll(bankrollAddr);
+        minBet = minBet_;
+        maxBet = maxBet_;
+    }
+
+    // ---- Owner ----
+
+    /// @notice Set the per-bet stake floor and ceiling.
+    function setBetBounds(uint256 newMin, uint256 newMax) external onlyOwner {
+        if (newMax < newMin) revert InvalidBetBounds();
+        if (newMax > type(uint96).max) revert InvalidBetBounds();
+        uint256 required = ((PAYOUT_NUM - PAYOUT_DEN) * newMax) / PAYOUT_DEN;
+        uint256 available = bankroll.allowanceOf(address(this));
+        if (available < required) revert BankrollAllowanceTooLow(required, available);
+
+        emit MinBetSet(minBet, newMin);
+        emit MaxBetSet(maxBet, newMax);
+        minBet = newMin;
+        maxBet = newMax;
+    }
+
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    function unpause() external onlyOwner {
+        _unpause();
+    }
+
+    /// @notice Owner-set the soft-launch allowlist contract. Pass address(0)
+    ///         to fully detach (open house). Mainnet ships with this set; the
+    ///         operator clears it once the soft-launch window closes.
+    function setAllowlist(address newAllowlist) external onlyOwner {
+        allowlist = ICasinoAllowlist(newAllowlist);
+        emit AllowlistSet(newAllowlist);
+    }
+
+    // ---- Player ----
+
+    /// @notice Lock a stake on `side` against the server commit.
+    function placeBet(Side side, bytes32 clientSeed, bytes32 serverCommit)
+        external
+        payable
+        whenNotPaused
+        nonReentrant
+        returns (uint256 betId)
+    {
+        ICasinoAllowlist al = allowlist;
+        if (address(al) != address(0)) {
+            try al.enforceAccess(msg.sender) {}
+            catch {
+                revert NotAllowed();
+            }
+        }
+        if (msg.value < minBet || msg.value > maxBet) revert StakeOutOfBounds();
+        if (serverCommit == bytes32(0)) revert ZeroCommit();
+        if (commitUsed[serverCommit]) revert CommitAlreadyUsed();
+        commitUsed[serverCommit] = true;
+
+        betId = nextBetId++;
+        uint256 nonce = playerNonce[msg.sender]++;
+
+        bets[betId] = Bet({
+            player: msg.sender,
+            stake: uint96(msg.value),
+            clientSeed: clientSeed,
+            serverCommit: serverCommit,
+            blockPlaced: uint64(block.number),
+            side: side,
+            status: Status.Pending,
+            serverReveal: bytes32(0),
+            nonce: nonce
+        });
+
+        emit BetPlaced(
+            betId,
+            msg.sender,
+            side,
+            msg.value,
+            clientSeed,
+            serverCommit,
+            nonce,
+            uint64(block.number)
+        );
+    }
+
+    /// @notice Settle a bet by revealing the server seed.
+    function settleBet(uint256 betId, bytes32 serverReveal) external nonReentrant {
+        Bet storage b = bets[betId];
+        if (b.status == Status.None) revert BetNotFound();
+        if (b.status != Status.Pending) revert BetNotPending();
+        if (!CommitRevealRandomness.verifyCommit(serverReveal, b.serverCommit)) {
+            revert InvalidReveal();
+        }
+
+        uint256 outcome = CommitRevealRandomness.rollOutcome(serverReveal, b.clientSeed, b.nonce, 2);
+        Side rolled = outcome == 0 ? Side.Heads : Side.Tails;
+        b.serverReveal = serverReveal;
+
+        if (rolled == b.side) {
+            uint256 payoutAmt = (uint256(b.stake) * PAYOUT_NUM) / PAYOUT_DEN;
+            b.status = Status.Won;
+            bankroll.settle{value: uint256(b.stake)}();
+            bankroll.payout(b.player, payoutAmt);
+            emit BetSettled(betId, b.player, rolled, true, payoutAmt, serverReveal);
+        } else {
+            b.status = Status.Lost;
+            bankroll.settle{value: uint256(b.stake)}();
+            emit BetSettled(betId, b.player, rolled, false, 0, serverReveal);
+        }
+    }
+
+    /// @notice Refund a bet that was never settled within `EXPIRY_BLOCKS`.
+    function refundBet(uint256 betId) external nonReentrant {
+        Bet storage b = bets[betId];
+        if (b.status == Status.None) revert BetNotFound();
+        if (b.status != Status.Pending) revert BetNotPending();
+        if (msg.sender != b.player) revert NotPlayer();
+        if (block.number < uint256(b.blockPlaced) + EXPIRY_BLOCKS) revert BetNotExpired();
+
+        uint256 stake = uint256(b.stake);
+        b.status = Status.Refunded;
+        (bool ok,) = b.player.call{value: stake}("");
+        if (!ok) revert("CosmicFlip: refund failed");
+        emit BetRefunded(betId, b.player, stake);
+    }
+
+    // ---- Read helpers ----
+
+    /// @notice Compute the on-chain outcome side from a (reveal, clientSeed, nonce) tuple.
+    function previewOutcome(bytes32 serverReveal, bytes32 clientSeed, uint256 nonce)
+        external
+        pure
+        returns (Side)
+    {
+        uint256 o = CommitRevealRandomness.rollOutcome(serverReveal, clientSeed, nonce, 2);
+        return o == 0 ? Side.Heads : Side.Tails;
+    }
+
+    /// @notice Whether a Pending bet is past its refund window.
+    function isExpired(uint256 betId) external view returns (bool) {
+        Bet storage b = bets[betId];
+        if (b.status != Status.Pending) return false;
+        return block.number >= uint256(b.blockPlaced) + EXPIRY_BLOCKS;
+    }
+
+    /// @dev Reject stray native sends except via `placeBet` / refunds.
+    receive() external payable {
+        revert("CosmicFlip: use placeBet");
+    }
+}

--- a/contracts/casino/flattened/GravityDice.flat.sol
+++ b/contracts/casino/flattened/GravityDice.flat.sol
@@ -1,0 +1,658 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20 ^0.8.24;
+
+// src/CommitRevealRandomness.sol
+
+/// @title CommitRevealRandomness
+/// @notice Stateless commit-reveal helpers shared by every Cosmic Casino game.
+/// @dev    Mirrors the off-chain verify layer byte-for-byte. Test vectors in
+///         both layers MUST agree, or settlement is broken. No state, no
+///         events, no external calls — just three pure functions.
+///
+///         Hash schema (also enforced off-chain):
+///             outcomeHash = keccak256(abi.encodePacked(serverSeed, clientSeed, nonce))
+///             commit      = keccak256(abi.encodePacked(serverSeed))
+library CommitRevealRandomness {
+    /// @notice Compute the raw outcome hash for a single bet/step.
+    function outcomeHash(bytes32 serverSeed, bytes32 clientSeed, uint256 nonce)
+        internal
+        pure
+        returns (bytes32)
+    {
+        return keccak256(abi.encodePacked(serverSeed, clientSeed, nonce));
+    }
+
+    /// @notice Reduce an outcome hash to a uniform integer in [0, mod).
+    /// @dev    Modulo bias is negligible while `mod` ≪ 2^256.
+    function outcomeFromHash(bytes32 hash, uint256 mod) internal pure returns (uint256) {
+        require(mod > 0, "CommitRevealRandomness: mod=0");
+        return uint256(hash) % mod;
+    }
+
+    /// @notice Verify that `serverSeed` matches a previously published `commit`.
+    function verifyCommit(bytes32 serverSeed, bytes32 commit) internal pure returns (bool) {
+        return keccak256(abi.encodePacked(serverSeed)) == commit;
+    }
+
+    /// @notice Convenience: derive a uniform `[0, mod)` outcome end-to-end.
+    function rollOutcome(bytes32 serverSeed, bytes32 clientSeed, uint256 nonce, uint256 mod)
+        internal
+        pure
+        returns (uint256)
+    {
+        return outcomeFromHash(outcomeHash(serverSeed, clientSeed, nonce), mod);
+    }
+}
+
+// lib/openzeppelin-contracts/contracts/utils/Context.sol
+
+// OpenZeppelin Contracts (last updated v5.0.1) (utils/Context.sol)
+
+/**
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes calldata) {
+        return msg.data;
+    }
+
+    function _contextSuffixLength() internal view virtual returns (uint256) {
+        return 0;
+    }
+}
+
+// lib/openzeppelin-contracts/contracts/utils/ReentrancyGuard.sol
+
+// OpenZeppelin Contracts (last updated v5.0.0) (utils/ReentrancyGuard.sol)
+
+/**
+ * @dev Contract module that helps prevent reentrant calls to a function.
+ *
+ * Inheriting from `ReentrancyGuard` will make the {nonReentrant} modifier
+ * available, which can be applied to functions to make sure there are no nested
+ * (reentrant) calls to them.
+ *
+ * Note that because there is a single `nonReentrant` guard, functions marked as
+ * `nonReentrant` may not call one another. This can be worked around by making
+ * those functions `private`, and then adding `external` `nonReentrant` entry
+ * points to them.
+ *
+ * TIP: If you would like to learn more about reentrancy and alternative ways
+ * to protect against it, check out our blog post
+ * https://blog.openzeppelin.com/reentrancy-after-istanbul/[Reentrancy After Istanbul].
+ */
+abstract contract ReentrancyGuard {
+    // Booleans are more expensive than uint256 or any type that takes up a full
+    // word because each write operation emits an extra SLOAD to first read the
+    // slot's contents, replace the bits taken up by the boolean, and then write
+    // back. This is the compiler's defense against contract upgrades and
+    // pointer aliasing, and it cannot be disabled.
+
+    // The values being non-zero value makes deployment a bit more expensive,
+    // but in exchange the refund on every call to nonReentrant will be lower in
+    // amount. Since refunds are capped to a percentage of the total
+    // transaction's gas, it is best to keep them low in cases like this one, to
+    // increase the likelihood of the full refund coming into effect.
+    uint256 private constant NOT_ENTERED = 1;
+    uint256 private constant ENTERED = 2;
+
+    uint256 private _status;
+
+    /**
+     * @dev Unauthorized reentrant call.
+     */
+    error ReentrancyGuardReentrantCall();
+
+    constructor() {
+        _status = NOT_ENTERED;
+    }
+
+    /**
+     * @dev Prevents a contract from calling itself, directly or indirectly.
+     * Calling a `nonReentrant` function from another `nonReentrant`
+     * function is not supported. It is possible to prevent this from happening
+     * by making the `nonReentrant` function external, and making it call a
+     * `private` function that does the actual work.
+     */
+    modifier nonReentrant() {
+        _nonReentrantBefore();
+        _;
+        _nonReentrantAfter();
+    }
+
+    function _nonReentrantBefore() private {
+        // On the first call to nonReentrant, _status will be NOT_ENTERED
+        if (_status == ENTERED) {
+            revert ReentrancyGuardReentrantCall();
+        }
+
+        // Any calls to nonReentrant after this point will fail
+        _status = ENTERED;
+    }
+
+    function _nonReentrantAfter() private {
+        // By storing the original value once again, a refund is triggered (see
+        // https://eips.ethereum.org/EIPS/eip-2200)
+        _status = NOT_ENTERED;
+    }
+
+    /**
+     * @dev Returns true if the reentrancy guard is currently set to "entered", which indicates there is a
+     * `nonReentrant` function in the call stack.
+     */
+    function _reentrancyGuardEntered() internal view returns (bool) {
+        return _status == ENTERED;
+    }
+}
+
+// lib/openzeppelin-contracts/contracts/access/Ownable.sol
+
+// OpenZeppelin Contracts (last updated v5.0.0) (access/Ownable.sol)
+
+/**
+ * @dev Contract module which provides a basic access control mechanism, where
+ * there is an account (an owner) that can be granted exclusive access to
+ * specific functions.
+ *
+ * The initial owner is set to the address provided by the deployer. This can
+ * later be changed with {transferOwnership}.
+ *
+ * This module is used through inheritance. It will make available the modifier
+ * `onlyOwner`, which can be applied to your functions to restrict their use to
+ * the owner.
+ */
+abstract contract Ownable is Context {
+    address private _owner;
+
+    /**
+     * @dev The caller account is not authorized to perform an operation.
+     */
+    error OwnableUnauthorizedAccount(address account);
+
+    /**
+     * @dev The owner is not a valid owner account. (eg. `address(0)`)
+     */
+    error OwnableInvalidOwner(address owner);
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev Initializes the contract setting the address provided by the deployer as the initial owner.
+     */
+    constructor(address initialOwner) {
+        if (initialOwner == address(0)) {
+            revert OwnableInvalidOwner(address(0));
+        }
+        _transferOwnership(initialOwner);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        _checkOwner();
+        _;
+    }
+
+    /**
+     * @dev Returns the address of the current owner.
+     */
+    function owner() public view virtual returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Throws if the sender is not the owner.
+     */
+    function _checkOwner() internal view virtual {
+        if (owner() != _msgSender()) {
+            revert OwnableUnauthorizedAccount(_msgSender());
+        }
+    }
+
+    /**
+     * @dev Leaves the contract without owner. It will not be possible to call
+     * `onlyOwner` functions. Can only be called by the current owner.
+     *
+     * NOTE: Renouncing ownership will leave the contract without an owner,
+     * thereby disabling any functionality that is only available to the owner.
+     */
+    function renounceOwnership() public virtual onlyOwner {
+        _transferOwnership(address(0));
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Can only be called by the current owner.
+     */
+    function transferOwnership(address newOwner) public virtual onlyOwner {
+        if (newOwner == address(0)) {
+            revert OwnableInvalidOwner(address(0));
+        }
+        _transferOwnership(newOwner);
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Internal function without access restriction.
+     */
+    function _transferOwnership(address newOwner) internal virtual {
+        address oldOwner = _owner;
+        _owner = newOwner;
+        emit OwnershipTransferred(oldOwner, newOwner);
+    }
+}
+
+// lib/openzeppelin-contracts/contracts/utils/Pausable.sol
+
+// OpenZeppelin Contracts (last updated v5.0.0) (utils/Pausable.sol)
+
+/**
+ * @dev Contract module which allows children to implement an emergency stop
+ * mechanism that can be triggered by an authorized account.
+ *
+ * This module is used through inheritance. It will make available the
+ * modifiers `whenNotPaused` and `whenPaused`, which can be applied to
+ * the functions of your contract. Note that they will not be pausable by
+ * simply including this module, only once the modifiers are put in place.
+ */
+abstract contract Pausable is Context {
+    bool private _paused;
+
+    /**
+     * @dev Emitted when the pause is triggered by `account`.
+     */
+    event Paused(address account);
+
+    /**
+     * @dev Emitted when the pause is lifted by `account`.
+     */
+    event Unpaused(address account);
+
+    /**
+     * @dev The operation failed because the contract is paused.
+     */
+    error EnforcedPause();
+
+    /**
+     * @dev The operation failed because the contract is not paused.
+     */
+    error ExpectedPause();
+
+    /**
+     * @dev Initializes the contract in unpaused state.
+     */
+    constructor() {
+        _paused = false;
+    }
+
+    /**
+     * @dev Modifier to make a function callable only when the contract is not paused.
+     *
+     * Requirements:
+     *
+     * - The contract must not be paused.
+     */
+    modifier whenNotPaused() {
+        _requireNotPaused();
+        _;
+    }
+
+    /**
+     * @dev Modifier to make a function callable only when the contract is paused.
+     *
+     * Requirements:
+     *
+     * - The contract must be paused.
+     */
+    modifier whenPaused() {
+        _requirePaused();
+        _;
+    }
+
+    /**
+     * @dev Returns true if the contract is paused, and false otherwise.
+     */
+    function paused() public view virtual returns (bool) {
+        return _paused;
+    }
+
+    /**
+     * @dev Throws if the contract is paused.
+     */
+    function _requireNotPaused() internal view virtual {
+        if (paused()) {
+            revert EnforcedPause();
+        }
+    }
+
+    /**
+     * @dev Throws if the contract is not paused.
+     */
+    function _requirePaused() internal view virtual {
+        if (!paused()) {
+            revert ExpectedPause();
+        }
+    }
+
+    /**
+     * @dev Triggers stopped state.
+     *
+     * Requirements:
+     *
+     * - The contract must not be paused.
+     */
+    function _pause() internal virtual whenNotPaused {
+        _paused = true;
+        emit Paused(_msgSender());
+    }
+
+    /**
+     * @dev Returns to normal state.
+     *
+     * Requirements:
+     *
+     * - The contract must be paused.
+     */
+    function _unpause() internal virtual whenPaused {
+        _paused = false;
+        emit Unpaused(_msgSender());
+    }
+}
+
+// src/GravityDice.sol
+
+interface ICasinoBankroll {
+    function payout(address recipient, uint256 amount) external;
+    function settle() external payable;
+}
+
+interface ICasinoAllowlist {
+    function enforceAccess(address player) external view;
+}
+
+/// @title GravityDice
+/// @notice Phase 2 solo Roll-Under dice for the Cosmic Casino. Server commit-
+///         reveal randomness; payout routed through the shared bankroll; refund
+///         path on stale settle. Mirrors the lifecycle of `CosmicFlip` so that
+///         the keeper bot, indexer, and verify UI can reuse their settle/refund
+///         plumbing one-to-one.
+/// @dev    Lifecycle:
+///           1. Off-chain: seed manager publishes `commit = keccak(serverSeed)`.
+///           2. Player calls `placeBet(rollUnder, clientSeed, commit)` and locks
+///              stake. `rollUnder` is the target threshold in [2, 98].
+///           3. Backend calls `settleBet(betId, serverReveal)` within
+///              `EXPIRY_BLOCKS`.
+///           4. If backend never settles, player calls `refundBet(betId)`.
+///         Outcome derivation:
+///             roll = (uint256(outcomeHash) % 100) + 1   // ∈ [1, 100]
+///             win  = roll < rollUnder                    // strict <
+///         Multiplier: `99 / (R-1)` — encodes a 1.00% house edge against the
+///         fair payout `100 / (R-1)`. Per-bet cap mirrors CosmicFlip.
+contract GravityDice is Ownable, Pausable, ReentrancyGuard {
+    using CommitRevealRandomness for bytes32;
+
+    enum Status {
+        None, // 0 — slot empty
+        Pending, // 1 — placed, not yet settled
+        Won, // 2 — settled, player won
+        Lost, // 3 — settled, house won
+        Refunded // 4 — expired, player refunded
+    }
+
+    struct Bet {
+        address player;
+        uint96 stake; // wei, fits 79+ bn tokens; plenty
+        bytes32 clientSeed;
+        bytes32 serverCommit;
+        uint64 blockPlaced;
+        uint8 rollUnder; // target threshold in [MIN_ROLL_UNDER, MAX_ROLL_UNDER]
+        Status status;
+        uint8 roll; // populated on settle, in [1, 100]
+        bytes32 serverReveal; // populated on settle
+        uint256 nonce; // matches per-bet nonce in randomness scheme
+    }
+
+    /// @notice Number of blocks after which an unsettled bet can be refunded.
+    /// @dev    Same as CosmicFlip: 256 blocks ≈ ~2 min on Monad (~500ms blocks).
+    uint64 public constant EXPIRY_BLOCKS = 256;
+
+    /// @notice Payout numerator. Multiplier = `PAYOUT_NUM / (rollUnder - 1)`.
+    ///         Encodes a 1.00% house edge against the fair `100 / (R-1)`.
+    uint256 public constant PAYOUT_NUM = 99;
+
+    /// @notice Roll outcome modulus (dice are 1..100 → modulo 100).
+    uint256 public constant ROLL_MOD = 100;
+
+    /// @notice Smallest legal `rollUnder`. Below this the win probability is
+    ///         effectively zero (only roll==1 wins) — keep a meaningful floor.
+    uint8 public constant MIN_ROLL_UNDER = 2;
+
+    /// @notice Largest legal `rollUnder`. Above 98 the multiplier collapses
+    ///         to 1.0102…× and the house edge is too thin to matter; cap there.
+    uint8 public constant MAX_ROLL_UNDER = 98;
+
+    /// @notice Hard ceiling per individual bet (in wei). Owner-tunable.
+    uint256 public maxBet;
+
+    /// @notice Minimum bet to keep gas / settlement worthwhile.
+    uint256 public minBet;
+
+    ICasinoBankroll public immutable bankroll;
+
+    /// @notice Optional soft-launch allowlist.
+    ICasinoAllowlist public allowlist;
+
+    mapping(uint256 => Bet) public bets;
+    uint256 public nextBetId;
+
+    /// @dev Per-player monotonic nonce mixed into the randomness hash.
+    mapping(address => uint256) public playerNonce;
+
+    /// @dev Single-use guard for `serverCommit`.
+    mapping(bytes32 => bool) public commitUsed;
+
+    event BetPlaced(
+        uint256 indexed betId,
+        address indexed player,
+        uint8 rollUnder,
+        uint256 stake,
+        bytes32 clientSeed,
+        bytes32 serverCommit,
+        uint256 nonce,
+        uint64 blockPlaced
+    );
+    event BetSettled(
+        uint256 indexed betId,
+        address indexed player,
+        uint8 rollUnder,
+        uint8 roll,
+        bool won,
+        uint256 payout,
+        bytes32 serverReveal
+    );
+    event BetRefunded(uint256 indexed betId, address indexed player, uint256 stake);
+
+    event MaxBetSet(uint256 oldMax, uint256 newMax);
+    event MinBetSet(uint256 oldMin, uint256 newMin);
+    event AllowlistSet(address indexed allowlist);
+
+    error BetNotFound();
+    error BetNotPending();
+    error BetNotExpired();
+    error InvalidReveal();
+    error InvalidRollUnder();
+    error StakeOutOfBounds();
+    error NotPlayer();
+    error ZeroAddress();
+    error CommitAlreadyUsed();
+    error ZeroCommit();
+    error NotAllowed();
+    error InvalidBetBounds();
+
+    constructor(address initialOwner, address bankrollAddr, uint256 minBet_, uint256 maxBet_)
+        Ownable(initialOwner)
+    {
+        if (bankrollAddr == address(0)) revert ZeroAddress();
+        bankroll = ICasinoBankroll(bankrollAddr);
+        minBet = minBet_;
+        maxBet = maxBet_;
+    }
+
+    // ---- Owner ----
+
+    function setBetBounds(uint256 newMin, uint256 newMax) external onlyOwner {
+        if (newMax < newMin) revert InvalidBetBounds();
+        if (newMax > type(uint96).max) revert InvalidBetBounds();
+        emit MinBetSet(minBet, newMin);
+        emit MaxBetSet(maxBet, newMax);
+        minBet = newMin;
+        maxBet = newMax;
+    }
+
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    function unpause() external onlyOwner {
+        _unpause();
+    }
+
+    function setAllowlist(address newAllowlist) external onlyOwner {
+        allowlist = ICasinoAllowlist(newAllowlist);
+        emit AllowlistSet(newAllowlist);
+    }
+
+    // ---- Player ----
+
+    function placeBet(uint8 rollUnder, bytes32 clientSeed, bytes32 serverCommit)
+        external
+        payable
+        whenNotPaused
+        nonReentrant
+        returns (uint256 betId)
+    {
+        ICasinoAllowlist al = allowlist;
+        if (address(al) != address(0)) {
+            try al.enforceAccess(msg.sender) {}
+            catch {
+                revert NotAllowed();
+            }
+        }
+        if (rollUnder < MIN_ROLL_UNDER || rollUnder > MAX_ROLL_UNDER) {
+            revert InvalidRollUnder();
+        }
+        if (msg.value < minBet || msg.value > maxBet) revert StakeOutOfBounds();
+        if (serverCommit == bytes32(0)) revert ZeroCommit();
+        if (commitUsed[serverCommit]) revert CommitAlreadyUsed();
+        commitUsed[serverCommit] = true;
+
+        betId = nextBetId++;
+        uint256 nonce = playerNonce[msg.sender]++;
+
+        bets[betId] = Bet({
+            player: msg.sender,
+            stake: uint96(msg.value),
+            clientSeed: clientSeed,
+            serverCommit: serverCommit,
+            blockPlaced: uint64(block.number),
+            rollUnder: rollUnder,
+            status: Status.Pending,
+            roll: 0,
+            serverReveal: bytes32(0),
+            nonce: nonce
+        });
+
+        emit BetPlaced(
+            betId,
+            msg.sender,
+            rollUnder,
+            msg.value,
+            clientSeed,
+            serverCommit,
+            nonce,
+            uint64(block.number)
+        );
+    }
+
+    function settleBet(uint256 betId, bytes32 serverReveal) external nonReentrant {
+        Bet storage b = bets[betId];
+        if (b.status == Status.None) revert BetNotFound();
+        if (b.status != Status.Pending) revert BetNotPending();
+        if (!CommitRevealRandomness.verifyCommit(serverReveal, b.serverCommit)) {
+            revert InvalidReveal();
+        }
+
+        uint256 raw =
+            CommitRevealRandomness.rollOutcome(serverReveal, b.clientSeed, b.nonce, ROLL_MOD);
+        // forge-lint: disable-next-line(unsafe-typecast)
+        uint8 roll = uint8(raw + 1);
+        b.serverReveal = serverReveal;
+        b.roll = roll;
+
+        bool won = roll < b.rollUnder;
+        if (won) {
+            uint256 payoutAmt = (uint256(b.stake) * PAYOUT_NUM) / (uint256(b.rollUnder) - 1);
+            b.status = Status.Won;
+            bankroll.settle{value: uint256(b.stake)}();
+            bankroll.payout(b.player, payoutAmt);
+            emit BetSettled(betId, b.player, b.rollUnder, roll, true, payoutAmt, serverReveal);
+        } else {
+            b.status = Status.Lost;
+            bankroll.settle{value: uint256(b.stake)}();
+            emit BetSettled(betId, b.player, b.rollUnder, roll, false, 0, serverReveal);
+        }
+    }
+
+    function refundBet(uint256 betId) external nonReentrant {
+        Bet storage b = bets[betId];
+        if (b.status == Status.None) revert BetNotFound();
+        if (b.status != Status.Pending) revert BetNotPending();
+        if (msg.sender != b.player) revert NotPlayer();
+        if (block.number < uint256(b.blockPlaced) + EXPIRY_BLOCKS) revert BetNotExpired();
+
+        uint256 stake = uint256(b.stake);
+        b.status = Status.Refunded;
+        (bool ok,) = b.player.call{value: stake}("");
+        if (!ok) revert("GravityDice: refund failed");
+        emit BetRefunded(betId, b.player, stake);
+    }
+
+    // ---- Read helpers ----
+
+    function previewRoll(bytes32 serverReveal, bytes32 clientSeed, uint256 nonce)
+        external
+        pure
+        returns (uint8)
+    {
+        uint256 raw = CommitRevealRandomness.rollOutcome(serverReveal, clientSeed, nonce, ROLL_MOD);
+        // forge-lint: disable-next-line(unsafe-typecast)
+        return uint8(raw + 1);
+    }
+
+    function quotePayout(uint256 stake, uint8 rollUnder) external pure returns (uint256) {
+        if (rollUnder < MIN_ROLL_UNDER || rollUnder > MAX_ROLL_UNDER) revert InvalidRollUnder();
+        return (stake * PAYOUT_NUM) / (uint256(rollUnder) - 1);
+    }
+
+    function isExpired(uint256 betId) external view returns (bool) {
+        Bet storage b = bets[betId];
+        if (b.status != Status.Pending) return false;
+        return block.number >= uint256(b.blockPlaced) + EXPIRY_BLOCKS;
+    }
+
+    receive() external payable {
+        revert("GravityDice: use placeBet");
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a **Verification** section to `contracts/casino/README.md` documenting the `forge verify-contract` command for each of the four contracts deployed on Monad testnet (chain `10143`), with explicit constructor-arg encodings, the four contract addresses, and the `monad-testnet` chain alias (forge CLI uses a hyphen even though the `[etherscan]` table key in `foundry.toml` uses an underscore).
- Adds `contracts/casino/flattened/{CasinoBankroll,CosmicFlip,GravityDice,ConstellationClimb}.flat.sol` (4 files, 2 751 lines) produced by `forge flatten` against `solc 0.8.24` + `optimizer_runs = 200`. These let any third party reproduce the on-chain bytecode without an explorer API key, and can be uploaded directly to Monadscan's "single file" manual verification UI.
- Documents the API rejection that triggered the flattened-source fallback: invoking `forge verify-contract --chain monad-testnet --etherscan-api-key \"$MONAD_ETHERSCAN_KEY\"` against `testnet.monadscan.com` returns `Invalid API Key` for unauthenticated submissions, which is the exact fallback condition the task description anticipates.

## Acceptance mapping
- (a) Source-code-verified on Monadscan: **deferred** — Monadscan's API rejected the unauthenticated submission attempted from this environment, so the alternative acceptance path applies.
- (a, alt) Flattened sources committed with a comment explaining the API rejection: **DONE** — `contracts/casino/flattened/*.flat.sol` + the "Why ship flattened sources now" subsection.
- (b) Verification commands documented in `contracts/casino/README.md` §Verification: **DONE** — full block of `forge verify-contract` invocations per contract, plus a constructor-arg table and an explorer-tx-based recovery procedure for when env-var overrides were used at deploy.

## PR class: B
Class B — best safe progress: the README + flattened-sources artifact is the complete deliverable for path (a, alt). Once a `MONAD_ETHERSCAN_KEY` is provisioned, running the documented commands will close out path (a) without further code changes.

**Why not Class A:** the live "Source code verified" status on `testnet.monadscan.com/address/<addr>` cannot be achieved without a Monadscan API key, which is not available in this environment. The flattened-sources fallback is explicitly the alternative path the task description permits.

**Next step:** with a key in hand, run the four `forge verify-contract` commands documented in the README from `contracts/casino/`. No code change required.

## Test plan
- [x] `forge build flattened/ --skip 'test/**' --skip 'script/**'` — 4 files compile cleanly with `solc 0.8.24`.
- [x] `forge verify-contract --chain monad-testnet ...` — surfaces the expected `Invalid API Key` from Monadscan when no key is set (this is the rejection that motivates the flattened-sources fallback).
- [x] Source contract bodies unchanged; only `README.md` + new `flattened/` directory added.

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS (36 pre-existing errors, all in `game/scenes/` and `game/v3/scenes/` — unrelated to this change; baseline 36, post-overlay 36, 0 new)
- **vitest run**: PASS (41 test files, 819 tests; 11 pre-existing unhandled errors from a missing `happy-dom` dep in PROD's `node_modules`, unrelated to this change)

Overall: **PASS** (zero new diagnostics introduced by the change).