### PR TITLE
docs(casino): publish predicted mainnet (143) CREATE3 addresses [SWO_CASINO_MAINNET_ADDRESS_PREDICTION]

### DIFF
--- a/contracts/DEPLOYED.md
+++ b/contracts/DEPLOYED.md
@@ -14,6 +14,28 @@ same PR that deploys a contract.
 | StarSkrumpeyMarketplace | v1 | _not yet deployed_ | — | Planned | See `contracts/StarSkrumpeyMarketplace.sol` |
 | StarSkrumpeyStaking | v1 | _not yet deployed_ | — | Planned | See `contracts/StarSkrumpeyStaking.sol` |
 | StarWorldOrderGovernor | v1 | _not yet deployed_ | — | Planned | See `contracts/StarWorldOrderGovernor.sol` |
+| CasinoBankroll | v1 | `0x33C5B6a95e71611F5dC821A74DDAD0F746fF2dFf` | — | Predicted (pending operator deploy) | CREATE3, salt entropy `0xBB01` |
+| CosmicFlip | v1 | `0x064b8bfc03b23D2b525deD9d3969090347A21983` | — | Predicted (pending operator deploy) | CREATE3, salt entropy `0xBBC1` |
+| GravityDice | v1 | `0xAC023542A8168465EE4A1b3e8Ae0f58F36A6d84B` | — | Predicted (pending operator deploy) | CREATE3, salt entropy `0xBBD1` |
+| ConstellationClimb | v1 | `0xd9B9b6c37ad4f3D5b07ae76dE261c5C865600d6e` | — | Predicted (pending operator deploy) | CREATE3, salt entropy `0xBBA1` |
+
+> **Predicted = the address mainnet WILL have if deployer + salts are unchanged.**
+> The four casino rows above are CREATE3 predictions, not live deployments. They
+> were derived by running
+> `forge script Deploy --rpc-url $MONAD_MAINNET_RPC --sender 0xb29e6735629539cEd64F0d6f0c476Fe92539fD7B --skip-simulation`
+> against the live Monad mainnet RPC; the script does not broadcast in this
+> mode, it only computes the CREATE3 addresses via the CreateX singleton at
+> `0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed`. Because CREATE3 addresses
+> depend only on `(deployer, salt)` and CreateX sits at the same address on
+> both Monad chains, these predicted addresses are identical to the live
+> testnet (10143) deployment. They will be the real mainnet addresses iff
+> the operator broadcasts the same `Deploy.s.sol` with (a) the same
+> deployer `0xb29e6735629539cEd64F0d6f0c476Fe92539fD7B` and (b) unchanged
+> salt entropy (`CASINO_*_SALT` env vars left at defaults). Changing
+> either invalidates this table — re-run the dry-run and update the rows
+> before broadcasting.
+>
+> Full predicted artifact: `contracts/casino/deployments/143.predicted.json`.
 
 ## Monad Testnet (chain id 10143)
 

--- a/contracts/casino/deployments/143.predicted.json
+++ b/contracts/casino/deployments/143.predicted.json
@@ -1,0 +1,18 @@
+{
+  "_comment": "Predicted CREATE3 addresses for Monad mainnet (chainId 143). These are NOT live — derived from forge script Deploy --rpc-url $MONAD_MAINNET_RPC --sender 0xb29e6735629539cEd64F0d6f0c476Fe92539fD7B --skip-simulation. Identical to the testnet artifact because CREATE3 addresses depend only on (deployer, salt) and CreateX is at the same address on both Monad chains. These addresses WILL be the live mainnet addresses iff the operator broadcasts the same script with the same deployer key and unchanged salt entropy. If the deployer or any *_SALT env var changes before broadcast, this file is stale.",
+  "status": "predicted",
+  "chainId": 143,
+  "deployer": "0xb29e6735629539cEd64F0d6f0c476Fe92539fD7B",
+  "createX": "0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed",
+  "bankroll": "0x33C5B6a95e71611F5dC821A74DDAD0F746fF2dFf",
+  "bankrollSalt": "0xb29e6735629539ced64f0d6f0c476fe92539fd7b00000000000000000000bb01",
+  "cosmicFlip": "0x064b8bfc03b23D2b525deD9d3969090347A21983",
+  "cosmicFlipSalt": "0xb29e6735629539ced64f0d6f0c476fe92539fd7b00000000000000000000bbc1",
+  "gravityDice": "0xAC023542A8168465EE4A1b3e8Ae0f58F36A6d84B",
+  "gravityDiceSalt": "0xb29e6735629539ced64f0d6f0c476fe92539fd7b00000000000000000000bbd1",
+  "constellationClimb": "0xd9B9b6c37ad4f3D5b07ae76dE261c5C865600d6e",
+  "constellationClimbSalt": "0xb29e6735629539ced64f0d6f0c476fe92539fd7b00000000000000000000bba1",
+  "allowlist": "0x0000000000000000000000000000000000000000",
+  "allowlistSalt": "0xb29e6735629539ced64f0d6f0c476fe92539fd7b00000000000000000000bbaa",
+  "allowlistEnabled": true
+}


### PR DESCRIPTION
## Summary

Run `forge script Deploy --rpc-url $MONAD_MAINNET_RPC --sender 0xb29e6735629539cEd64F0d6f0c476Fe92539fD7B --skip-simulation` in dry-run mode (no broadcast) against the live Monad mainnet RPC, and publish the resulting predicted CREATE3 addresses for the Cosmic Casino stack on chain 143.

- **New file** — `contracts/casino/deployments/143.predicted.json` (status field = `"predicted"`, with leading `_comment` explaining the artifact is *not* live and what invalidates it).
- **DEPLOYED.md** — four casino rows under the Monad Mainnet table with status `Predicted (pending operator deploy)`, plus an explanatory note that defines "predicted" as "the address mainnet WILL have if deployer + salts are unchanged" and lists what invalidates the prediction (new deployer key or any `CASINO_*_SALT` env override before broadcast).

### Predicted mainnet (143) addresses

| Contract | Address | Salt entropy |
|---|---|---|
| CasinoBankroll | `0x33C5B6a95e71611F5dC821A74DDAD0F746fF2dFf` | `0xBB01` |
| CosmicFlip | `0x064b8bfc03b23D2b525deD9d3969090347A21983` | `0xBBC1` |
| GravityDice | `0xAC023542A8168465EE4A1b3e8Ae0f58F36A6d84B` | `0xBBD1` |
| ConstellationClimb | `0xd9B9b6c37ad4f3D5b07ae76dE261c5C865600d6e` | `0xBBA1` |

CREATE3 addresses depend only on `(deployer, salt)` and CreateX sits at the same singleton `0xba5Ed099...ba5Ed` on both Monad chains, so the predicted mainnet addresses are byte-identical to the live testnet (10143) deployment. No live contracts are deployed by this PR — documentation only.

### Acceptance checklist

- [x] `contracts/casino/deployments/143.predicted.json` committed
- [x] `DEPLOYED.md` mainnet rows updated with predicted addresses
- [x] Note in doc clarifying "predicted = the address mainnet WILL have if deployer + salts are unchanged"

### How it was generated

```bash
cd contracts/casino
forge script Deploy \
  --rpc-url https://rpc.monad.xyz \
  --sender 0xb29e6735629539cEd64F0d6f0c476Fe92539fD7B \
  --skip-simulation
```

Raw return values from the dry-run (CreateX sanity-checked as present on chain 143, codesize=11838):
```
bankrollAddr: 0x33C5B6a95e71611F5dC821A74DDAD0F746fF2dFf
flipAddr:     0x064b8bfc03b23D2b525deD9d3969090347A21983
diceAddr:     0xAC023542A8168465EE4A1b3e8Ae0f58F36A6d84B
climbAddr:    0xd9B9b6c37ad4f3D5b07ae76dE261c5C865600d6e
```

## Test plan

- [x] `forge script Deploy --rpc-url https://rpc.monad.xyz --sender 0xb29e... --skip-simulation` succeeds and prints the four addresses above
- [x] `node -e "JSON.parse(require('fs').readFileSync('contracts/casino/deployments/143.predicted.json','utf8'))"` — JSON is valid
- [x] No code path imports `143.predicted.json`; grep confirmed (`lib/casino/addresses.ts` only loads `10143.json`)
- [x] Mirror validation (see below)

## Mirror Validation (PROD)

- **tsc --noEmit**: PASS (36 pre-existing errors excluded — baseline + post-overlay both = 36, zero new)
- **vitest run**: SKIPPED — full vitest run exceeded the 120s wall-clock budget. Changes are pure docs/JSON in a path not imported by any TypeScript module (`lib/casino/addresses.ts` only loads `10143.json`), so vitest behavior cannot be affected by this diff.

Overall: **PASS** (mirror restored byte-identical after overlay).

## PR class

**Class A — Full completion.** Acceptance criteria (a)–(c) all met; the predicted artifact is the canonical reference for whichever operator broadcasts the live mainnet deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)