### PR TITLE
feat(sanctuary): ExpeditionDialog overlay UI (PR3/7)

### DIFF
--- a/app/api/sanctuary/expeditions/abandon/route.ts
+++ b/app/api/sanctuary/expeditions/abandon/route.ts
@@ -1,0 +1,46 @@
+/**
+ * POST /api/sanctuary/expeditions/abandon
+ *
+ * Abandon an active expedition run. Idempotent on already-ended rows.
+ * The STAR cost paid at start is NOT refunded — abandoning is a choice
+ * the player makes about a run they paid into.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { abandonExpeditionRun } from '@/lib/db';
+import { verifyWalletAccess } from '@/lib/walletAuth';
+import { applyRateLimit } from '@/lib/sanctuary/rateLimit';
+import { ethAddress, tokenId, parseBody, formatZodError } from '@/lib/sanctuary/validation';
+
+const bodySchema = z.object({
+  address: ethAddress,
+  token_id: tokenId,
+  row_id: z.coerce.number().int().min(1),
+});
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const parsed = parseBody(bodySchema, body);
+    if (!parsed.success) {
+      return NextResponse.json({ success: false, error: formatZodError(parsed.error) }, { status: 400 });
+    }
+    const { address, token_id: tid, row_id } = parsed.data;
+
+    const auth = await verifyWalletAccess(request, address);
+    if (!auth.valid) {
+      return NextResponse.json({ success: false, error: auth.error }, { status: 401 });
+    }
+
+    const rateLimited = applyRateLimit(address, 'expeditions/abandon');
+    if (rateLimited) return rateLimited;
+
+    const result = abandonExpeditionRun(address, tid, row_id);
+    return NextResponse.json({ success: true, run: result });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : 'Failed to abandon expedition';
+    const status =
+      msg === 'NOT_FOUND' || msg === 'EXPEDITION_NOT_FOUND' ? 404 : 500;
+    return NextResponse.json({ success: false, error: msg }, { status });
+  }
+}

--- a/app/api/sanctuary/expeditions/choose/route.ts
+++ b/app/api/sanctuary/expeditions/choose/route.ts
@@ -1,0 +1,53 @@
+/**
+ * POST /api/sanctuary/expeditions/choose
+ *
+ * Apply a choice to the current step of an active run. On a terminal step
+ * the run is finalized in the same transaction: STAR/bond/trait are granted
+ * according to the outcome scale ({@link EXPEDITION_OUTCOME_REWARD_SCALE}).
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { chooseExpeditionStep } from '@/lib/db';
+import { verifyWalletAccess } from '@/lib/walletAuth';
+import { applyRateLimit } from '@/lib/sanctuary/rateLimit';
+import { ethAddress, tokenId, parseBody, formatZodError } from '@/lib/sanctuary/validation';
+
+const bodySchema = z.object({
+  address: ethAddress,
+  token_id: tokenId,
+  row_id: z.coerce.number().int().min(1),
+  choice_id: z.string().min(1).max(128),
+});
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const parsed = parseBody(bodySchema, body);
+    if (!parsed.success) {
+      return NextResponse.json({ success: false, error: formatZodError(parsed.error) }, { status: 400 });
+    }
+    const { address, token_id: tid, row_id, choice_id } = parsed.data;
+
+    const auth = await verifyWalletAccess(request, address);
+    if (!auth.valid) {
+      return NextResponse.json({ success: false, error: auth.error }, { status: 401 });
+    }
+
+    const rateLimited = applyRateLimit(address, 'expeditions/choose');
+    if (rateLimited) return rateLimited;
+
+    const result = chooseExpeditionStep(address, tid, row_id, choice_id);
+    return NextResponse.json({ success: true, run: result });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : 'Failed to apply choice';
+    const status =
+      msg === 'NOT_FOUND' || msg === 'EXPEDITION_NOT_FOUND'
+        ? 404
+        : msg === 'NOT_ACTIVE'
+          ? 409
+          : msg.startsWith('expedition') // reducer programmer errors
+            ? 400
+            : 500;
+    return NextResponse.json({ success: false, error: msg }, { status });
+  }
+}

--- a/app/api/sanctuary/expeditions/list/route.ts
+++ b/app/api/sanctuary/expeditions/list/route.ts
@@ -1,0 +1,31 @@
+/**
+ * GET /api/sanctuary/expeditions/list?address=0x..&token_id=123
+ *
+ * Returns the merged easy/medium/hard catalog, annotated with whether the
+ * requester has an active run for each expedition (so the overlay can resume
+ * instead of opening a fresh dialog).
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { listExpeditions } from '@/lib/db';
+import { ethAddress, tokenId, parseSearchParams, formatZodError } from '@/lib/sanctuary/validation';
+
+const querySchema = z.object({
+  address: ethAddress,
+  token_id: tokenId,
+});
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const parsed = parseSearchParams(querySchema, searchParams);
+    if (!parsed.success) {
+      return NextResponse.json({ success: false, error: formatZodError(parsed.error) }, { status: 400 });
+    }
+    const result = listExpeditions(parsed.data.address, parsed.data.token_id);
+    return NextResponse.json({ success: true, ...result });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : 'Failed to list expeditions';
+    return NextResponse.json({ success: false, error: msg }, { status: 500 });
+  }
+}

--- a/app/api/sanctuary/expeditions/run/route.ts
+++ b/app/api/sanctuary/expeditions/run/route.ts
@@ -1,0 +1,57 @@
+/**
+ * GET /api/sanctuary/expeditions/run?address=0x..&token_id=123&row_id=42
+ *
+ * Returns the full {@link ExpeditionRunView} for one run: the row record,
+ * the reducer state primed at `current_step_id`, and the matching
+ * {@link ExpeditionDefinition} so the overlay can render the current
+ * narrative + choices without re-loading the catalog client-side.
+ *
+ * Used by ExpeditionDialog to resume an in-flight run after a remount or
+ * page reload: the QuestBoard hands the dialog the `active_row_id` from
+ * {@link listExpeditions}, the dialog hits this endpoint to hydrate.
+ *
+ * Read-only: no rate limit, no wallet signature — same posture as the
+ * sibling `/list` route. Returns 404 when the run does not belong to
+ * (address, token_id).
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getExpeditionRun } from '@/lib/db';
+import {
+  ethAddress,
+  tokenId,
+  parseSearchParams,
+  formatZodError,
+} from '@/lib/sanctuary/validation';
+
+const querySchema = z.object({
+  address: ethAddress,
+  token_id: tokenId,
+  row_id: z.coerce.number().int().min(1),
+});
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const parsed = parseSearchParams(querySchema, searchParams);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { success: false, error: formatZodError(parsed.error) },
+        { status: 400 },
+      );
+    }
+    const { address, token_id: tid, row_id } = parsed.data;
+    const run = getExpeditionRun(address, tid, row_id);
+    if (!run) {
+      return NextResponse.json(
+        { success: false, error: 'NOT_FOUND' },
+        { status: 404 },
+      );
+    }
+    return NextResponse.json({ success: true, run });
+  } catch (error) {
+    const msg =
+      error instanceof Error ? error.message : 'Failed to load expedition run';
+    return NextResponse.json({ success: false, error: msg }, { status: 500 });
+  }
+}

--- a/app/api/sanctuary/expeditions/start/route.ts
+++ b/app/api/sanctuary/expeditions/start/route.ts
@@ -1,0 +1,53 @@
+/**
+ * POST /api/sanctuary/expeditions/start
+ *
+ * Begins a new expedition run for (address, token_id, expedition_id).
+ * Deducts the seed-declared STAR cost atomically — insufficient balance
+ * returns 402 and no run is created. Returns the new row + reducer state
+ * primed on the start step.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { startExpeditionRun } from '@/lib/db';
+import { verifyWalletAccess } from '@/lib/walletAuth';
+import { applyRateLimit } from '@/lib/sanctuary/rateLimit';
+import { ethAddress, tokenId, parseBody, formatZodError } from '@/lib/sanctuary/validation';
+
+const bodySchema = z.object({
+  address: ethAddress,
+  token_id: tokenId,
+  expedition_id: z.string().min(1).max(128),
+});
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const parsed = parseBody(bodySchema, body);
+    if (!parsed.success) {
+      return NextResponse.json({ success: false, error: formatZodError(parsed.error) }, { status: 400 });
+    }
+    const { address, token_id: tid, expedition_id } = parsed.data;
+
+    const auth = await verifyWalletAccess(request, address);
+    if (!auth.valid) {
+      return NextResponse.json({ success: false, error: auth.error }, { status: 401 });
+    }
+
+    const rateLimited = applyRateLimit(address, 'expeditions/start');
+    if (rateLimited) return rateLimited;
+
+    const result = startExpeditionRun(address, tid, expedition_id);
+    return NextResponse.json({ success: true, run: result });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : 'Failed to start expedition';
+    const status =
+      msg === 'EXPEDITION_NOT_FOUND'
+        ? 404
+        : msg === 'ALREADY_ACTIVE'
+          ? 409
+          : msg.includes('Insufficient')
+            ? 402
+            : 500;
+    return NextResponse.json({ success: false, error: msg }, { status });
+  }
+}

--- a/app/sanctuary/SanctuaryV2.tsx
+++ b/app/sanctuary/SanctuaryV2.tsx
@@ -61,6 +61,11 @@ const ShopDialog = dynamic(
   { ssr: false }
 );
 
+const ExpeditionDialog = dynamic(
+  () => import('@/components/sanctuary/overlays/ExpeditionDialog'),
+  { ssr: false }
+);
+
 const QuestTracker = dynamic(
   () => import('@/components/sanctuary/overlays/QuestTracker'),
   { ssr: false }
@@ -196,6 +201,7 @@ export default function SanctuaryV2() {
         <MinigameDialog walletAddress={address} tokenId={activeTokenId} />
         <QuestBoard walletAddress={address} tokenId={activeTokenId} />
         <ShopDialog walletAddress={address} tokenId={activeTokenId} />
+        <ExpeditionDialog walletAddress={address} tokenId={activeTokenId} />
         <QuestTracker walletAddress={address} tokenId={activeTokenId} />
         <JournalOverlay walletAddress={address} tokenId={activeTokenId} />
         <TraitsOverlay walletAddress={address} tokenId={activeTokenId} />

--- a/app/sanctuary/SanctuaryV3.tsx
+++ b/app/sanctuary/SanctuaryV3.tsx
@@ -39,6 +39,10 @@ const ShopDialog = dynamic(
   () => import('@/components/sanctuary/overlays/ShopDialog'),
   { ssr: false },
 );
+const ExpeditionDialog = dynamic(
+  () => import('@/components/sanctuary/overlays/ExpeditionDialog'),
+  { ssr: false },
+);
 const JournalOverlay = dynamic(
   () => import('@/components/sanctuary/overlays/JournalOverlay'),
   { ssr: false },
@@ -132,6 +136,7 @@ export default function SanctuaryV3() {
         <QuestBoard walletAddress={address} tokenId={activeTokenId} />
         <QuestTracker walletAddress={address} tokenId={activeTokenId} />
         <ShopDialog walletAddress={address} tokenId={activeTokenId} />
+        <ExpeditionDialog walletAddress={address} tokenId={activeTokenId} />
         <JournalOverlay walletAddress={address} tokenId={activeTokenId} />
         <TraitsOverlay walletAddress={address} tokenId={activeTokenId} />
         <WelcomeDialog walletAddress={address} />

--- a/components/sanctuary/overlays/ExpeditionDialog.tsx
+++ b/components/sanctuary/overlays/ExpeditionDialog.tsx
@@ -1,0 +1,436 @@
+'use client';
+
+/**
+ * ExpeditionDialog — overlay UI for the multi-step expedition adventures
+ * persisted by PR2 ([SWO_V2_SANCTUARY_EXPEDITIONS_DB_API]).
+ *
+ * Lifecycle:
+ *   1. QuestBoard fires `expedition-open` with either:
+ *        { expedition_id }           — start a fresh run (POST /start)
+ *        { expedition_id, row_id }   — resume an active run (GET /run)
+ *   2. The dialog renders the current step's narrative and choice buttons.
+ *      Each choice click POSTs /choose, which advances the reducer state
+ *      and (on a terminal step) settles rewards in the same transaction.
+ *   3. The "Abandon" CTA POSTs /abandon, transitioning the run to
+ *      `abandoned` without refunding the STAR cost.
+ *   4. On remount with an `expedition-open` payload that carries a
+ *      `row_id`, the dialog re-fetches the run via /run so the player
+ *      lands on the same step they left — DB-backed resume.
+ *
+ * The component is rendering-style agnostic between V2 (cosmic palette)
+ * and V3 (Forgotten Memories): both pages mount the same instance.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import EventBus from '@/components/sanctuary/EventBus';
+import { getWalletAuthHeader } from '@/lib/clientWalletAuth';
+import type {
+  ExpeditionDefinition,
+  ExpeditionState,
+  ExpeditionStep,
+} from '@/lib/sanctuary/expeditions';
+import type { SanctuaryExpeditionRow } from '@/lib/db';
+
+interface ExpeditionRunPayload {
+  row: SanctuaryExpeditionRow;
+  state: ExpeditionState;
+  definition: ExpeditionDefinition;
+}
+
+interface RewardSummary {
+  xp: number;
+  bond: number;
+  trait: string | null;
+  starGained: number;
+}
+
+interface ExpeditionOpenPayload {
+  expedition_id: string;
+  row_id?: number | null;
+}
+
+interface ExpeditionDialogProps {
+  walletAddress: string | undefined;
+  tokenId: number | null;
+}
+
+function getCurrentStep(
+  state: ExpeditionState | null,
+  def: ExpeditionDefinition | null,
+): ExpeditionStep | null {
+  if (!state || !def || !state.currentStepId) return null;
+  return def.steps.find((s) => s.id === state.currentStepId) ?? null;
+}
+
+export default function ExpeditionDialog({
+  walletAddress,
+  tokenId,
+}: ExpeditionDialogProps) {
+  const [open, setOpen] = useState(false);
+  const [run, setRun] = useState<ExpeditionRunPayload | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [rewards, setRewards] = useState<RewardSummary | null>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  const close = useCallback(() => {
+    setOpen(false);
+    setRun(null);
+    setError(null);
+    setRewards(null);
+  }, []);
+
+  // Resume an in-flight run by reading current_step_id from the DB via
+  // GET /run. This is what makes "reload mid-flight resumes at the
+  // correct step" work — see acceptance criterion (d).
+  const resumeRun = useCallback(
+    async (rowId: number) => {
+      if (!walletAddress || tokenId === null) return;
+      setLoading(true);
+      setError(null);
+      try {
+        const url = `/api/sanctuary/expeditions/run?address=${walletAddress}&token_id=${tokenId}&row_id=${rowId}`;
+        const res = await fetch(url);
+        const data = await res.json();
+        if (!data.success) {
+          setError(data.error ?? 'Failed to resume expedition.');
+          return;
+        }
+        setRun(data.run as ExpeditionRunPayload);
+      } catch {
+        setError('Failed to resume expedition.');
+      } finally {
+        setLoading(false);
+      }
+    },
+    [walletAddress, tokenId],
+  );
+
+  const startRun = useCallback(
+    async (expeditionId: string) => {
+      if (!walletAddress || tokenId === null) {
+        setError('Connect a wallet and select a Skrumpey to begin.');
+        return;
+      }
+      setLoading(true);
+      setError(null);
+      try {
+        const auth = await getWalletAuthHeader(walletAddress);
+        if (!auth) {
+          setError('Wallet signature required to begin an expedition.');
+          return;
+        }
+        const res = await fetch('/api/sanctuary/expeditions/start', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-wallet-auth': auth,
+          },
+          body: JSON.stringify({
+            address: walletAddress,
+            token_id: tokenId,
+            expedition_id: expeditionId,
+          }),
+        });
+        const data = await res.json();
+        if (!data.success) {
+          setError(data.error ?? 'Failed to start expedition.');
+          return;
+        }
+        setRun(data.run as ExpeditionRunPayload);
+      } catch {
+        setError('Failed to start expedition.');
+      } finally {
+        setLoading(false);
+      }
+    },
+    [walletAddress, tokenId],
+  );
+
+  // EventBus entry point: QuestBoard (or any caller) fires
+  // `expedition-open` to spin up the dialog.
+  useEffect(() => {
+    const handleOpen = (payload: ExpeditionOpenPayload) => {
+      setOpen(true);
+      setRewards(null);
+      setError(null);
+      if (payload.row_id != null) {
+        void resumeRun(payload.row_id);
+      } else {
+        void startRun(payload.expedition_id);
+      }
+    };
+    EventBus.on('expedition-open', handleOpen);
+    return () => {
+      EventBus.off('expedition-open', handleOpen);
+    };
+  }, [resumeRun, startRun]);
+
+  // Click-outside to close (only when not actively transitioning).
+  useEffect(() => {
+    if (!open) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (busy) return;
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        close();
+      }
+    };
+    const timer = setTimeout(() => {
+      document.addEventListener('mousedown', handleClickOutside);
+    }, 50);
+    return () => {
+      clearTimeout(timer);
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [open, busy, close]);
+
+  const chooseStep = useCallback(
+    async (choiceId: string) => {
+      if (!run || !walletAddress || tokenId === null) return;
+      setBusy(true);
+      setError(null);
+      try {
+        const auth = await getWalletAuthHeader(walletAddress);
+        if (!auth) {
+          setError('Wallet signature required to advance the expedition.');
+          return;
+        }
+        const res = await fetch('/api/sanctuary/expeditions/choose', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-wallet-auth': auth,
+          },
+          body: JSON.stringify({
+            address: walletAddress,
+            token_id: tokenId,
+            row_id: run.row.id,
+            choice_id: choiceId,
+          }),
+        });
+        const data = await res.json();
+        if (!data.success) {
+          setError(data.error ?? 'Failed to advance expedition.');
+          return;
+        }
+        setRun(data.run as ExpeditionRunPayload);
+        if (data.run?.rewards) {
+          setRewards(data.run.rewards as RewardSummary);
+        }
+        // The choose endpoint returns the rewards object at the top level
+        // (see app/api/sanctuary/expeditions/choose/route.ts).
+        if (data.rewards) {
+          setRewards(data.rewards as RewardSummary);
+        }
+        // On terminal step the API also bundles rewards inside `run`.
+      } catch {
+        setError('Failed to advance expedition.');
+      } finally {
+        setBusy(false);
+      }
+    },
+    [run, walletAddress, tokenId],
+  );
+
+  const abandonRun = useCallback(async () => {
+    if (!run || !walletAddress || tokenId === null) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const auth = await getWalletAuthHeader(walletAddress);
+      if (!auth) {
+        setError('Wallet signature required to abandon the expedition.');
+        return;
+      }
+      const res = await fetch('/api/sanctuary/expeditions/abandon', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-wallet-auth': auth,
+        },
+        body: JSON.stringify({
+          address: walletAddress,
+          token_id: tokenId,
+          row_id: run.row.id,
+        }),
+      });
+      const data = await res.json();
+      if (!data.success) {
+        setError(data.error ?? 'Failed to abandon expedition.');
+        return;
+      }
+      setRun(data.run as ExpeditionRunPayload);
+      EventBus.emit('expedition-abandoned', { row_id: run.row.id });
+    } catch {
+      setError('Failed to abandon expedition.');
+    } finally {
+      setBusy(false);
+    }
+  }, [run, walletAddress, tokenId]);
+
+  const currentStep = useMemo(
+    () => getCurrentStep(run?.state ?? null, run?.definition ?? null),
+    [run],
+  );
+
+  const status = run?.state.status ?? 'active';
+  const isTerminal = status !== 'active';
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="absolute inset-0 z-40 flex items-center justify-center pointer-events-none"
+      data-testid="expedition-dialog-root"
+    >
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-label="Expedition"
+        data-testid="expedition-dialog-panel"
+        className="w-[420px] max-w-[92%] max-h-[85%] overflow-hidden flex flex-col pointer-events-auto
+          bg-black/95 border border-[#9966ff]/40 rounded-lg shadow-[0_0_25px_rgba(153,102,255,0.18)]
+          transition-all duration-200"
+      >
+        {/* Header */}
+        <div className="bg-[#1a0033] border-b border-[#9966ff]/20 p-3 flex items-center justify-between">
+          <div className="flex items-center gap-2 min-w-0">
+            <span className="text-base">🗺️</span>
+            <div className="min-w-0">
+              <h3 className="text-[#9966ff] font-['Press_Start_2P'] text-[8px] truncate">
+                {run?.definition.title ?? 'EXPEDITION'}
+              </h3>
+              {run && (
+                <p className="text-gray-500 text-[6px] truncate">
+                  {run.definition.npcSource}
+                </p>
+              )}
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={close}
+            className="text-gray-500 hover:text-white text-sm transition-colors"
+            aria-label="Close expedition dialog"
+            data-testid="expedition-close"
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto p-4 space-y-3">
+          {loading && (
+            <p
+              className="text-gray-500 text-[7px] text-center py-4"
+              data-testid="expedition-loading"
+            >
+              Loading expedition...
+            </p>
+          )}
+
+          {error && (
+            <p
+              className="text-red-400 text-[7px] bg-red-950/40 border border-red-900/40 rounded p-2"
+              data-testid="expedition-error"
+            >
+              {error}
+            </p>
+          )}
+
+          {!loading && currentStep && (
+            <>
+              <p
+                className="text-gray-300 text-[8px] leading-relaxed"
+                data-testid="expedition-narrative"
+              >
+                {currentStep.narrative}
+              </p>
+              <ol className="space-y-1.5" data-testid="expedition-choices">
+                {currentStep.choices.map((choice) => (
+                  <li key={choice.id}>
+                    <button
+                      type="button"
+                      onClick={() => chooseStep(choice.id)}
+                      disabled={busy}
+                      data-testid={`expedition-choice-${choice.id}`}
+                      data-choice-id={choice.id}
+                      className="w-full text-left px-3 py-2 rounded border border-[#9966ff]/30 bg-[#9966ff]/10
+                        hover:bg-[#9966ff]/20 text-white text-[8px] disabled:opacity-40 disabled:cursor-not-allowed
+                        transition-colors font-['Press_Start_2P'] leading-tight"
+                    >
+                      {choice.label}
+                    </button>
+                  </li>
+                ))}
+              </ol>
+            </>
+          )}
+
+          {!loading && !currentStep && run && isTerminal && (
+            <div
+              className="space-y-2"
+              data-testid="expedition-summary"
+              data-status={status}
+            >
+              <p className="text-[#ffd700] font-['Press_Start_2P'] text-[9px]">
+                {status === 'completed'
+                  ? `Expedition ${run.state.finalOutcome ?? 'complete'}`
+                  : 'Expedition abandoned'}
+              </p>
+              {status === 'completed' && rewards && (
+                <ul className="space-y-1 text-[7px] text-gray-300">
+                  {rewards.xp > 0 && (
+                    <li className="text-[#ffd700]">+{rewards.xp} XP</li>
+                  )}
+                  {rewards.bond > 0 && (
+                    <li className="text-[#ff66aa]">+{rewards.bond} Bond</li>
+                  )}
+                  {rewards.starGained > 0 && (
+                    <li className="text-[#44ff88]">
+                      +{rewards.starGained} STAR
+                    </li>
+                  )}
+                  {rewards.trait && (
+                    <li className="text-[#9966ff]">🏷️ {rewards.trait}</li>
+                  )}
+                </ul>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Footer: abandon CTA only while a run is active */}
+        {run && status === 'active' && (
+          <div className="border-t border-[#9966ff]/20 p-2 flex items-center justify-end gap-2 bg-black/80">
+            <button
+              type="button"
+              onClick={abandonRun}
+              disabled={busy}
+              data-testid="expedition-abandon"
+              className="px-3 py-1.5 rounded border border-red-500/40 bg-red-950/40 text-red-300 text-[7px]
+                font-['Press_Start_2P'] hover:bg-red-900/40 disabled:opacity-40 disabled:cursor-not-allowed
+                transition-colors"
+            >
+              ABANDON
+            </button>
+          </div>
+        )}
+        {run && isTerminal && (
+          <div className="border-t border-[#9966ff]/20 p-2 flex items-center justify-end gap-2 bg-black/80">
+            <button
+              type="button"
+              onClick={close}
+              data-testid="expedition-dismiss"
+              className="px-3 py-1.5 rounded border border-[#9966ff]/40 bg-[#9966ff]/10 text-[#9966ff] text-[7px]
+                font-['Press_Start_2P'] hover:bg-[#9966ff]/20 transition-colors"
+            >
+              CLOSE
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/sanctuary/overlays/QuestBoard.tsx
+++ b/components/sanctuary/overlays/QuestBoard.tsx
@@ -32,7 +32,24 @@ interface NPCClickPayload {
   screenY: number;
 }
 
+interface ExpeditionListing {
+  id: string;
+  title: string;
+  description: string;
+  npcSource: string;
+  star_cost: number;
+  tier: 'easy' | 'medium' | 'hard';
+  rewards: { xp: number; bond: number; trait?: string | null };
+  active_row_id: number | null;
+}
+
 type TabFilter = 'all' | 'room' | 'daily' | 'weekly';
+
+const TIER_COLOR: Record<ExpeditionListing['tier'], string> = {
+  easy: '#44ff88',
+  medium: '#ffd700',
+  hard: '#ff66aa',
+};
 
 const QUEST_TYPE_BADGE: Record<string, { label: string; color: string }> = {
   daily: { label: 'DAILY', color: '#44ff88' },
@@ -83,6 +100,7 @@ export default function QuestBoard({
   const [loading, setLoading] = useState(false);
   const [tab, setTab] = useState<TabFilter>('all');
   const [claiming, setClaiming] = useState<number | null>(null);
+  const [expeditions, setExpeditions] = useState<ExpeditionListing[]>([]);
   const panelRef = useRef<HTMLDivElement>(null);
 
   const close = useCallback(() => setOpen(false), []);
@@ -103,23 +121,51 @@ export default function QuestBoard({
     }
   }, [walletAddress, tokenId]);
 
+  const loadExpeditions = useCallback(async () => {
+    if (!walletAddress || tokenId === null) return;
+    try {
+      const res = await fetch(
+        `/api/sanctuary/expeditions/list?address=${walletAddress}&token_id=${tokenId}`
+      );
+      const data = await res.json();
+      if (data.success) setExpeditions(data.expeditions ?? []);
+    } catch {
+      // Non-critical — expedition list is additive over the quest board.
+    }
+  }, [walletAddress, tokenId]);
+
+  const launchExpedition = useCallback((entry: ExpeditionListing) => {
+    EventBus.emit('expedition-open', {
+      expedition_id: entry.id,
+      row_id: entry.active_row_id,
+    });
+  }, []);
+
   useEffect(() => {
     const handleOpen = () => {
       setOpen(true);
       loadQuests();
+      loadExpeditions();
     };
     const handleNPCClick = (payload: NPCClickPayload) => {
       if (payload.npcId !== 'quest-board') return;
       setOpen(true);
       loadQuests();
+      loadExpeditions();
+    };
+    const handleExpeditionAbandoned = () => {
+      // Active-run badge clears on abandon — refresh listings.
+      loadExpeditions();
     };
     EventBus.on('quest-board-open', handleOpen);
     EventBus.on('npc-clicked', handleNPCClick);
+    EventBus.on('expedition-abandoned', handleExpeditionAbandoned);
     return () => {
       EventBus.off('quest-board-open', handleOpen);
       EventBus.off('npc-clicked', handleNPCClick);
+      EventBus.off('expedition-abandoned', handleExpeditionAbandoned);
     };
-  }, [loadQuests]);
+  }, [loadQuests, loadExpeditions]);
 
   useEffect(() => {
     if (!open) return;
@@ -363,6 +409,76 @@ export default function QuestBoard({
               })}
             </div>
           ))}
+
+          {expeditions.length > 0 && (
+            <div className="space-y-2" data-testid="expedition-section">
+              <p className="text-gray-500 text-[6px] font-['Press_Start_2P'] tracking-wider mt-2">
+                EXPEDITIONS
+              </p>
+              {expeditions.map((exp) => {
+                const color = TIER_COLOR[exp.tier];
+                const isActive = exp.active_row_id !== null;
+                return (
+                  <div
+                    key={exp.id}
+                    data-testid={`expedition-card-${exp.id}`}
+                    className="bg-[#0a0a15] rounded-lg border border-[#9966ff]/30 p-3"
+                  >
+                    <div className="flex items-start justify-between mb-1">
+                      <div className="min-w-0">
+                        <span
+                          className="text-[6px] px-1.5 py-0.5 rounded mr-1.5 uppercase"
+                          style={{
+                            color,
+                            backgroundColor: color + '20',
+                            border: `1px solid ${color}40`,
+                          }}
+                        >
+                          {exp.tier}
+                        </span>
+                        <span className="text-white text-[8px]">{exp.title}</span>
+                      </div>
+                      <span className="text-[#ffd700] text-[7px] shrink-0 ml-2">
+                        ⭐ {exp.star_cost}
+                      </span>
+                    </div>
+                    <p className="text-gray-500 text-[7px] mb-1.5">
+                      {exp.description}
+                    </p>
+                    <div className="flex items-center justify-between gap-2">
+                      <div className="flex items-center gap-2">
+                        {exp.rewards.xp > 0 && (
+                          <span className="text-[6px] text-[#ffd700]">
+                            +{exp.rewards.xp} XP
+                          </span>
+                        )}
+                        {exp.rewards.bond > 0 && (
+                          <span className="text-[6px] text-[#ff66aa]">
+                            +{exp.rewards.bond} Bond
+                          </span>
+                        )}
+                        {exp.rewards.trait && (
+                          <span className="text-[6px] text-[#9966ff]">
+                            🏷️ {exp.rewards.trait}
+                          </span>
+                        )}
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => launchExpedition(exp)}
+                        data-testid={`expedition-launch-${exp.id}`}
+                        className="px-2 py-1 rounded border border-[#9966ff]/40 bg-[#9966ff]/10
+                          hover:bg-[#9966ff]/20 text-[#9966ff] text-[6px] font-['Press_Start_2P']
+                          transition-colors shrink-0"
+                      >
+                        {isActive ? 'RESUME ▸' : 'BEGIN ▸'}
+                      </button>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
 
           {completed.length > 0 && (
             <div className="space-y-2">

--- a/components/sanctuary/overlays/__tests__/ExpeditionDialog.test.tsx
+++ b/components/sanctuary/overlays/__tests__/ExpeditionDialog.test.tsx
@@ -1,0 +1,338 @@
+// @vitest-environment happy-dom
+//
+// ExpeditionDialog — acceptance contract for
+// [SWO_V2_SANCTUARY_EXPEDITIONS_UI] (PR3 of 7).
+//
+// Verified here:
+//   (a) renders the current step (narrative + choice buttons) sourced from
+//       the reducer state returned by /run or /start
+//   (b) clicking a choice POSTs /api/sanctuary/expeditions/choose with the
+//       exact choice_id and refreshes the rendered step on the response
+//   (c) the abandon CTA POSTs /api/sanctuary/expeditions/abandon and the
+//       dialog reflects the resulting status (no more choice buttons,
+//       no abandon button)
+//   (d) on remount, the dialog re-fetches the active row via /run so the
+//       player resumes at the same current_step_id that the DB stored —
+//       this is the "reload mid-flight" property.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import EventBus from '@/components/sanctuary/EventBus';
+import ExpeditionDialog from '../ExpeditionDialog';
+
+// React 19's act(...) checks for this flag and warns otherwise.
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('@/lib/clientWalletAuth', () => ({
+  getWalletAuthHeader: vi.fn(async () => 'mocked-auth-header'),
+}));
+
+const WALLET = '0x000000000000000000000000000000000000abcd';
+const TOKEN_ID = 7;
+
+interface MockChoice {
+  id: string;
+  label: string;
+  nextStepId?: string | null;
+  outcome?: 'success' | 'partial' | 'failure';
+}
+
+interface MockStep {
+  id: string;
+  narrative: string;
+  choices: MockChoice[];
+  isFinal?: boolean;
+}
+
+const MOCK_DEFINITION = {
+  id: 'exp-test-meadow',
+  title: 'Meadow Walk',
+  description: 'A short walk through the Stellar Meadow.',
+  npcSource: 'meadow',
+  startStepId: 'start',
+  rewards: { xp: 20, bond: 2, trait: 'Wanderer' },
+  steps: [
+    {
+      id: 'start',
+      narrative: 'The meadow is in full bloom. Two trails fork.',
+      choices: [
+        { id: 'flowers', label: 'Follow the flowers.', nextStepId: 'final' },
+        { id: 'stream', label: 'Follow the stream.', nextStepId: 'final' },
+      ],
+    },
+    {
+      id: 'final',
+      narrative: 'The trail loops back, sun warm.',
+      isFinal: true,
+      choices: [
+        { id: 'share', label: 'Share the snack.', outcome: 'success' },
+        { id: 'leave', label: 'Head home.', outcome: 'partial' },
+      ],
+    },
+  ] as MockStep[],
+};
+
+function runPayload(currentStepId: string | null, status = 'active') {
+  return {
+    row: {
+      id: 99,
+      wallet_address: WALLET,
+      token_id: TOKEN_ID,
+      expedition_id: MOCK_DEFINITION.id,
+      star_cost: 5,
+      started_at: '2026-05-20T00:00:00Z',
+      ended_at: status === 'active' ? null : '2026-05-20T00:01:00Z',
+      outcome: null,
+      status,
+    },
+    state: {
+      expeditionId: MOCK_DEFINITION.id,
+      currentStepId,
+      status,
+      history: [],
+    },
+    definition: MOCK_DEFINITION,
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+let fetchMock: ReturnType<typeof vi.fn>;
+let fetchCalls: Array<{ url: string; init?: RequestInit }>;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  fetchCalls = [];
+  fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+    fetchCalls.push({ url, init });
+    if (url.includes('/api/sanctuary/expeditions/run')) {
+      return new Response(
+        JSON.stringify({ success: true, run: runPayload('start') }),
+        { status: 200 },
+      );
+    }
+    if (url.includes('/api/sanctuary/expeditions/start')) {
+      return new Response(
+        JSON.stringify({ success: true, run: runPayload('start') }),
+        { status: 200 },
+      );
+    }
+    if (url.includes('/api/sanctuary/expeditions/choose')) {
+      // Advance reducer to step `final`.
+      return new Response(
+        JSON.stringify({
+          success: true,
+          run: runPayload('final'),
+          rewards: { xp: 0, bond: 0, trait: null, starGained: 0 },
+        }),
+        { status: 200 },
+      );
+    }
+    if (url.includes('/api/sanctuary/expeditions/abandon')) {
+      return new Response(
+        JSON.stringify({
+          success: true,
+          run: runPayload(null, 'abandoned'),
+        }),
+        { status: 200 },
+      );
+    }
+    return new Response(JSON.stringify({ success: false }), { status: 404 });
+  });
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+function render() {
+  act(() => {
+    root.render(
+      <ExpeditionDialog walletAddress={WALLET} tokenId={TOKEN_ID} />,
+    );
+  });
+}
+
+async function flush() {
+  // Settle microtasks (fetch promise → setState → re-render).
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function fireOpen(payload: { expedition_id: string; row_id?: number | null }) {
+  act(() => {
+    EventBus.emit('expedition-open', payload);
+  });
+}
+
+describe('ExpeditionDialog — current step rendering', () => {
+  it('(a) renders the current step narrative + choices after start', async () => {
+    render();
+    fireOpen({ expedition_id: 'exp-test-meadow' });
+    await flush();
+
+    const narrative = container.querySelector(
+      '[data-testid="expedition-narrative"]',
+    );
+    expect(narrative?.textContent).toBe(
+      'The meadow is in full bloom. Two trails fork.',
+    );
+
+    const flowers = container.querySelector(
+      '[data-testid="expedition-choice-flowers"]',
+    );
+    const stream = container.querySelector(
+      '[data-testid="expedition-choice-stream"]',
+    );
+    expect(flowers?.textContent).toBe('Follow the flowers.');
+    expect(stream?.textContent).toBe('Follow the stream.');
+
+    // Abandon CTA must be present while the run is active.
+    expect(
+      container.querySelector('[data-testid="expedition-abandon"]'),
+    ).toBeTruthy();
+  });
+});
+
+describe('ExpeditionDialog — choice click', () => {
+  it('(b) clicking a choice POSTs /choose with the choice id', async () => {
+    render();
+    fireOpen({ expedition_id: 'exp-test-meadow' });
+    await flush();
+
+    const flowers = container.querySelector(
+      '[data-testid="expedition-choice-flowers"]',
+    ) as HTMLButtonElement;
+    expect(flowers).toBeTruthy();
+
+    act(() => {
+      flowers.click();
+    });
+    await flush();
+
+    const chooseCall = fetchCalls.find((c) =>
+      c.url.includes('/api/sanctuary/expeditions/choose'),
+    );
+    expect(chooseCall).toBeDefined();
+    expect(chooseCall?.init?.method).toBe('POST');
+    const body = JSON.parse(String(chooseCall?.init?.body));
+    expect(body).toMatchObject({
+      address: WALLET,
+      token_id: TOKEN_ID,
+      row_id: 99,
+      choice_id: 'flowers',
+    });
+
+    // The new step is reflected in the rendered narrative.
+    const narrative = container.querySelector(
+      '[data-testid="expedition-narrative"]',
+    );
+    expect(narrative?.textContent).toBe('The trail loops back, sun warm.');
+  });
+});
+
+describe('ExpeditionDialog — abandon CTA', () => {
+  it('(c) the abandon CTA POSTs /abandon and removes the choice buttons', async () => {
+    render();
+    fireOpen({ expedition_id: 'exp-test-meadow' });
+    await flush();
+
+    const abandon = container.querySelector(
+      '[data-testid="expedition-abandon"]',
+    ) as HTMLButtonElement;
+    expect(abandon).toBeTruthy();
+
+    act(() => {
+      abandon.click();
+    });
+    await flush();
+
+    const abandonCall = fetchCalls.find((c) =>
+      c.url.includes('/api/sanctuary/expeditions/abandon'),
+    );
+    expect(abandonCall).toBeDefined();
+    expect(abandonCall?.init?.method).toBe('POST');
+    const body = JSON.parse(String(abandonCall?.init?.body));
+    expect(body).toMatchObject({
+      address: WALLET,
+      token_id: TOKEN_ID,
+      row_id: 99,
+    });
+
+    // Post-abandon: no choice buttons, no abandon CTA, summary visible.
+    expect(
+      container.querySelector('[data-testid="expedition-choices"]'),
+    ).toBeNull();
+    expect(
+      container.querySelector('[data-testid="expedition-abandon"]'),
+    ).toBeNull();
+    const summary = container.querySelector(
+      '[data-testid="expedition-summary"]',
+    );
+    expect(summary?.getAttribute('data-status')).toBe('abandoned');
+  });
+});
+
+describe('ExpeditionDialog — DB-backed resume on remount', () => {
+  it('(d) resume reads current_step_id from /run on remount', async () => {
+    // First mount: start a run.
+    render();
+    fireOpen({ expedition_id: 'exp-test-meadow' });
+    await flush();
+    expect(
+      fetchCalls.some((c) => c.url.includes('/expeditions/start')),
+    ).toBe(true);
+
+    // Now simulate a remount with a known active row_id — the dialog
+    // must fetch /run (NOT /start) and seed the current step from the
+    // DB response.
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    fetchCalls.length = 0;
+
+    render();
+    fireOpen({ expedition_id: 'exp-test-meadow', row_id: 99 });
+    await flush();
+
+    const resumeCall = fetchCalls.find((c) =>
+      c.url.includes('/api/sanctuary/expeditions/run'),
+    );
+    expect(resumeCall).toBeDefined();
+    expect(resumeCall?.url).toContain(`address=${WALLET}`);
+    expect(resumeCall?.url).toContain(`token_id=${TOKEN_ID}`);
+    expect(resumeCall?.url).toContain('row_id=99');
+
+    // Crucially: /start must NOT be called on resume.
+    expect(
+      fetchCalls.some((c) => c.url.includes('/expeditions/start')),
+    ).toBe(false);
+
+    // The narrative reflects the resumed step (the API mock returns the
+    // `start` step here — same as it would persist after a refresh
+    // before any choice has been made).
+    const narrative = container.querySelector(
+      '[data-testid="expedition-narrative"]',
+    );
+    expect(narrative?.textContent).toBe(
+      'The meadow is in full bloom. Two trails fork.',
+    );
+  });
+});

--- a/data/sanctuary/expeditions/easy.json
+++ b/data/sanctuary/expeditions/easy.json
@@ -1,0 +1,58 @@
+{
+  "$comment": "Sanctuary expedition seed — easy tier. Loaded by app/api/sanctuary/expeditions/start/route.ts. Each entry conforms to ExpeditionDefinition in lib/sanctuary/expeditions.ts with an extra `star_cost` field for the persistence layer.",
+  "tier": "easy",
+  "expeditions": [
+    {
+      "id": "exp-easy-meadow-walk",
+      "title": "Meadow Walk",
+      "description": "A short stroll through the Stellar Meadow with your Skrumpey. Nothing dangerous, just good company.",
+      "npcSource": "meadow",
+      "startStepId": "meadow-start",
+      "star_cost": 5,
+      "rewards": {
+        "xp": 20,
+        "bond": 2.0,
+        "trait": "Wanderer"
+      },
+      "steps": [
+        {
+          "id": "meadow-start",
+          "narrative": "The Stellar Meadow is in full bloom. Your Skrumpey tugs your sleeve and points down two trails.",
+          "choices": [
+            {
+              "id": "trail-flowers",
+              "label": "Follow the flower trail.",
+              "nextStepId": "meadow-final",
+              "tone": "gentle"
+            },
+            {
+              "id": "trail-stream",
+              "label": "Follow the stream trail.",
+              "nextStepId": "meadow-final",
+              "tone": "curious"
+            }
+          ]
+        },
+        {
+          "id": "meadow-final",
+          "narrative": "The trail loops back and the sun is warm. Your companion is humming.",
+          "isFinal": true,
+          "choices": [
+            {
+              "id": "rest-share",
+              "label": "Sit and share the snack you brought.",
+              "outcome": "success",
+              "tone": "warm"
+            },
+            {
+              "id": "rest-quick",
+              "label": "Head home — there's still time for chores.",
+              "outcome": "partial",
+              "tone": "brisk"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/sanctuary/expeditions/hard.json
+++ b/data/sanctuary/expeditions/hard.json
@@ -1,0 +1,113 @@
+{
+  "$comment": "Sanctuary expedition seed — hard tier. Branching with at least one risky/failure path; pays a Legendary trait on success.",
+  "tier": "hard",
+  "expeditions": [
+    {
+      "id": "exp-hard-forge-emberheart",
+      "title": "Emberheart Trial",
+      "description": "Pyrix is attempting a once-a-season Emberheart pour. One mistake collapses the forge for the night.",
+      "npcSource": "forge",
+      "startStepId": "ember-arrive",
+      "star_cost": 30,
+      "rewards": {
+        "xp": 150,
+        "bond": 8.0,
+        "trait": "Emberheart"
+      },
+      "steps": [
+        {
+          "id": "ember-arrive",
+          "narrative": "The forge is a furnace. Pyrix gestures: \"Bellows, hammer, or quench. Pick fast — the alloy is ready.\"",
+          "choices": [
+            {
+              "id": "take-bellows",
+              "label": "\"Bellows. I can keep the rhythm.\"",
+              "nextStepId": "ember-bellows",
+              "tone": "rhythm"
+            },
+            {
+              "id": "take-hammer",
+              "label": "\"Hammer. I'll strike where you point.\"",
+              "nextStepId": "ember-hammer",
+              "tone": "brave"
+            },
+            {
+              "id": "take-quench",
+              "label": "\"Quench. I'll dunk on your call.\"",
+              "nextStepId": "ember-risky",
+              "tone": "risky"
+            }
+          ]
+        },
+        {
+          "id": "ember-bellows",
+          "narrative": "You pump steady, hard. The metal sings.",
+          "choices": [
+            {
+              "id": "bellows-pour",
+              "label": "Hold the rhythm to the final pour.",
+              "nextStepId": "ember-final",
+              "tone": "patient"
+            }
+          ]
+        },
+        {
+          "id": "ember-hammer",
+          "narrative": "Three measured strikes. The alloy responds — you hear the note.",
+          "choices": [
+            {
+              "id": "hammer-pour",
+              "label": "Step back and let Pyrix pour.",
+              "nextStepId": "ember-final",
+              "tone": "trusting"
+            }
+          ]
+        },
+        {
+          "id": "ember-risky",
+          "narrative": "The quench bucket is heavy. Pyrix shouts the timing — you have one beat.",
+          "isFinal": true,
+          "choices": [
+            {
+              "id": "risky-dunk-perfect",
+              "label": "Dunk on the exact beat.",
+              "outcome": "success",
+              "tone": "decisive"
+            },
+            {
+              "id": "risky-dunk-late",
+              "label": "Hesitate — make sure of the angle.",
+              "outcome": "partial",
+              "tone": "cautious"
+            },
+            {
+              "id": "risky-dunk-early",
+              "label": "Dunk early — the alloy looked ready.",
+              "outcome": "failure",
+              "tone": "rattled"
+            }
+          ]
+        },
+        {
+          "id": "ember-final",
+          "narrative": "The Emberheart cools dark and even. Pyrix exhales.",
+          "isFinal": true,
+          "choices": [
+            {
+              "id": "credit-pyrix",
+              "label": "\"All you, master.\"",
+              "outcome": "success",
+              "tone": "humble"
+            },
+            {
+              "id": "credit-self",
+              "label": "\"We make a good pair.\"",
+              "outcome": "partial",
+              "tone": "boastful"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/sanctuary/expeditions/medium.json
+++ b/data/sanctuary/expeditions/medium.json
@@ -1,0 +1,64 @@
+{
+  "$comment": "Sanctuary expedition seed — medium tier. Heavier choices, partial-failure paths reachable, modest STAR cost.",
+  "tier": "medium",
+  "expeditions": [
+    {
+      "id": "exp-medium-observatory-eclipse",
+      "title": "Eclipse Watch",
+      "description": "Astris needs help logging an eclipse. Two readings have to be taken at the right moment or the data is lost.",
+      "npcSource": "observatory",
+      "startStepId": "eclipse-arrive",
+      "star_cost": 15,
+      "rewards": {
+        "xp": 60,
+        "bond": 4.0,
+        "trait": "Eclipse Scribe"
+      },
+      "steps": [
+        {
+          "id": "eclipse-arrive",
+          "narrative": "Astris hands you a logbook. \"Stand by the smaller scope. When I call totality, write what you see.\"",
+          "choices": [
+            {
+              "id": "ready-pen",
+              "label": "Ready your pen and watch the sky.",
+              "nextStepId": "eclipse-totality",
+              "tone": "diligent"
+            },
+            {
+              "id": "ready-stopwatch",
+              "label": "Pull out a stopwatch first.",
+              "nextStepId": "eclipse-totality",
+              "tone": "methodical"
+            }
+          ]
+        },
+        {
+          "id": "eclipse-totality",
+          "narrative": "The disc darkens. Astris's voice cracks — \"Now!\" — and the corona blooms.",
+          "isFinal": true,
+          "choices": [
+            {
+              "id": "write-fast",
+              "label": "Capture the corona description in full sentences.",
+              "outcome": "success",
+              "tone": "skilled"
+            },
+            {
+              "id": "write-bullets",
+              "label": "Scribble bullet points — speed over detail.",
+              "outcome": "partial",
+              "tone": "pragmatic"
+            },
+            {
+              "id": "freeze",
+              "label": "Stare at the corona, forgetting to write.",
+              "outcome": "failure",
+              "tone": "rattled"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -23,6 +23,23 @@ import {
 } from './sanctuary/companionStats';
 import { decayStats, computeNeeds, type DecayedStats } from './sanctuary/decay';
 import { journalLineForAction } from './sanctuary/companionGreeting';
+import {
+  abandonExpedition,
+  chooseExpeditionPath,
+  getExpeditionRewards,
+  startExpedition,
+  type ExpeditionDefinition,
+  type ExpeditionHistoryEntry,
+  type ExpeditionState,
+  type ExpeditionStatus,
+  type ExpeditionOutcome,
+} from './sanctuary/expeditions';
+import {
+  EXPEDITION_TIERS,
+  getExpeditionCatalog,
+  getExpeditionCatalogEntry,
+  type ExpeditionTier,
+} from './sanctuary/expeditionDefs';
 
 // Database path - stored in the repo's data directory
 const DB_PATH = process.env.DATABASE_URL?.replace('file:', '') || 
@@ -45,6 +62,15 @@ export function getDatabase(): Database.Database {
     initializeDatabase(db);
   }
   return db;
+}
+
+/**
+ * Test-only escape hatch: replace the singleton DB handle with an in-memory
+ * one. Lets unit tests exercise db-helper transactions against fresh schemas
+ * without touching the real swo.db on disk.
+ */
+export function __setTestDatabase(testDb: Database.Database | null): void {
+  db = testDb;
 }
 
 /**
@@ -5843,6 +5869,11 @@ function initializeSanctuary(database: Database.Database): void {
     const sql = fs.readFileSync(v25Path, 'utf-8');
     database.exec(sql);
   }
+  const v26Path = path.join(process.cwd(), 'scripts', 'init-sanctuary-v2.6.sql');
+  if (fs.existsSync(v26Path)) {
+    const sql = fs.readFileSync(v26Path, 'utf-8');
+    database.exec(sql);
+  }
   // V1.7: per-companion XP/level columns (Training Grounds). ALTER TABLE IF NOT
   // EXISTS is not portable across SQLite versions, so wrap in try/catch.
   try { database.exec('ALTER TABLE sanctuary_companions ADD COLUMN xp INTEGER NOT NULL DEFAULT 0'); }
@@ -7117,20 +7148,9 @@ export function getActiveExpeditionRun(_walletAddress: string) {
   return null;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function getExpeditionHistory(_walletAddress: string) {
-  return [];
-}
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function startExpedition(_walletAddress: string, _tokenId: number, _expeditionId: number): Record<string, unknown> {
-  throw new Error('Expeditions not yet implemented');
-}
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function completeExpedition(_walletAddress: string, _tokenId: number): Record<string, unknown> | null {
-  return null;
-}
+// Legacy stubs removed in V2.6 — see startExpeditionRun / chooseExpeditionStep
+// below for the real expedition lifecycle. Old callers (none in tree at the
+// time of this PR) should migrate to the new helpers.
 
 export function getPublicActivityFeed(limit: number, before?: string) {
   const db = getDatabase();
@@ -8347,4 +8367,331 @@ export function equipCosmetic(
   ).run(JSON.stringify(equipped), companion.id);
 
   return { token_id: tokenId, equipped_cosmetics: equipped };
+}
+
+// ---------------------------------------------------------------------------
+// Expeditions (V2.6) — see [SWO_V2_SANCTUARY_EXPEDITIONS_DB_API]
+// ---------------------------------------------------------------------------
+
+export interface SanctuaryExpeditionRow {
+  id: number;
+  wallet_address: string;
+  token_id: number;
+  expedition_id: string;
+  star_cost: number;
+  started_at: string;
+  ended_at: string | null;
+  outcome: ExpeditionOutcome | null;
+  status: ExpeditionStatus;
+}
+
+export interface SanctuaryExpeditionProgressRow {
+  expedition_row_id: number;
+  current_step_id: string | null;
+  choices_jsonb: string;
+  updated_at: string;
+}
+
+export interface ExpeditionListing {
+  tier: ExpeditionTier;
+  star_cost: number;
+  id: string;
+  title: string;
+  description: string;
+  npcSource: string;
+  rewards: ExpeditionDefinition['rewards'];
+  /** True when the holder has an active run for this expedition. */
+  active_row_id: number | null;
+}
+
+export interface ExpeditionRunView {
+  row: SanctuaryExpeditionRow;
+  state: ExpeditionState;
+  definition: ExpeditionDefinition;
+}
+
+function parseHistory(json: string): ExpeditionHistoryEntry[] {
+  try {
+    const parsed = JSON.parse(json);
+    if (Array.isArray(parsed)) return parsed as ExpeditionHistoryEntry[];
+  } catch {
+    /* fall through */
+  }
+  return [];
+}
+
+function rowToState(
+  row: SanctuaryExpeditionRow,
+  progress: SanctuaryExpeditionProgressRow | undefined,
+): ExpeditionState {
+  return {
+    expeditionId: row.expedition_id,
+    currentStepId: progress?.current_step_id ?? null,
+    status: row.status,
+    history: progress ? parseHistory(progress.choices_jsonb) : [],
+    finalOutcome: row.outcome ?? undefined,
+  };
+}
+
+export function listExpeditions(walletAddress: string, tokenId: number): {
+  tiers: typeof EXPEDITION_TIERS;
+  expeditions: ExpeditionListing[];
+} {
+  const db = getDatabase();
+  const addr = walletAddress.toLowerCase();
+  const catalog = getExpeditionCatalog();
+
+  const active = db.prepare(
+    "SELECT id, expedition_id FROM sanctuary_expeditions WHERE wallet_address = ? AND token_id = ? AND status = 'active'"
+  ).all(addr, tokenId) as Array<{ id: number; expedition_id: string }>;
+  const activeById = new Map(active.map((a) => [a.expedition_id, a.id]));
+
+  return {
+    tiers: EXPEDITION_TIERS,
+    expeditions: catalog.map((entry) => ({
+      tier: entry.tier,
+      star_cost: entry.star_cost,
+      id: entry.definition.id,
+      title: entry.definition.title,
+      description: entry.definition.description,
+      npcSource: entry.definition.npcSource,
+      rewards: entry.definition.rewards,
+      active_row_id: activeById.get(entry.definition.id) ?? null,
+    })),
+  };
+}
+
+/**
+ * Start a new expedition run for (wallet, token). Deducts the seed-declared
+ * `star_cost` atomically; on insufficient balance the run is not created.
+ * Returns the new run plus the reducer state primed on the start step.
+ */
+export function startExpeditionRun(
+  walletAddress: string,
+  tokenId: number,
+  expeditionId: string,
+): ExpeditionRunView {
+  const db = getDatabase();
+  const addr = walletAddress.toLowerCase();
+  const entry = getExpeditionCatalogEntry(expeditionId);
+  if (!entry) throw new Error('EXPEDITION_NOT_FOUND');
+
+  const txn = db.transaction(() => {
+    const existing = db.prepare(
+      "SELECT id FROM sanctuary_expeditions WHERE wallet_address = ? AND token_id = ? AND expedition_id = ? AND status = 'active'"
+    ).get(addr, tokenId, expeditionId) as { id: number } | undefined;
+    if (existing) throw new Error('ALREADY_ACTIVE');
+
+    if (entry.star_cost > 0) {
+      // Inline spend to keep ledger consistent with run id.
+      const balRow = db.prepare(
+        'SELECT balance, lifetime_earned FROM sanctuary_star_balance WHERE wallet_address = ?'
+      ).get(addr) as { balance: number; lifetime_earned: number } | undefined;
+      const cur = balRow?.balance ?? 0;
+      if (cur < entry.star_cost) throw new Error('Insufficient STAR balance');
+      const newBal = cur - entry.star_cost;
+      if (balRow) {
+        db.prepare(
+          'UPDATE sanctuary_star_balance SET balance = ?, updated_at = CURRENT_TIMESTAMP WHERE wallet_address = ?'
+        ).run(newBal, addr);
+      } else {
+        db.prepare(
+          'INSERT INTO sanctuary_star_balance (wallet_address, balance, lifetime_earned) VALUES (?, ?, ?)'
+        ).run(addr, newBal, 0);
+      }
+      db.prepare(
+        'INSERT INTO sanctuary_star_ledger (wallet_address, delta, kind, source, balance_after) VALUES (?, ?, ?, ?, ?)'
+      ).run(addr, -entry.star_cost, 'spend', `expedition:${expeditionId}`, newBal);
+    }
+
+    const state = startExpedition(entry.definition);
+    const result = db.prepare(
+      "INSERT INTO sanctuary_expeditions (wallet_address, token_id, expedition_id, star_cost, status) VALUES (?, ?, ?, ?, 'active')"
+    ).run(addr, tokenId, expeditionId, entry.star_cost);
+    const rowId = Number(result.lastInsertRowid);
+    db.prepare(
+      'INSERT INTO sanctuary_expedition_progress (expedition_row_id, current_step_id, choices_jsonb) VALUES (?, ?, ?)'
+    ).run(rowId, state.currentStepId, JSON.stringify(state.history));
+
+    const row = db.prepare('SELECT * FROM sanctuary_expeditions WHERE id = ?').get(rowId) as SanctuaryExpeditionRow;
+    return { row, state, definition: entry.definition };
+  });
+
+  return txn();
+}
+
+export function getExpeditionRun(
+  walletAddress: string,
+  tokenId: number,
+  rowId: number,
+): ExpeditionRunView | null {
+  const db = getDatabase();
+  const row = db.prepare(
+    'SELECT * FROM sanctuary_expeditions WHERE id = ? AND wallet_address = ? AND token_id = ?'
+  ).get(rowId, walletAddress.toLowerCase(), tokenId) as SanctuaryExpeditionRow | undefined;
+  if (!row) return null;
+
+  const entry = getExpeditionCatalogEntry(row.expedition_id);
+  if (!entry) return null;
+  const progress = db.prepare(
+    'SELECT * FROM sanctuary_expedition_progress WHERE expedition_row_id = ?'
+  ).get(rowId) as SanctuaryExpeditionProgressRow | undefined;
+
+  return { row, state: rowToState(row, progress), definition: entry.definition };
+}
+
+/**
+ * Apply a choice to the current step of a run. On a terminal step this also
+ * settles rewards: success grants STAR + bond + trait, partial/failure grant
+ * the scaled subset per {@link EXPEDITION_OUTCOME_REWARD_SCALE}.
+ */
+export function chooseExpeditionStep(
+  walletAddress: string,
+  tokenId: number,
+  rowId: number,
+  choiceId: string,
+): ExpeditionRunView & {
+  rewards: { xp: number; bond: number; trait: string | null; starGained: number };
+} {
+  const db = getDatabase();
+  const addr = walletAddress.toLowerCase();
+
+  const txn = db.transaction(() => {
+    const row = db.prepare(
+      'SELECT * FROM sanctuary_expeditions WHERE id = ? AND wallet_address = ? AND token_id = ?'
+    ).get(rowId, addr, tokenId) as SanctuaryExpeditionRow | undefined;
+    if (!row) throw new Error('NOT_FOUND');
+    if (row.status !== 'active') throw new Error('NOT_ACTIVE');
+
+    const entry = getExpeditionCatalogEntry(row.expedition_id);
+    if (!entry) throw new Error('EXPEDITION_NOT_FOUND');
+
+    const progress = db.prepare(
+      'SELECT * FROM sanctuary_expedition_progress WHERE expedition_row_id = ?'
+    ).get(rowId) as SanctuaryExpeditionProgressRow | undefined;
+    const state = rowToState(row, progress);
+    const nextState = chooseExpeditionPath(state, entry.definition, choiceId);
+
+    db.prepare(
+      'UPDATE sanctuary_expedition_progress SET current_step_id = ?, choices_jsonb = ?, updated_at = CURRENT_TIMESTAMP WHERE expedition_row_id = ?'
+    ).run(nextState.currentStepId, JSON.stringify(nextState.history), rowId);
+
+    let rewards = { xp: 0, bond: 0, trait: null as string | null, starGained: 0 };
+
+    if (nextState.status === 'completed' && nextState.finalOutcome) {
+      const def = entry.definition;
+      const computed = getExpeditionRewards(nextState, def);
+      const starGained = Math.max(0, Math.round(computed.xp / 4));
+      rewards = {
+        xp: computed.xp,
+        bond: computed.bond,
+        trait: computed.trait ?? null,
+        starGained,
+      };
+
+      db.prepare(
+        "UPDATE sanctuary_expeditions SET status = 'completed', ended_at = CURRENT_TIMESTAMP, outcome = ? WHERE id = ?"
+      ).run(nextState.finalOutcome, rowId);
+
+      if (computed.xp > 0) {
+        try { addUserXP(addr, computed.xp); } catch { /* user_xp may not be wired for tests */ }
+      }
+      if (computed.bond > 0) {
+        db.prepare(
+          'UPDATE sanctuary_companions SET bond_score = MIN(bond_score + ?, 100.0), updated_at = CURRENT_TIMESTAMP WHERE wallet_address = ? AND token_id = ?'
+        ).run(computed.bond, addr, tokenId);
+      }
+      if (computed.trait) {
+        const traitName = computed.trait;
+        const existing = db.prepare(
+          'SELECT id FROM sanctuary_traits WHERE wallet_address = ? AND token_id = ? AND trait_name = ?'
+        ).get(addr, tokenId, traitName) as { id: number } | undefined;
+        if (existing) {
+          db.prepare(
+            'UPDATE sanctuary_traits SET unlocked = 1, progress = 1, unlocked_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP WHERE id = ?'
+          ).run(existing.id);
+        } else {
+          db.prepare(
+            "INSERT INTO sanctuary_traits (wallet_address, token_id, trait_name, trait_category, progress, unlocked, unlocked_at) VALUES (?, ?, ?, 'special', 1, 1, CURRENT_TIMESTAMP)"
+          ).run(addr, tokenId, traitName);
+        }
+      }
+      if (starGained > 0) {
+        const balRow = db.prepare(
+          'SELECT balance, lifetime_earned FROM sanctuary_star_balance WHERE wallet_address = ?'
+        ).get(addr) as { balance: number; lifetime_earned: number } | undefined;
+        const newBalance = (balRow?.balance ?? 0) + starGained;
+        const newLifetime = (balRow?.lifetime_earned ?? 0) + starGained;
+        if (balRow) {
+          db.prepare(
+            'UPDATE sanctuary_star_balance SET balance = ?, lifetime_earned = ?, updated_at = CURRENT_TIMESTAMP WHERE wallet_address = ?'
+          ).run(newBalance, newLifetime, addr);
+        } else {
+          db.prepare(
+            'INSERT INTO sanctuary_star_balance (wallet_address, balance, lifetime_earned) VALUES (?, ?, ?)'
+          ).run(addr, newBalance, newLifetime);
+        }
+        db.prepare(
+          'INSERT INTO sanctuary_star_ledger (wallet_address, delta, kind, source, balance_after) VALUES (?, ?, ?, ?, ?)'
+        ).run(addr, starGained, 'earn', `expedition:${row.expedition_id}:${nextState.finalOutcome}`, newBalance);
+      }
+
+      try {
+        addJournalEntry(
+          addr, tokenId, 'quest',
+          `Expedition "${def.title}" — ${nextState.finalOutcome}`,
+          JSON.stringify({ expedition_id: def.id, outcome: nextState.finalOutcome, ...rewards }),
+        );
+      } catch { /* journal optional in tests */ }
+    }
+
+    const updatedRow = db.prepare('SELECT * FROM sanctuary_expeditions WHERE id = ?').get(rowId) as SanctuaryExpeditionRow;
+    return { row: updatedRow, state: nextState, definition: entry.definition, rewards };
+  });
+
+  return txn();
+}
+
+/**
+ * Abandon an active run. Idempotent on already-ended rows: returns the
+ * existing state unchanged rather than re-stamping.
+ */
+export function abandonExpeditionRun(
+  walletAddress: string,
+  tokenId: number,
+  rowId: number,
+): ExpeditionRunView {
+  const db = getDatabase();
+  const addr = walletAddress.toLowerCase();
+
+  const txn = db.transaction(() => {
+    const row = db.prepare(
+      'SELECT * FROM sanctuary_expeditions WHERE id = ? AND wallet_address = ? AND token_id = ?'
+    ).get(rowId, addr, tokenId) as SanctuaryExpeditionRow | undefined;
+    if (!row) throw new Error('NOT_FOUND');
+
+    const entry = getExpeditionCatalogEntry(row.expedition_id);
+    if (!entry) throw new Error('EXPEDITION_NOT_FOUND');
+
+    const progress = db.prepare(
+      'SELECT * FROM sanctuary_expedition_progress WHERE expedition_row_id = ?'
+    ).get(rowId) as SanctuaryExpeditionProgressRow | undefined;
+    const state = rowToState(row, progress);
+    if (state.status !== 'active') {
+      return { row, state, definition: entry.definition };
+    }
+
+    const nextState = abandonExpedition(state);
+    db.prepare(
+      "UPDATE sanctuary_expeditions SET status = 'abandoned', ended_at = CURRENT_TIMESTAMP WHERE id = ?"
+    ).run(rowId);
+    db.prepare(
+      'UPDATE sanctuary_expedition_progress SET current_step_id = NULL, updated_at = CURRENT_TIMESTAMP WHERE expedition_row_id = ?'
+    ).run(rowId);
+
+    const updatedRow = db.prepare('SELECT * FROM sanctuary_expeditions WHERE id = ?').get(rowId) as SanctuaryExpeditionRow;
+    return { row: updatedRow, state: nextState, definition: entry.definition };
+  });
+
+  return txn();
 }

--- a/lib/sanctuary/__tests__/expedition-routes.test.ts
+++ b/lib/sanctuary/__tests__/expedition-routes.test.ts
@@ -1,0 +1,177 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// Route-level tests for /api/sanctuary/expeditions/{list,start,choose,abandon}.
+// Mirrors api-e2e.test.ts: mock the db helpers, wallet auth, and rate limiter,
+// then drive each route handler directly with crafted NextRequests.
+
+const db = vi.hoisted(() => ({
+  listExpeditions: vi.fn(),
+  startExpeditionRun: vi.fn(),
+  chooseExpeditionStep: vi.fn(),
+  abandonExpeditionRun: vi.fn(),
+}));
+const walletAuth = vi.hoisted(() => ({ verifyWalletAccess: vi.fn() }));
+const rateLimit = vi.hoisted(() => ({
+  applyRateLimit: vi.fn().mockReturnValue(null),
+  checkRateLimit: vi.fn().mockReturnValue({ allowed: true }),
+  recordRequest: vi.fn(),
+}));
+
+vi.mock('@/lib/db', () => db);
+vi.mock('@/lib/walletAuth', () => walletAuth);
+vi.mock('@/lib/sanctuary/rateLimit', () => rateLimit);
+
+import { GET as listGET } from '@/app/api/sanctuary/expeditions/list/route';
+import { POST as startPOST } from '@/app/api/sanctuary/expeditions/start/route';
+import { POST as choosePOST } from '@/app/api/sanctuary/expeditions/choose/route';
+import { POST as abandonPOST } from '@/app/api/sanctuary/expeditions/abandon/route';
+
+const ALICE = '0x' + 'a'.repeat(40);
+const TOKEN = 3;
+
+function get(path: string, params?: Record<string, string>): NextRequest {
+  const url = new URL(path, 'http://test');
+  if (params) for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
+  return new NextRequest(url);
+}
+function post(path: string, body: Record<string, unknown>): NextRequest {
+  return new NextRequest(new URL(path, 'http://test'), {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => vi.resetAllMocks());
+
+describe('GET /api/sanctuary/expeditions/list', () => {
+  it('returns 400 when params missing', async () => {
+    const res = await listGET(get('/api/sanctuary/expeditions/list'));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns catalog from db helper', async () => {
+    db.listExpeditions.mockReturnValue({
+      tiers: ['easy', 'medium', 'hard'],
+      expeditions: [
+        { tier: 'easy', star_cost: 5, id: 'exp-easy-meadow-walk', title: 'Meadow Walk', description: '', npcSource: 'meadow', rewards: { xp: 20, bond: 2, trait: 'Wanderer' }, active_row_id: null },
+      ],
+    });
+    const res = await listGET(get('/api/sanctuary/expeditions/list', { address: ALICE, token_id: String(TOKEN) }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.expeditions[0].id).toBe('exp-easy-meadow-walk');
+    expect(db.listExpeditions).toHaveBeenCalledWith(ALICE, TOKEN);
+  });
+});
+
+describe('POST /api/sanctuary/expeditions/start', () => {
+  it('returns 400 on missing params', async () => {
+    const res = await startPOST(post('/api/sanctuary/expeditions/start', { address: ALICE }));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 401 when wallet auth fails', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: false, error: 'Missing auth' });
+    const res = await startPOST(post('/api/sanctuary/expeditions/start', { address: ALICE, token_id: TOKEN, expedition_id: 'x' }));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 200 with the run on success', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: true });
+    db.startExpeditionRun.mockReturnValue({ row: { id: 7, status: 'active' }, state: { currentStepId: 'a' }, definition: { id: 'x' } });
+    const res = await startPOST(post('/api/sanctuary/expeditions/start', { address: ALICE, token_id: TOKEN, expedition_id: 'x' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.run.row.id).toBe(7);
+  });
+
+  it('returns 402 on insufficient STAR', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: true });
+    db.startExpeditionRun.mockImplementation(() => { throw new Error('Insufficient STAR balance'); });
+    const res = await startPOST(post('/api/sanctuary/expeditions/start', { address: ALICE, token_id: TOKEN, expedition_id: 'x' }));
+    expect(res.status).toBe(402);
+  });
+
+  it('returns 409 when an active run already exists', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: true });
+    db.startExpeditionRun.mockImplementation(() => { throw new Error('ALREADY_ACTIVE'); });
+    const res = await startPOST(post('/api/sanctuary/expeditions/start', { address: ALICE, token_id: TOKEN, expedition_id: 'x' }));
+    expect(res.status).toBe(409);
+  });
+
+  it('returns 404 when expedition id is unknown', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: true });
+    db.startExpeditionRun.mockImplementation(() => { throw new Error('EXPEDITION_NOT_FOUND'); });
+    const res = await startPOST(post('/api/sanctuary/expeditions/start', { address: ALICE, token_id: TOKEN, expedition_id: 'x' }));
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('POST /api/sanctuary/expeditions/choose', () => {
+  it('returns 401 when wallet auth fails', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: false, error: 'Missing auth' });
+    const res = await choosePOST(post('/api/sanctuary/expeditions/choose', { address: ALICE, token_id: TOKEN, row_id: 1, choice_id: 'go' }));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns updated run + rewards', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: true });
+    db.chooseExpeditionStep.mockReturnValue({
+      row: { id: 1, status: 'completed', outcome: 'success' },
+      state: { status: 'completed', finalOutcome: 'success' },
+      definition: { id: 'x' },
+      rewards: { xp: 100, bond: 4, trait: 'TestTrait', starGained: 25 },
+    });
+    const res = await choosePOST(post('/api/sanctuary/expeditions/choose', { address: ALICE, token_id: TOKEN, row_id: 1, choice_id: 'win' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.run.rewards.trait).toBe('TestTrait');
+  });
+
+  it('returns 409 when run is not active', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: true });
+    db.chooseExpeditionStep.mockImplementation(() => { throw new Error('NOT_ACTIVE'); });
+    const res = await choosePOST(post('/api/sanctuary/expeditions/choose', { address: ALICE, token_id: TOKEN, row_id: 1, choice_id: 'go' }));
+    expect(res.status).toBe(409);
+  });
+
+  it('returns 404 when run not found', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: true });
+    db.chooseExpeditionStep.mockImplementation(() => { throw new Error('NOT_FOUND'); });
+    const res = await choosePOST(post('/api/sanctuary/expeditions/choose', { address: ALICE, token_id: TOKEN, row_id: 99, choice_id: 'go' }));
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('POST /api/sanctuary/expeditions/abandon', () => {
+  it('returns 401 when wallet auth fails', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: false, error: 'Missing auth' });
+    const res = await abandonPOST(post('/api/sanctuary/expeditions/abandon', { address: ALICE, token_id: TOKEN, row_id: 1 }));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns updated abandoned row', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: true });
+    db.abandonExpeditionRun.mockReturnValue({
+      row: { id: 1, status: 'abandoned', ended_at: '2026-01-01' },
+      state: { status: 'abandoned' },
+      definition: { id: 'x' },
+    });
+    const res = await abandonPOST(post('/api/sanctuary/expeditions/abandon', { address: ALICE, token_id: TOKEN, row_id: 1 }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.run.row.status).toBe('abandoned');
+  });
+
+  it('returns 404 when run not found', async () => {
+    walletAuth.verifyWalletAccess.mockResolvedValue({ valid: true });
+    db.abandonExpeditionRun.mockImplementation(() => { throw new Error('NOT_FOUND'); });
+    const res = await abandonPOST(post('/api/sanctuary/expeditions/abandon', { address: ALICE, token_id: TOKEN, row_id: 99 }));
+    expect(res.status).toBe(404);
+  });
+});

--- a/lib/sanctuary/__tests__/expedition-store.test.ts
+++ b/lib/sanctuary/__tests__/expedition-store.test.ts
@@ -1,0 +1,324 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import fs from 'fs';
+import path from 'path';
+
+import {
+  chooseExpeditionPath,
+  getExpeditionRewards,
+  startExpedition,
+  type ExpeditionDefinition,
+} from '../expeditions';
+
+// Tests for the V2.6 expedition persistence layer. We exercise the SQL/logic
+// against an in-memory SQLite DB and the pure reducer, mirroring the pattern
+// established by starCurrency.test.ts and shop.test.ts.
+//
+// For the DB-backed integration tests we redirect lib/db.ts's getDatabase()
+// to a fresh in-memory DB and let it load the real catalog from
+// data/sanctuary/expeditions/easy.json — that doubles as a check that the
+// seed files are wellformed.
+
+const ALICE = '0x' + 'a'.repeat(40);
+const TOKEN_ID = 3;
+// Real seed from data/sanctuary/expeditions/easy.json — 5 STAR cost, 2 steps.
+const EASY_EXP_ID = 'exp-easy-meadow-walk';
+const EASY_STAR_COST = 5;
+// Real seed from data/sanctuary/expeditions/medium.json — 15 STAR, 3-outcome final.
+const MEDIUM_EXP_ID = 'exp-medium-observatory-eclipse';
+
+function loadSql(file: string): string {
+  return fs.readFileSync(path.join(process.cwd(), 'scripts', file), 'utf-8');
+}
+
+function createExpeditionDb(): Database.Database {
+  const db = new Database(':memory:');
+  db.pragma('journal_mode = WAL');
+  db.pragma('foreign_keys = ON');
+
+  // Minimal upstream tables so FKs resolve.
+  db.exec(`
+    CREATE TABLE star_skrumpey_metadata (
+      token_id INTEGER PRIMARY KEY,
+      name TEXT
+    )
+  `);
+  db.exec(`
+    CREATE TABLE user_xp (
+      wallet_address TEXT PRIMARY KEY,
+      total_xp INTEGER DEFAULT 0,
+      level INTEGER DEFAULT 1
+    )
+  `);
+  db.exec(loadSql('init-sanctuary.sql'));
+  db.exec(loadSql('init-sanctuary-v1.5.sql'));
+  db.exec(loadSql('init-sanctuary-v2.1.sql'));
+  db.exec(loadSql('init-sanctuary-v2.6.sql'));
+
+  db.prepare('INSERT INTO star_skrumpey_metadata (token_id, name) VALUES (?, ?)').run(TOKEN_ID, 'Star #3');
+  db.prepare(
+    "INSERT INTO sanctuary_companions (wallet_address, token_id, is_active, bond_score, equipped_cosmetics) VALUES (?, ?, 1, 10.0, '{}')"
+  ).run(ALICE, TOKEN_ID);
+  return db;
+}
+
+function buildSimpleDef(): ExpeditionDefinition {
+  return {
+    id: 'test-easy',
+    title: 'Easy',
+    description: 'Easy run',
+    npcSource: 'meadow',
+    startStepId: 'a',
+    rewards: { xp: 100, bond: 4.0, trait: 'TestTrait' },
+    steps: [
+      {
+        id: 'a',
+        narrative: 'start',
+        choices: [{ id: 'go', label: 'go', nextStepId: 'b' }],
+      },
+      {
+        id: 'b',
+        narrative: 'end',
+        isFinal: true,
+        choices: [
+          { id: 'win', label: 'win', outcome: 'success' },
+          { id: 'lose', label: 'lose', outcome: 'failure' },
+        ],
+      },
+    ],
+  };
+}
+
+describe('sanctuary_expeditions schema', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createExpeditionDb();
+  });
+
+  it('creates both tables with the spec columns', () => {
+    const expCols = db.prepare("PRAGMA table_info(sanctuary_expeditions)").all() as Array<{ name: string }>;
+    const names = expCols.map((c) => c.name).sort();
+    expect(names).toEqual(
+      ['ended_at', 'expedition_id', 'id', 'outcome', 'star_cost', 'started_at', 'status', 'token_id', 'wallet_address'].sort(),
+    );
+
+    const progCols = db.prepare("PRAGMA table_info(sanctuary_expedition_progress)").all() as Array<{ name: string }>;
+    const progNames = progCols.map((c) => c.name).sort();
+    expect(progNames).toEqual(
+      ['choices_jsonb', 'current_step_id', 'expedition_row_id', 'updated_at'].sort(),
+    );
+  });
+
+  it('rejects an unknown outcome value via CHECK', () => {
+    expect(() => {
+      db.prepare(
+        "INSERT INTO sanctuary_expeditions (wallet_address, token_id, expedition_id, star_cost, status, outcome) VALUES (?, ?, ?, 0, 'completed', 'bogus')"
+      ).run(ALICE, TOKEN_ID, 'x');
+    }).toThrow();
+  });
+});
+
+describe('expedition reducer round-trip via JSON history', () => {
+  it('rehydrates state from serialized history without losing the path', () => {
+    const def = buildSimpleDef();
+    const s0 = startExpedition(def);
+    const s1 = chooseExpeditionPath(s0, def, 'go');
+    const s2 = chooseExpeditionPath(s1, def, 'win');
+
+    const serialized = JSON.stringify(s2.history);
+    const rehydrated = { ...s2, history: JSON.parse(serialized) };
+
+    expect(rehydrated.history).toHaveLength(2);
+    expect(rehydrated.history[0]).toMatchObject({ stepId: 'a', choiceId: 'go' });
+    expect(rehydrated.history[1]).toMatchObject({ stepId: 'b', choiceId: 'win', outcome: 'success' });
+
+    const rewards = getExpeditionRewards(s2, def);
+    expect(rewards.xp).toBe(100);
+    expect(rewards.trait).toBe('TestTrait');
+  });
+
+  it('deterministically produces the same outcome for the same choices', () => {
+    const def = buildSimpleDef();
+    const runOnce = () => {
+      let s = startExpedition(def);
+      s = chooseExpeditionPath(s, def, 'go');
+      s = chooseExpeditionPath(s, def, 'lose');
+      return getExpeditionRewards(s, def);
+    };
+    expect(runOnce()).toEqual(runOnce());
+  });
+});
+
+// ─── Integration tests against the real seed catalog ──────────────────
+
+async function withDb<T>(testDb: Database.Database, fn: (mod: typeof import('../../db')) => Promise<T> | T): Promise<T> {
+  const mod = await import('../../db');
+  mod.__setTestDatabase(testDb);
+  try {
+    return await fn(mod);
+  } finally {
+    mod.__setTestDatabase(null);
+  }
+}
+
+describe('startExpeditionRun deducts STAR and creates a run', () => {
+  it('rejects when balance is insufficient and creates no row', async () => {
+    const db = createExpeditionDb();
+    await withDb(db, (mod) => {
+      expect(() => mod.startExpeditionRun(ALICE, TOKEN_ID, EASY_EXP_ID)).toThrow(/Insufficient STAR/);
+    });
+    const count = db.prepare('SELECT COUNT(*) AS c FROM sanctuary_expeditions').get() as { c: number };
+    expect(count.c).toBe(0);
+  });
+
+  it('deducts STAR on success and seeds the progress row', async () => {
+    const db = createExpeditionDb();
+    db.prepare(
+      'INSERT INTO sanctuary_star_balance (wallet_address, balance, lifetime_earned) VALUES (?, ?, ?)'
+    ).run(ALICE, 50, 50);
+
+    await withDb(db, (mod) => {
+      const result = mod.startExpeditionRun(ALICE, TOKEN_ID, EASY_EXP_ID);
+      expect(result.row.expedition_id).toBe(EASY_EXP_ID);
+      expect(result.row.star_cost).toBe(EASY_STAR_COST);
+      expect(result.row.status).toBe('active');
+      expect(result.state.currentStepId).toBe('meadow-start');
+    });
+
+    const bal = db.prepare('SELECT balance FROM sanctuary_star_balance WHERE wallet_address = ?').get(ALICE) as { balance: number };
+    expect(bal.balance).toBe(50 - EASY_STAR_COST);
+
+    const progress = db.prepare('SELECT * FROM sanctuary_expedition_progress WHERE expedition_row_id = 1').get() as { current_step_id: string };
+    expect(progress.current_step_id).toBe('meadow-start');
+  });
+
+  it('rejects starting a second concurrent run for the same expedition', async () => {
+    const db = createExpeditionDb();
+    db.prepare(
+      'INSERT INTO sanctuary_star_balance (wallet_address, balance, lifetime_earned) VALUES (?, ?, ?)'
+    ).run(ALICE, 50, 50);
+
+    await withDb(db, (mod) => {
+      mod.startExpeditionRun(ALICE, TOKEN_ID, EASY_EXP_ID);
+      expect(() => mod.startExpeditionRun(ALICE, TOKEN_ID, EASY_EXP_ID)).toThrow('ALREADY_ACTIVE');
+    });
+  });
+});
+
+describe('chooseExpeditionStep settles rewards on terminal outcome', () => {
+  it('on success: grants STAR + bond + trait', async () => {
+    const db = createExpeditionDb();
+    db.prepare(
+      'INSERT INTO sanctuary_star_balance (wallet_address, balance, lifetime_earned) VALUES (?, ?, ?)'
+    ).run(ALICE, 50, 50);
+
+    await withDb(db, (mod) => {
+      const run = mod.startExpeditionRun(ALICE, TOKEN_ID, EASY_EXP_ID);
+      mod.chooseExpeditionStep(ALICE, TOKEN_ID, run.row.id, 'trail-flowers');
+      const finished = mod.chooseExpeditionStep(ALICE, TOKEN_ID, run.row.id, 'rest-share');
+
+      expect(finished.state.status).toBe('completed');
+      expect(finished.state.finalOutcome).toBe('success');
+      expect(finished.rewards.trait).toBe('Wanderer');
+      expect(finished.rewards.starGained).toBeGreaterThan(0);
+
+      // STAR settled (cost 5 deducted at start, success grant added).
+      const bal = db.prepare('SELECT balance FROM sanctuary_star_balance WHERE wallet_address = ?').get(ALICE) as { balance: number };
+      expect(bal.balance).toBe(50 - EASY_STAR_COST + finished.rewards.starGained);
+
+      // Trait unlocked
+      const trait = db.prepare(
+        'SELECT * FROM sanctuary_traits WHERE wallet_address = ? AND token_id = ? AND trait_name = ?'
+      ).get(ALICE, TOKEN_ID, 'Wanderer') as { unlocked: number } | undefined;
+      expect(trait?.unlocked).toBe(1);
+
+      // Bond increased
+      const comp = db.prepare(
+        'SELECT bond_score FROM sanctuary_companions WHERE wallet_address = ? AND token_id = ? AND is_active = 1'
+      ).get(ALICE, TOKEN_ID) as { bond_score: number };
+      expect(comp.bond_score).toBeGreaterThan(10); // started at 10
+    });
+  });
+
+  it('on failure path (hard tier risky branch): cost stays deducted, no trait, scaled reward', async () => {
+    const db = createExpeditionDb();
+    db.prepare(
+      'INSERT INTO sanctuary_star_balance (wallet_address, balance, lifetime_earned) VALUES (?, ?, ?)'
+    ).run(ALICE, 100, 100);
+
+    await withDb(db, (mod) => {
+      // The hard tier risky branch (take-quench → risky-dunk-early) yields failure.
+      const HARD_EXP = 'exp-hard-forge-emberheart';
+      const run = mod.startExpeditionRun(ALICE, TOKEN_ID, HARD_EXP);
+      mod.chooseExpeditionStep(ALICE, TOKEN_ID, run.row.id, 'take-quench');
+      const finished = mod.chooseExpeditionStep(ALICE, TOKEN_ID, run.row.id, 'risky-dunk-early');
+
+      expect(finished.state.finalOutcome).toBe('failure');
+      expect(finished.rewards.trait).toBeNull();
+      expect(finished.rewards.xp).toBeLessThan(150); // scaled below base 150 xp
+      const trait = db.prepare(
+        'SELECT * FROM sanctuary_traits WHERE wallet_address = ? AND token_id = ? AND trait_name = ?'
+      ).get(ALICE, TOKEN_ID, 'Emberheart') as { unlocked: number } | undefined;
+      expect(trait?.unlocked ?? 0).toBe(0);
+    });
+  });
+
+  it('outcomes are deterministic against (expedition, choice path)', async () => {
+    const db = createExpeditionDb();
+    db.prepare(
+      'INSERT INTO sanctuary_star_balance (wallet_address, balance, lifetime_earned) VALUES (?, ?, ?)'
+    ).run(ALICE, 200, 200);
+
+    await withDb(db, (mod) => {
+      const run1 = mod.startExpeditionRun(ALICE, TOKEN_ID, MEDIUM_EXP_ID);
+      mod.chooseExpeditionStep(ALICE, TOKEN_ID, run1.row.id, 'ready-pen');
+      const a = mod.chooseExpeditionStep(ALICE, TOKEN_ID, run1.row.id, 'write-bullets');
+      const run2 = mod.startExpeditionRun(ALICE, TOKEN_ID, MEDIUM_EXP_ID);
+      mod.chooseExpeditionStep(ALICE, TOKEN_ID, run2.row.id, 'ready-pen');
+      const b = mod.chooseExpeditionStep(ALICE, TOKEN_ID, run2.row.id, 'write-bullets');
+      expect(a.state.finalOutcome).toBe(b.state.finalOutcome);
+      expect(a.rewards.xp).toBe(b.rewards.xp);
+      expect(a.rewards.starGained).toBe(b.rewards.starGained);
+    });
+  });
+});
+
+describe('abandonExpeditionRun', () => {
+  it('marks the row abandoned and does not refund STAR', async () => {
+    const db = createExpeditionDb();
+    db.prepare(
+      'INSERT INTO sanctuary_star_balance (wallet_address, balance, lifetime_earned) VALUES (?, ?, ?)'
+    ).run(ALICE, 50, 50);
+    await withDb(db, (mod) => {
+      const run = mod.startExpeditionRun(ALICE, TOKEN_ID, EASY_EXP_ID);
+      const result = mod.abandonExpeditionRun(ALICE, TOKEN_ID, run.row.id);
+      expect(result.row.status).toBe('abandoned');
+      expect(result.row.ended_at).not.toBeNull();
+    });
+    const bal = db.prepare('SELECT balance FROM sanctuary_star_balance WHERE wallet_address = ?').get(ALICE) as { balance: number };
+    expect(bal.balance).toBe(50 - EASY_STAR_COST); // no refund
+  });
+});
+
+describe('listExpeditions surfaces tiered catalog', () => {
+  it('returns all tiers and flags the active row', async () => {
+    const db = createExpeditionDb();
+    db.prepare(
+      'INSERT INTO sanctuary_star_balance (wallet_address, balance, lifetime_earned) VALUES (?, ?, ?)'
+    ).run(ALICE, 50, 50);
+
+    await withDb(db, (mod) => {
+      const before = mod.listExpeditions(ALICE, TOKEN_ID);
+      expect(before.tiers).toEqual(['easy', 'medium', 'hard']);
+      expect(before.expeditions.length).toBeGreaterThanOrEqual(3);
+      expect(before.expeditions.every((e) => e.active_row_id === null)).toBe(true);
+
+      const run = mod.startExpeditionRun(ALICE, TOKEN_ID, EASY_EXP_ID);
+      const after = mod.listExpeditions(ALICE, TOKEN_ID);
+      const easyRow = after.expeditions.find((e) => e.id === EASY_EXP_ID);
+      expect(easyRow?.active_row_id).toBe(run.row.id);
+    });
+  });
+});

--- a/lib/sanctuary/expeditionDefs.ts
+++ b/lib/sanctuary/expeditionDefs.ts
@@ -1,0 +1,71 @@
+/**
+ * Server-side loader for expedition definitions.
+ *
+ * Reads the three tier seeds under `data/sanctuary/expeditions/` and exposes
+ * the merged catalog plus the per-tier `star_cost` charged at start. The cost
+ * lives outside {@link ExpeditionDefinition} because the engine module is
+ * intentionally currency-agnostic — the persistence layer wraps it.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+import type { ExpeditionDefinition } from './expeditions';
+import { validateExpeditionDefinition } from './expeditions';
+
+export type ExpeditionTier = 'easy' | 'medium' | 'hard';
+
+export const EXPEDITION_TIERS: readonly ExpeditionTier[] = ['easy', 'medium', 'hard'];
+
+export interface ExpeditionCatalogEntry {
+  tier: ExpeditionTier;
+  star_cost: number;
+  definition: ExpeditionDefinition;
+}
+
+let cachedCatalog: ExpeditionCatalogEntry[] | null = null;
+
+interface SeedShape {
+  tier?: string;
+  expeditions: Array<ExpeditionDefinition & { star_cost?: number }>;
+}
+
+function loadTier(tier: ExpeditionTier): ExpeditionCatalogEntry[] {
+  const filePath = path.join(process.cwd(), 'data', 'sanctuary', 'expeditions', `${tier}.json`);
+  if (!fs.existsSync(filePath)) return [];
+  const raw = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as SeedShape;
+  const out: ExpeditionCatalogEntry[] = [];
+  for (const seed of raw.expeditions ?? []) {
+    const { star_cost, ...def } = seed;
+    const validation = validateExpeditionDefinition(def);
+    if (!validation.ok) {
+      throw new Error(
+        `Invalid expedition seed ${tier}.json#${def.id}: ${validation.errors.join('; ')}`,
+      );
+    }
+    out.push({
+      tier,
+      star_cost: typeof star_cost === 'number' && star_cost >= 0 ? Math.floor(star_cost) : 0,
+      definition: def,
+    });
+  }
+  return out;
+}
+
+export function getExpeditionCatalog(): ExpeditionCatalogEntry[] {
+  if (cachedCatalog) return cachedCatalog;
+  const entries: ExpeditionCatalogEntry[] = [];
+  for (const tier of EXPEDITION_TIERS) {
+    entries.push(...loadTier(tier));
+  }
+  cachedCatalog = entries;
+  return entries;
+}
+
+export function getExpeditionCatalogEntry(expeditionId: string): ExpeditionCatalogEntry | null {
+  return getExpeditionCatalog().find((e) => e.definition.id === expeditionId) ?? null;
+}
+
+/** Test-only escape hatch — clears the in-process cache. */
+export function __resetExpeditionCatalogCache(): void {
+  cachedCatalog = null;
+}

--- a/lib/sanctuary/rateLimit.ts
+++ b/lib/sanctuary/rateLimit.ts
@@ -19,6 +19,9 @@ const LIMITS: Record<string, RateLimitConfig> = {
   'minigame/score': { maxRequests: 30, windowSeconds: 60 },
   'shop/buy': { maxRequests: 20, windowSeconds: 60 },
   'inventory/equip': { maxRequests: 30, windowSeconds: 60 },
+  'expeditions/start': { maxRequests: 10, windowSeconds: 60 },
+  'expeditions/choose': { maxRequests: 30, windowSeconds: 60 },
+  'expeditions/abandon': { maxRequests: 10, windowSeconds: 60 },
 };
 
 let cleanupCounter = 0;

--- a/scripts/init-sanctuary-v2.6.sql
+++ b/scripts/init-sanctuary-v2.6.sql
@@ -1,0 +1,41 @@
+-- Star Sanctuary — V2.6 Schema: Multi-step expedition adventures
+--
+-- Persists the engine-agnostic expedition flow defined in
+-- lib/sanctuary/expeditions.ts. Each row in `sanctuary_expeditions` is one
+-- run of one expedition for one (wallet, token) pair. Per-step progress
+-- (current step + choice history) is kept in `sanctuary_expedition_progress`
+-- alongside it so the reducer can be rehydrated by id and choose/abandon
+-- operations stay transactional.
+--
+-- Loaded by lib/db.ts initializeSanctuary(). Safe to re-run.
+
+CREATE TABLE IF NOT EXISTS sanctuary_expeditions (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  wallet_address TEXT NOT NULL,
+  token_id INTEGER NOT NULL,
+  expedition_id TEXT NOT NULL,
+  star_cost INTEGER NOT NULL DEFAULT 0,
+  started_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  ended_at DATETIME,
+  outcome TEXT CHECK (outcome IN ('success', 'partial', 'failure')),
+  status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'completed', 'abandoned')),
+  FOREIGN KEY (token_id) REFERENCES star_skrumpey_metadata(token_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_sanctuary_expeditions_wallet_token
+  ON sanctuary_expeditions(wallet_address, token_id);
+
+CREATE INDEX IF NOT EXISTS idx_sanctuary_expeditions_active
+  ON sanctuary_expeditions(wallet_address, token_id, status);
+
+-- One progress row per expedition run. Holds the reducer's current step
+-- and a JSON-serialized choice history (`choices_jsonb`). SQLite has no
+-- native JSONB; we use TEXT and parse in app layer (matches the convention
+-- already used elsewhere for serialized state).
+CREATE TABLE IF NOT EXISTS sanctuary_expedition_progress (
+  expedition_row_id INTEGER PRIMARY KEY,
+  current_step_id TEXT,
+  choices_jsonb TEXT NOT NULL DEFAULT '[]',
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (expedition_row_id) REFERENCES sanctuary_expeditions(id) ON DELETE CASCADE
+);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -33,7 +33,15 @@ export default defineConfig({
         test: {
           name: 'default',
           environment: 'node',
-          include: ['**/*.test.ts', '**/*.spec.ts'],
+          include: [
+            '**/*.test.ts',
+            '**/*.spec.ts',
+            // `.tsx` is opt-in per-suite via the `@vitest-environment` header
+            // (happy-dom for component tests). The default project still
+            // defaults to `node` — only the suites that need DOM ask for it.
+            'components/sanctuary/**/*.test.tsx',
+            'components/sanctuary/**/*.spec.tsx',
+          ],
           exclude: [
             'node_modules',
             '.next',


### PR DESCRIPTION
## Summary
- Engine-agnostic `<ExpeditionDialog>` overlay consumes PR2's expedition API. Renders current step narrative + choices, POSTs `/choose` and `/abandon`, and **hydrates from `/run` on remount** so a mid-flight page reload lands on the same `current_step_id` the DB recorded.
- `<QuestBoard>` gains an EXPEDITIONS section. Each catalog entry shows tier, STAR cost, rewards, and a BEGIN/RESUME CTA that fires `expedition-open` for the dialog to consume.
- New read-only endpoint `GET /api/sanctuary/expeditions/run?address&token_id&row_id` returns the full `ExpeditionRunView` (row + reducer state + definition). This is the DB-backed resume entry point — without it the only way back into an active run would be to call `/start`, which throws `ALREADY_ACTIVE`.
- `SanctuaryV2` + `SanctuaryV3` mount the same dialog so both engines surface the flow.

## Task acceptance criteria (from [SWO_V2_SANCTUARY_EXPEDITIONS_UI])
- [x] (a) Component vitest covers rendering of the current step
- [x] (b) Choice click POSTs `/api/sanctuary/expeditions/choose`
- [x] (c) Abandon CTA POSTs `/api/sanctuary/expeditions/abandon`
- [x] (d) Remount reads `current_step_id` via `/run` (verified the dialog calls `/run` and NOT `/start` when given `row_id`)
- [ ] **Playwright E2E walkthrough + reload mid-flight** — owed as a follow-up. Component-level vitest exercises the same contract against mocked endpoints, but a browser walkthrough is not in this PR.

## Dependency note
This branch contains PR2's commit (`feat(sanctuary): expeditions DB + API + seed catalog`) cherry-picked locally because PR2 (#328) was still OPEN at compose time. Once PR2 merges to `dev`, the diff will reduce to only PR3's seven files.

## Test plan
- [x] `npx vitest run components/sanctuary/overlays/__tests__/ExpeditionDialog.test.tsx` — 4/4 pass
- [x] `npx vitest run --project default` — 47 files, 886 tests pass
- [x] `npx eslint <changed-files>` — clean (0 warnings, 0 errors on PR3 files)
- [x] `npm run type-check` — 36 pre-existing errors in `game/scenes/*` and `game/v3/scenes/*`; zero new
- [ ] Browser walkthrough — see follow-up

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS (baseline 36 → post-overlay 36, zero new errors)
- **vitest run**: deferred (PROD vitest started but did not produce output within the budget — local `vitest run --project default` is green, 886/886)
- Overlay restored cleanly post-validation.

## PR class
**Class A** — full task completion for the component contract. The Playwright walkthrough remains as an explicit follow-up rather than blocking this PR; the same behavior is exercised by the component-level vitest against mocked endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)