### PR TITLE
feat(sanctuary): per-Skrumpey preference profile + journal clue (PR1/7) [SWO_V2_SANCTUARY_PREFERENCE_PROFILE]

### DIFF
--- a/lib/sanctuary/__tests__/companionAction.test.ts
+++ b/lib/sanctuary/__tests__/companionAction.test.ts
@@ -5,6 +5,8 @@ import {
   resolveCompanionActionState,
   companionActionVariantClasses,
   formatCooldownBadge,
+  companionActionPreferenceBadge,
+  previewBondDelta,
   COMPANION_ACTIONS,
   type CompanionActionId,
   type CompanionActionState,
@@ -170,6 +172,43 @@ describe('formatCooldownBadge', () => {
     expect(formatCooldownBadge(3599)).toBe('59m');
     expect(formatCooldownBadge(3600)).toBe('1h');
     expect(formatCooldownBadge(7200)).toBe('2h');
+  });
+});
+
+describe('companionActionPreferenceBadge', () => {
+  it('returns a distinct glyph for loved/liked/disliked/hated', () => {
+    const loved = companionActionPreferenceBadge('loved');
+    const liked = companionActionPreferenceBadge('liked');
+    const disliked = companionActionPreferenceBadge('disliked');
+    const hated = companionActionPreferenceBadge('hated');
+    const set = new Set([loved, liked, disliked, hated]);
+    expect(set.size).toBe(4);
+    expect(loved.length).toBeGreaterThan(0);
+    expect(hated.length).toBeGreaterThan(0);
+  });
+
+  it('returns empty string for neutral / null / undefined', () => {
+    expect(companionActionPreferenceBadge('neutral')).toBe('');
+    expect(companionActionPreferenceBadge(null)).toBe('');
+    expect(companionActionPreferenceBadge(undefined)).toBe('');
+  });
+});
+
+describe('previewBondDelta', () => {
+  it('loved preview is 4× neutral preview at same baseline', () => {
+    const neutral = previewBondDelta({ baseline: 0.5, preference: 'neutral' });
+    const loved = previewBondDelta({ baseline: 0.5, preference: 'loved' });
+    expect(loved).toBeCloseTo(neutral * 4);
+  });
+
+  it('hated preview is negative', () => {
+    expect(previewBondDelta({ baseline: 0.5, preference: 'hated' })).toBeLessThan(0);
+  });
+
+  it('need-boost stacks multiplicatively', () => {
+    const flat = previewBondDelta({ baseline: 0.5, preference: 'loved' });
+    const boosted = previewBondDelta({ baseline: 0.5, preference: 'loved', needBoosted: true });
+    expect(boosted).toBeGreaterThan(flat);
   });
 });
 

--- a/lib/sanctuary/__tests__/companionGreeting.test.ts
+++ b/lib/sanctuary/__tests__/companionGreeting.test.ts
@@ -5,10 +5,12 @@ import {
   greetingForMood,
   journalLineForAction,
   lastVisitedPhrase,
+  preferenceClueLine,
   timeOfDayPrefix,
   type CozyAction,
   type CozyMood,
 } from '../companionGreeting';
+import { PREFERENCE_CLUE_REVEAL_N, preferenceClueRevealed } from '../preferences';
 
 describe('greetingForMood', () => {
   it('substitutes the companion name into the line', () => {
@@ -235,5 +237,42 @@ describe('journalLineForAction', () => {
     expect(() => journalLineForAction('pet', '', 99)).not.toThrow();
     const line = journalLineForAction('pet', '', -7);
     expect(line.length).toBeGreaterThan(0);
+  });
+});
+
+describe('preferenceClueLine — journal reveal copy', () => {
+  it('returns null for neutral / null / undefined preference', () => {
+    expect(preferenceClueLine('Pico', 'feed', 'neutral')).toBeNull();
+    expect(preferenceClueLine('Pico', 'feed', null)).toBeNull();
+    expect(preferenceClueLine('Pico', 'feed', undefined)).toBeNull();
+  });
+
+  it('writes the companion name into every revealed clue', () => {
+    for (const action of ['feed', 'pet', 'talk', 'play', 'sleep'] as CozyAction[]) {
+      for (const level of ['loved', 'liked', 'disliked', 'hated'] as const) {
+        const line = preferenceClueLine('Pico', action, level);
+        expect(line).not.toBeNull();
+        expect(line!).toContain('Pico');
+      }
+    }
+  });
+
+  it('hated clue reads negatively (acceptance c surface)', () => {
+    const line = preferenceClueLine('Pico', 'feed', 'hated');
+    expect(line).toMatch(/flinch|something else|don't|doesn't|not into/i);
+  });
+
+  it('loved clue reads positively', () => {
+    const line = preferenceClueLine('Pico', 'feed', 'loved');
+    expect(line).toMatch(/glow|favorite|love|positively/i);
+  });
+
+  it('integrates with preferenceClueRevealed gating (acceptance d)', () => {
+    // N-1 interactions: gate says "do not surface"; UI should pass null.
+    expect(preferenceClueRevealed(PREFERENCE_CLUE_REVEAL_N - 1)).toBe(false);
+    // N interactions: gate opens; clue renders.
+    expect(preferenceClueRevealed(PREFERENCE_CLUE_REVEAL_N)).toBe(true);
+    const revealedLine = preferenceClueLine('Pico', 'pet', 'loved');
+    expect(revealedLine).not.toBeNull();
   });
 });

--- a/lib/sanctuary/__tests__/preferences.test.ts
+++ b/lib/sanctuary/__tests__/preferences.test.ts
@@ -1,0 +1,188 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+
+import {
+  preferenceProfile,
+  preferenceFor,
+  computeBondDelta,
+  isNeedTargeted,
+  preferenceClueRevealed,
+  PREFERENCE_BOND_MULTIPLIER,
+  PREFERENCE_CLUE_REVEAL_N,
+  NEED_BOOST_MULTIPLIER,
+  NEED_STATE_THRESHOLD,
+  type PreferenceLevel,
+} from '../preferences';
+import type { CompanionStatAction } from '../companionStats';
+
+// ---------------------------------------------------------------------------
+// Determinism + per-Skrumpey divergence (acceptance criterion a)
+// ---------------------------------------------------------------------------
+
+describe('preferenceProfile — determinism', () => {
+  it('returns the same profile on every call for the same token id', () => {
+    const a = preferenceProfile(42);
+    const b = preferenceProfile(42);
+    expect(a).toEqual(b);
+  });
+
+  it('exposes one of each preference level across the five actions', () => {
+    const profile = preferenceProfile(7);
+    const levels = Object.values(profile).sort();
+    expect(levels).toEqual(['disliked', 'hated', 'liked', 'loved', 'neutral']);
+    expect(Object.keys(profile).sort()).toEqual(
+      (['feed', 'pet', 'play', 'sleep', 'talk'] as CompanionStatAction[]).sort(),
+    );
+  });
+
+  it('two Skrumpey on the same wallet have different profiles (fixture)', () => {
+    // Acceptance (a): pick two concrete token ids that any wallet might hold
+    // and assert their profiles diverge — i.e., the bond outcome of any
+    // given action is not identical across Skrumpey on that wallet.
+    const skrumpeyA = preferenceProfile(101);
+    const skrumpeyB = preferenceProfile(202);
+    expect(skrumpeyA).not.toEqual(skrumpeyB);
+    // Stronger: at least one action's preference must differ — otherwise
+    // bond deltas would coincide and the personality system is invisible.
+    const diverged = (['feed', 'pet', 'talk', 'play', 'sleep'] as CompanionStatAction[]).some(
+      (a) => skrumpeyA[a] !== skrumpeyB[a],
+    );
+    expect(diverged).toBe(true);
+  });
+
+  it('frozen profile object cannot be mutated by accident', () => {
+    const profile = preferenceProfile(99);
+    expect(() => {
+      (profile as Record<string, PreferenceLevel>).feed = 'loved';
+    }).toThrow();
+  });
+
+  it('handles tokenId=0 without producing a degenerate (all-same) profile', () => {
+    const profile = preferenceProfile(0);
+    const levels = Object.values(profile).sort();
+    expect(levels).toEqual(['disliked', 'hated', 'liked', 'loved', 'neutral']);
+  });
+
+  it('preferenceFor matches preferenceProfile lookup', () => {
+    const profile = preferenceProfile(55);
+    for (const action of ['feed', 'pet', 'talk', 'play', 'sleep'] as CompanionStatAction[]) {
+      expect(preferenceFor(55, action)).toBe(profile[action]);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bond delta math (acceptance criteria b + c)
+// ---------------------------------------------------------------------------
+
+describe('computeBondDelta — preference multiplier contract', () => {
+  it('loved bond delta is exactly 4× neutral baseline (acceptance b)', () => {
+    const baseline = 0.5;
+    const neutral = computeBondDelta({ baseline, preference: 'neutral' });
+    const loved = computeBondDelta({ baseline, preference: 'loved' });
+    expect(neutral).toBeCloseTo(baseline);
+    expect(loved).toBeCloseTo(neutral * 4);
+  });
+
+  it('hated action subtracts bond (acceptance c)', () => {
+    const delta = computeBondDelta({ baseline: 0.5, preference: 'hated' });
+    expect(delta).toBeLessThan(0);
+  });
+
+  it('disliked action gives zero bond — flat, not negative', () => {
+    const delta = computeBondDelta({ baseline: 0.5, preference: 'disliked' });
+    expect(delta).toBe(0);
+  });
+
+  it('liked action is between neutral and loved (2× baseline)', () => {
+    const baseline = 0.5;
+    expect(computeBondDelta({ baseline, preference: 'liked' })).toBeCloseTo(baseline * 2);
+  });
+
+  it('need boost multiplies on top of the preference multiplier', () => {
+    const baseline = 0.5;
+    const lovedFlat = computeBondDelta({ baseline, preference: 'loved' });
+    const lovedHungry = computeBondDelta({ baseline, preference: 'loved', needBoosted: true });
+    expect(lovedHungry).toBeCloseTo(lovedFlat * NEED_BOOST_MULTIPLIER);
+  });
+
+  it('need boost on a hated action makes it WORSE, not better', () => {
+    const baseline = 0.5;
+    const hatedFlat = computeBondDelta({ baseline, preference: 'hated' });
+    const hatedHungry = computeBondDelta({ baseline, preference: 'hated', needBoosted: true });
+    expect(hatedHungry).toBeLessThan(hatedFlat);
+  });
+
+  it('exposes the canonical multipliers for downstream wiring', () => {
+    expect(PREFERENCE_BOND_MULTIPLIER.loved).toBe(4);
+    expect(PREFERENCE_BOND_MULTIPLIER.neutral).toBe(1);
+    expect(PREFERENCE_BOND_MULTIPLIER.hated).toBeLessThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Need-state targeting
+// ---------------------------------------------------------------------------
+
+describe('isNeedTargeted', () => {
+  const full = { hunger: 80, happiness: 80, energy: 80 };
+  const hungry = { hunger: 10, happiness: 80, energy: 80 };
+  const lonely = { hunger: 80, happiness: 10, energy: 80 };
+  const tired = { hunger: 80, happiness: 80, energy: 10 };
+
+  it('feed boost fires when hunger is low', () => {
+    expect(isNeedTargeted('feed', hungry)).toBe(true);
+    expect(isNeedTargeted('feed', full)).toBe(false);
+  });
+
+  it('pet/talk/play boost fires when happiness is low', () => {
+    expect(isNeedTargeted('pet', lonely)).toBe(true);
+    expect(isNeedTargeted('talk', lonely)).toBe(true);
+    expect(isNeedTargeted('play', lonely)).toBe(true);
+    expect(isNeedTargeted('pet', full)).toBe(false);
+  });
+
+  it('sleep boost fires when energy is low', () => {
+    expect(isNeedTargeted('sleep', tired)).toBe(true);
+    expect(isNeedTargeted('sleep', full)).toBe(false);
+  });
+
+  it('threshold edge — value exactly at threshold counts as in-need', () => {
+    expect(isNeedTargeted('feed', { hunger: NEED_STATE_THRESHOLD, happiness: 80, energy: 80 })).toBe(true);
+    expect(isNeedTargeted('feed', { hunger: NEED_STATE_THRESHOLD + 1, happiness: 80, energy: 80 })).toBe(false);
+  });
+
+  it('null / undefined / NaN stats do not boost', () => {
+    expect(isNeedTargeted('feed', { hunger: null, happiness: 80, energy: 80 })).toBe(false);
+    expect(isNeedTargeted('feed', { hunger: undefined, happiness: 80, energy: 80 })).toBe(false);
+    expect(isNeedTargeted('feed', { hunger: NaN, happiness: 80, energy: 80 })).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Journal clue reveal (acceptance criterion d — constant + N−1 / N tests)
+// ---------------------------------------------------------------------------
+
+describe('preferenceClueRevealed', () => {
+  it('exposes the canonical reveal threshold as a constant', () => {
+    expect(PREFERENCE_CLUE_REVEAL_N).toBe(3);
+  });
+
+  it('stays hidden at N−1 matched interactions (acceptance d)', () => {
+    expect(preferenceClueRevealed(PREFERENCE_CLUE_REVEAL_N - 1)).toBe(false);
+  });
+
+  it('reveals at exactly N matched interactions (acceptance d)', () => {
+    expect(preferenceClueRevealed(PREFERENCE_CLUE_REVEAL_N)).toBe(true);
+  });
+
+  it('stays revealed for counts above N', () => {
+    expect(preferenceClueRevealed(PREFERENCE_CLUE_REVEAL_N + 5)).toBe(true);
+  });
+
+  it('treats non-finite counts as not-yet-revealed (safety)', () => {
+    expect(preferenceClueRevealed(NaN)).toBe(false);
+    expect(preferenceClueRevealed(Infinity)).toBe(false);
+    expect(preferenceClueRevealed(-Infinity)).toBe(false);
+  });
+});

--- a/lib/sanctuary/companionAction.ts
+++ b/lib/sanctuary/companionAction.ts
@@ -3,6 +3,12 @@
 // the React component so the variant matrix (idle / pressed / disabled /
 // sleeping / cooldown / selected) can be unit-tested in node without a DOM.
 
+import {
+  PREFERENCE_BOND_MULTIPLIER,
+  NEED_BOOST_MULTIPLIER,
+  type PreferenceLevel,
+} from './preferences';
+
 export type CompanionActionId = 'feed' | 'pet' | 'talk' | 'sleep' | 'play';
 
 export type CompanionActionState =
@@ -146,6 +152,51 @@ export function companionActionVariantClasses(
     default:
       return 'companion-action--idle';
   }
+}
+
+/**
+ * [SWO_V2_SANCTUARY_PREFERENCE_PROFILE]
+ *
+ * UI badge string for an action's revealed preference level. The journal
+ * reveals the preference after N matched interactions; before that the UI
+ * should pass `null` (or no preference at all) and this helper will hide the
+ * badge. Empty string means "no badge" so callers can render it directly.
+ */
+export function companionActionPreferenceBadge(
+  level: PreferenceLevel | null | undefined,
+): string {
+  switch (level) {
+    case 'loved':
+      return '\u{2665}\u{FE0F}'; // ♥️
+    case 'liked':
+      return '\u{1F44D}'; // 👍
+    case 'neutral':
+      return '';
+    case 'disliked':
+      return '\u{1F44E}'; // 👎
+    case 'hated':
+      return '\u{1F494}'; // 💔
+    default:
+      return '';
+  }
+}
+
+/**
+ * [SWO_V2_SANCTUARY_PREFERENCE_PROFILE]
+ *
+ * Compute the bond-delta preview the UI shows when hovering an action
+ * tile. Combines the action's baseline bond gain with the preference and
+ * need-state multipliers. Returns a number — formatting (sign, rounding) is
+ * left to the consuming component.
+ */
+export function previewBondDelta(input: {
+  baseline: number;
+  preference: PreferenceLevel;
+  needBoosted?: boolean;
+}): number {
+  const prefMult = PREFERENCE_BOND_MULTIPLIER[input.preference];
+  const needMult = input.needBoosted ? NEED_BOOST_MULTIPLIER : 1;
+  return input.baseline * prefMult * needMult;
 }
 
 /** Round a cooldown to a compact label like "12s" / "1m" / "1h". */

--- a/lib/sanctuary/companionGreeting.ts
+++ b/lib/sanctuary/companionGreeting.ts
@@ -243,6 +243,46 @@ export function journalLineForAction(
   return pool[idx] ?? pool[0];
 }
 
+/**
+ * [SWO_V2_SANCTUARY_PREFERENCE_PROFILE]
+ *
+ * Cozy journal line revealing a Skrumpey's preference for an action. Only
+ * surfaces once the matched-interaction count has crossed
+ * `PREFERENCE_CLUE_REVEAL_N` (see `preferences.ts`) — before that the caller
+ * should pass null/undefined or skip rendering entirely.
+ *
+ * Returns null when the level is `neutral` (nothing interesting to reveal)
+ * or unknown, so the caller doesn't render an empty clue card.
+ */
+export function preferenceClueLine(
+  name: string,
+  action: CozyAction,
+  level: 'loved' | 'liked' | 'neutral' | 'disliked' | 'hated' | null | undefined,
+): string | null {
+  if (!level || level === 'neutral') return null;
+  const verb = ACTION_VERB[action];
+  switch (level) {
+    case 'loved':
+      return `${name} positively glows whenever you ${verb}. It's clearly a favorite.`;
+    case 'liked':
+      return `${name} brightens up a little each time you ${verb}.`;
+    case 'disliked':
+      return `${name} just isn't into it when you ${verb}.`;
+    case 'hated':
+      return `${name} flinches whenever you ${verb}. Maybe try something else?`;
+    default:
+      return null;
+  }
+}
+
+const ACTION_VERB: Readonly<Record<CozyAction, string>> = Object.freeze({
+  feed: 'offer a snack',
+  pet: 'reach out for a scritch',
+  talk: 'sit down for a chat',
+  play: 'start a game',
+  sleep: 'tuck them in',
+});
+
 // ---------------------------------------------------------------------------
 // internal helpers (no exports below this line are part of the public API)
 // ---------------------------------------------------------------------------

--- a/lib/sanctuary/preferences.ts
+++ b/lib/sanctuary/preferences.ts
@@ -1,0 +1,195 @@
+/**
+ * Deterministic per-Skrumpey preference profile
+ * ([SWO_V2_SANCTUARY_PREFERENCE_PROFILE]).
+ *
+ * Every Skrumpey has a private personality: across the five sanctuary actions
+ * (feed / pet / talk / play / sleep) it has exactly one loved, one liked, one
+ * neutral, one disliked and one hated. The profile is a permutation of the
+ * five preference levels, seeded by the NFT's token id — so two Skrumpey on
+ * the same wallet draw different profiles, but the same Skrumpey always lands
+ * on the same profile across sessions and devices.
+ *
+ * The module is intentionally pure: no DB / fetch / React imports. It is
+ * called from
+ *   - the bond-math path in `db.ts#interactWithCompanion` (PR2 — wires the
+ *     multiplier into the persisted bond_score delta)
+ *   - the journal clue helper in `companionGreeting.ts` (PR1 — surfaces the
+ *     reveal line once N=3 matched interactions accumulate)
+ *   - the UI preview in `companionAction.ts` (PR1 — shows a small badge so
+ *     the player can read the personality once it's been revealed)
+ */
+import type { CompanionStatAction } from './companionStats';
+
+export type PreferenceLevel = 'loved' | 'liked' | 'neutral' | 'disliked' | 'hated';
+
+export type PreferenceProfile = Readonly<Record<CompanionStatAction, PreferenceLevel>>;
+
+/**
+ * Bond multiplier applied to the baseline per-action bond gain. The
+ * `loved → 4× neutral` ratio is part of the task acceptance contract; `hated`
+ * must subtract bond so a player who keeps shoving spinach at a Skrumpey who
+ * hates feeding sees the relationship slowly erode.
+ */
+export const PREFERENCE_BOND_MULTIPLIER: Readonly<Record<PreferenceLevel, number>> = Object.freeze({
+  loved: 4,
+  liked: 2,
+  neutral: 1,
+  disliked: 0,
+  hated: -1,
+});
+
+/**
+ * Extra multiplier when the action targets a stat that is currently below
+ * `NEED_STATE_THRESHOLD` — feeding a hungry Skrumpey, petting a lonely one,
+ * etc. Stacks multiplicatively with the preference multiplier.
+ */
+export const NEED_BOOST_MULTIPLIER = 1.5;
+
+/** Stats at or below this value count as "in need" for the boost multiplier. */
+export const NEED_STATE_THRESHOLD = 30;
+
+/**
+ * Number of times the player must perform the SAME action on a Skrumpey
+ * before the journal reveals its preference for that action. Below this the
+ * Skrumpey is "still figuring out how it feels" and the journal stays quiet.
+ */
+export const PREFERENCE_CLUE_REVEAL_N = 3;
+
+const ACTIONS_CANONICAL: readonly CompanionStatAction[] = [
+  'feed',
+  'pet',
+  'talk',
+  'play',
+  'sleep',
+];
+
+const LEVELS_CANONICAL: readonly PreferenceLevel[] = [
+  'loved',
+  'liked',
+  'neutral',
+  'disliked',
+  'hated',
+];
+
+/**
+ * Return the preference profile for a Skrumpey. Deterministic given the
+ * token id — two calls with the same id return the same (frozen) object;
+ * two different ids produce statistically-independent permutations.
+ *
+ * The returned object is a permutation of {loved, liked, neutral, disliked,
+ * hated} across {feed, pet, talk, play, sleep}, so every Skrumpey has
+ * exactly one of each preference level.
+ */
+export function preferenceProfile(tokenId: number): PreferenceProfile {
+  const shuffled: PreferenceLevel[] = [...LEVELS_CANONICAL];
+  let state = seedFromTokenId(tokenId);
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    state = mulberry32(state);
+    const j = state % (i + 1);
+    const tmp = shuffled[i];
+    shuffled[i] = shuffled[j];
+    shuffled[j] = tmp;
+  }
+  const out = {} as Record<CompanionStatAction, PreferenceLevel>;
+  for (let i = 0; i < ACTIONS_CANONICAL.length; i++) {
+    out[ACTIONS_CANONICAL[i]] = shuffled[i];
+  }
+  return Object.freeze(out);
+}
+
+/** Convenience accessor — same as `preferenceProfile(tokenId)[action]`. */
+export function preferenceFor(
+  tokenId: number,
+  action: CompanionStatAction,
+): PreferenceLevel {
+  return preferenceProfile(tokenId)[action];
+}
+
+export interface BondDeltaInput {
+  /** Baseline bond gain for the action before preference is applied. */
+  baseline: number;
+  preference: PreferenceLevel;
+  /** True when the action targets a currently-low stat (see {@link isNeedTargeted}). */
+  needBoosted?: boolean;
+}
+
+/**
+ * Compute the final bond delta for an interaction, taking preference and
+ * need-state into account. `baseline` is the action's neutral bond gain
+ * (from `INTERACTION_BOND` in db.ts); the preference multiplier scales it
+ * and the need boost (if any) stacks on top.
+ */
+export function computeBondDelta(input: BondDeltaInput): number {
+  const prefMult = PREFERENCE_BOND_MULTIPLIER[input.preference];
+  const needMult = input.needBoosted ? NEED_BOOST_MULTIPLIER : 1;
+  return input.baseline * prefMult * needMult;
+}
+
+export interface NeedSnapshot {
+  hunger: number | null | undefined;
+  happiness: number | null | undefined;
+  energy: number | null | undefined;
+}
+
+/**
+ * Map of action → the vitality stat it primarily affects. `sleep` targets
+ * energy; the three "social" actions all target happiness; feed targets
+ * hunger. Used to decide whether the action's need-boost multiplier kicks in.
+ */
+const ACTION_TARGET_STAT: Readonly<Record<CompanionStatAction, keyof NeedSnapshot>> = Object.freeze({
+  feed: 'hunger',
+  pet: 'happiness',
+  talk: 'happiness',
+  play: 'happiness',
+  sleep: 'energy',
+});
+
+/**
+ * True when the action's target stat is currently below the need threshold —
+ * e.g., feeding a Skrumpey whose hunger has dropped to 22. Treats
+ * null/undefined/NaN as "not in need" so legacy companions don't get a
+ * silent boost.
+ */
+export function isNeedTargeted(
+  action: CompanionStatAction,
+  stats: NeedSnapshot,
+  threshold: number = NEED_STATE_THRESHOLD,
+): boolean {
+  const key = ACTION_TARGET_STAT[action];
+  const value = stats[key];
+  return typeof value === 'number' && Number.isFinite(value) && value <= threshold;
+}
+
+/**
+ * Has the player performed this action enough times that the journal should
+ * reveal the Skrumpey's preference for it? The reveal threshold is constant
+ * (PREFERENCE_CLUE_REVEAL_N) so a designer can re-tune the pacing without
+ * touching call sites.
+ */
+export function preferenceClueRevealed(matchedCount: number): boolean {
+  return Number.isFinite(matchedCount) && matchedCount >= PREFERENCE_CLUE_REVEAL_N;
+}
+
+// ---------------------------------------------------------------------------
+// internal seed helpers — mulberry32 is good enough for cosmetic determinism
+// ---------------------------------------------------------------------------
+
+function seedFromTokenId(tokenId: number): number {
+  // Token ids on Monad are uint256; we only need a 32-bit seed and the JS
+  // number is already lossy past 2^53, so collapse via xor-fold and add a
+  // non-zero salt so tokenId=0 still produces a valid stream.
+  const n = Number.isFinite(tokenId) ? Math.trunc(tokenId) : 0;
+  const low = (n >>> 0);
+  const high = (Math.floor(n / 0x100000000) >>> 0);
+  let s = (low ^ high ^ 0x9e3779b9) >>> 0;
+  s = (Math.imul(s ^ (s >>> 16), 0x21f0aaad)) >>> 0;
+  s = (Math.imul(s ^ (s >>> 15), 0x735a2d97)) >>> 0;
+  return (s ^ (s >>> 15)) >>> 0;
+}
+
+function mulberry32(seed: number): number {
+  let t = (seed + 0x6d2b79f5) >>> 0;
+  t = Math.imul(t ^ (t >>> 15), t | 1);
+  t = (t ^ (t + Math.imul(t ^ (t >>> 7), t | 61))) >>> 0;
+  return (t ^ (t >>> 14)) >>> 0;
+}


### PR DESCRIPTION
## Summary
PR 1 of 7 for **[SWO_V2_SANCTUARY_PREFERENCE_PROFILE]**.

- Ships the pure `lib/sanctuary/preferences.ts` module: deterministic per-token-id permutation of `{loved, liked, neutral, disliked, hated}` across the 5 sanctuary actions, plus bond-delta math + need-state multiplier.
- Extends `companionAction.ts` with UI helpers (`companionActionPreferenceBadge`, `previewBondDelta`) and `companionGreeting.ts` with the journal reveal copy (`preferenceClueLine`).
- 33 new vitest cases — sanctuary suite goes from 622 → 655 tests, all green.

## Acceptance criteria (vitest)
- **(a) different profiles per Skrumpey** — `preferenceProfile(101)` and `preferenceProfile(202)` diverge (`preferences.test.ts > preferenceProfile — determinism > two Skrumpey on the same wallet have different profiles`).
- **(b) `loved` = 4× `neutral` baseline** — `computeBondDelta — preference multiplier contract > loved bond delta is exactly 4× neutral baseline`.
- **(c) `hated` subtracts bond** — `… hated action subtracts bond (acceptance c)`.
- **(d) journal clue at N=3** — constant exposed as `PREFERENCE_CLUE_REVEAL_N`; tests at `N-1` (hidden) and `N` (revealed) live in `preferences.test.ts` + integration test in `companionGreeting.test.ts`.

## PR class: B
Core task (the pure profile + bond-delta + journal clue) is fully shipped and tested at the unit layer. The acceptance contract is encoded in vitest. Deferred to **PR2/7** because they require touching the live DB write path and a Playwright stack:
- wiring `computeBondDelta` into `lib/db.ts#interactWithCompanion` (replace `INTERACTION_BOND[action]` multiplication with preference-aware delta + clamp at \[0, 100\] for the SQL UPDATE)
- counting matched interactions in the journal stream and surfacing the clue line into a new `entry_type='preference_clue'` journal entry
- the Playwright e2e (`tests/e2e/casino/`-style spec under `tests/e2e/sanctuary/preferences.spec.ts`) that feeds two companions on one wallet via `/api/sanctuary/companion/interact` and asserts the bond deltas differ, plus a hated-action negative outcome assertion

**Next PR (PR2/7):** wire `preferences.computeBondDelta` into `interactWithCompanion` and add the journal-emit on N-th matched interaction. Reference: lines around `lib/db.ts:6167` (`bondGain` computation) and `lib/db.ts:6200` (`addJournalEntry`).

## Test plan
- [x] `npx vitest run lib/sanctuary/__tests__/preferences.test.ts lib/sanctuary/__tests__/companionAction.test.ts lib/sanctuary/__tests__/companionGreeting.test.ts` → 78/78 ✅
- [x] Full sanctuary suite `npx vitest run lib/sanctuary/__tests__/` → 655/655 ✅
- [x] `npx eslint` on changed files → clean
- [x] `npx tsc --noEmit` → no new errors in our files (pre-existing game/* errors are unchanged)

## Mirror Validation (PROD)
Baseline-diff against `/opt/star_world_order/PROD`:
- **tsc --noEmit**: PASS (36 pre-existing errors; **0 new** after overlay)
- **vitest run lib/sanctuary/__tests__/**: PASS (622 baseline → 655 after overlay; **33 new tests, 0 failures**)

Overall: **PASS**

🤖 Generated with [Claude Code](https://claude.com/claude-code)