### PR TITLE
feat(sanctuary): sleep dynamics — Tired gate + dream reward + early-wake (PR4/7)

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -21,6 +21,13 @@ import {
   toSqlDate,
   type CompanionStatAction,
 } from './sanctuary/companionStats';
+import {
+  applyTiredBondMultiplier,
+  classifySleepTransition,
+  computeDreamReward,
+  computeEarlyWakeOutcome,
+  isCompanionTired,
+} from './sanctuary/sleepDynamics';
 import { decayStats, computeNeeds, type DecayedStats } from './sanctuary/decay';
 import { journalLineForAction } from './sanctuary/companionGreeting';
 import {
@@ -5763,6 +5770,9 @@ export interface SanctuaryCompanion {
   // wall-clock decay. `decayStats(companion, now)` projects forward from
   // this timestamp; `tickStats` writes the projection back and bumps it.
   stats_updated_at: string | null;
+  // [SWO_V2_SANCTUARY_SLEEP_DYNAMICS] — last full sleep cycle completion.
+  // 24h+ without a full cycle marks the companion `Tired` (half bond gains).
+  last_full_sleep_at: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -5902,6 +5912,13 @@ function initializeSanctuary(database: Database.Database): void {
   try {
     database.exec('ALTER TABLE sanctuary_companions ADD COLUMN stats_updated_at DATETIME');
     database.exec('UPDATE sanctuary_companions SET stats_updated_at = CURRENT_TIMESTAMP WHERE stats_updated_at IS NULL');
+  } catch { /* column already exists */ }
+  // [SWO_V2_SANCTUARY_SLEEP_DYNAMICS]: track last full sleep cycle for Tired gate.
+  // Backfilled to created_at so existing companions are not retroactively Tired
+  // (they get their first 24h window from the moment we deploy this column).
+  try {
+    database.exec('ALTER TABLE sanctuary_companions ADD COLUMN last_full_sleep_at DATETIME');
+    database.exec('UPDATE sanctuary_companions SET last_full_sleep_at = COALESCE(created_at, CURRENT_TIMESTAMP) WHERE last_full_sleep_at IS NULL');
   } catch { /* column already exists */ }
   const rateLimitPath = path.join(process.cwd(), 'scripts', 'init-sanctuary-rate-limits.sql');
   if (fs.existsSync(rateLimitPath)) {
@@ -6195,12 +6212,34 @@ export function interactWithCompanion(
     );
 
     const starBonus = options?.isStar ?? false;
-    const bondGain = INTERACTION_BOND[action] * (starBonus ? STAR_HOLDER_BOND_MULTIPLIER : 1);
+    const baseBond = INTERACTION_BOND[action] * (starBonus ? STAR_HOLDER_BOND_MULTIPLIER : 1);
+    // [SWO_V2_SANCTUARY_SLEEP_DYNAMICS] — Tired halves non-sleep bond gains.
+    const tired = isCompanionTired(comp.last_full_sleep_at, now);
+    let bondGain = applyTiredBondMultiplier(baseBond, action, tired);
     const xpGain = Math.round(INTERACTION_XP[action] * (starBonus ? STAR_HOLDER_XP_MULTIPLIER : 1));
+
+    // Classify the sleep-state delta this action produced and apply the
+    // dream-reward / early-wake economy on top of the baseline bond gain.
+    const transition = classifySleepTransition({
+      wasSleeping: comp.is_sleeping === 1,
+      nowSleeping: stats.is_sleeping === 1,
+      action,
+    });
+    let dreamStarGained = 0;
+    let nextLastFullSleep: string | null = comp.last_full_sleep_at ?? null;
+    if (transition === 'full_cycle') {
+      const reward = computeDreamReward({ starBonus });
+      bondGain += reward.bond;
+      dreamStarGained = reward.star;
+      nextLastFullSleep = toSqlDate(now);
+    } else if (transition === 'early_wake') {
+      const outcome = computeEarlyWakeOutcome();
+      bondGain += outcome.bondDelta;
+    }
 
     db.prepare(`
       UPDATE sanctuary_companions
-      SET bond_score = MIN(bond_score + ?, 100.0),
+      SET bond_score = MAX(MIN(bond_score + ?, 100.0), 0.0),
           total_interactions = total_interactions + 1,
           hunger = ?,
           happiness = ?,
@@ -6208,6 +6247,7 @@ export function interactWithCompanion(
           is_sleeping = ?,
           sleep_started_at = ?,
           stats_updated_at = ?,
+          last_full_sleep_at = ?,
           updated_at = CURRENT_TIMESTAMP
       WHERE id = ?
     `).run(
@@ -6218,10 +6258,18 @@ export function interactWithCompanion(
       stats.is_sleeping,
       stats.sleep_started_at,
       toSqlDate(now),
+      nextLastFullSleep,
       comp.id,
     );
 
     if (xpGain > 0) addUserXP(addr, xpGain);
+
+    // Dream reward STAR mints inside the same txn — the savepoint nesting in
+    // better-sqlite3 keeps the journal entry, bond bump, and STAR ledger row
+    // atomic with the interaction.
+    if (transition === 'full_cycle' && dreamStarGained > 0) {
+      earnStar(addr, 'dream', dreamStarGained, `token:${tokenId}`);
+    }
 
     const bonusTag = starBonus ? ' (Star Bonus!)' : '';
     // Seed the variety pool with the action itself — the live trait-mood is
@@ -6233,7 +6281,25 @@ export function interactWithCompanion(
         action, bond: bondGain, xp: xpGain, starBonus,
         hunger: stats.hunger, happiness: stats.happiness, energy: stats.energy,
         is_sleeping: stats.is_sleeping, woke_up: stats.woke_up,
+        tired, sleep_transition: transition,
       }));
+
+    // [SWO_V2_SANCTUARY_SLEEP_DYNAMICS] — annotate the journal with a
+    // dedicated entry for dream rewards / early-wake penalties so the UI
+    // surface (and Acceptance #2/#3) can render them distinctly.
+    if (transition === 'full_cycle') {
+      addJournalEntry(
+        addr, tokenId, 'sleep_dynamics',
+        `Drifted through a full dream cycle — felt rested and recharged. +${dreamStarGained} STAR, +1 Bond.`,
+        JSON.stringify({ transition, star: dreamStarGained, bond: 1 }),
+      );
+    } else if (transition === 'early_wake') {
+      addJournalEntry(
+        addr, tokenId, 'sleep_dynamics',
+        'Roused mid-dream. They blinked, a little wobbly, and the bond felt thinner. −2 Bond.',
+        JSON.stringify({ transition, bondDelta: -2 }),
+      );
+    }
 
     const updated = db.prepare('SELECT * FROM sanctuary_companions WHERE id = ?')
       .get(comp.id) as SanctuaryCompanion;
@@ -7945,7 +8011,8 @@ export type StarEarnSource =
   | 'minigame_first'
   | 'daily_login'
   | 'activity'
-  | 'levelup';
+  | 'levelup'
+  | 'dream';
 
 // Earn-rate guardrails. Earn endpoint clamps the requested amount into the
 // `[min, max]` band for its source so a single misbehaving caller cannot
@@ -7956,6 +8023,9 @@ export const STAR_EARN_RATES: Record<StarEarnSource, { min: number; max: number 
   daily_login: { min: 5, max: 5 },
   activity: { min: 5, max: 20 },
   levelup: { min: 50, max: 50 },
+  // [SWO_V2_SANCTUARY_SLEEP_DYNAMICS] — non-zero floor for the dream reward.
+  // Baseline 1 STAR; Star-holder boost may request up to 3.
+  dream: { min: 1, max: 3 },
 };
 
 export function getStarBalance(walletAddress: string): SanctuaryStarBalance {

--- a/lib/sanctuary/__tests__/companionAction.test.ts
+++ b/lib/sanctuary/__tests__/companionAction.test.ts
@@ -210,6 +210,28 @@ describe('previewBondDelta', () => {
     const boosted = previewBondDelta({ baseline: 0.5, preference: 'loved', needBoosted: true });
     expect(boosted).toBeGreaterThan(flat);
   });
+
+  it('Tired halves non-sleep bond preview (matches server-side gate)', () => {
+    const fresh = previewBondDelta({ baseline: 0.5, preference: 'neutral', action: 'feed' });
+    const tired = previewBondDelta({
+      baseline: 0.5,
+      preference: 'neutral',
+      action: 'feed',
+      isTired: true,
+    });
+    expect(tired).toBeCloseTo(fresh * 0.5);
+  });
+
+  it('Tired does NOT halve the sleep action (matches sleepDynamics gate)', () => {
+    const fresh = previewBondDelta({ baseline: 0.5, preference: 'neutral', action: 'sleep' });
+    const tired = previewBondDelta({
+      baseline: 0.5,
+      preference: 'neutral',
+      action: 'sleep',
+      isTired: true,
+    });
+    expect(tired).toBe(fresh);
+  });
 });
 
 describe('resolveCompanionActionState — error path', () => {

--- a/lib/sanctuary/__tests__/sleepDynamics.test.ts
+++ b/lib/sanctuary/__tests__/sleepDynamics.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isCompanionTired,
+  applyTiredBondMultiplier,
+  classifySleepTransition,
+  computeDreamReward,
+  computeEarlyWakeOutcome,
+  TIRED_THRESHOLD_HOURS,
+  TIRED_BOND_MULTIPLIER,
+  DREAM_REWARD_STAR_FLOOR,
+  DREAM_REWARD_BOND_FLOOR,
+  EARLY_WAKE_BOND_PENALTY,
+  DREAM_JOURNAL_MESSAGE,
+  EARLY_WAKE_JOURNAL_MESSAGE,
+} from '../sleepDynamics';
+
+const NOW = new Date('2026-05-20T12:00:00Z');
+
+function hoursAgoSql(h: number, base: Date = NOW): string {
+  const d = new Date(base.getTime() - h * 3_600_000);
+  return d.toISOString().replace('T', ' ').slice(0, 19);
+}
+
+describe('isCompanionTired — Tired gate after 24h no sleep', () => {
+  it('returns false when last full sleep is < 24h ago', () => {
+    expect(isCompanionTired(hoursAgoSql(23), NOW)).toBe(false);
+  });
+
+  it('returns true when last full sleep is ≥ 24h ago (Acceptance #1)', () => {
+    expect(isCompanionTired(hoursAgoSql(24), NOW)).toBe(true);
+    expect(isCompanionTired(hoursAgoSql(48), NOW)).toBe(true);
+  });
+
+  it('returns false when last_full_sleep_at is null (fresh companion)', () => {
+    expect(isCompanionTired(null, NOW)).toBe(false);
+  });
+
+  it('returns false for unparseable timestamps', () => {
+    expect(isCompanionTired('not-a-date', NOW)).toBe(false);
+  });
+
+  it('boundary exactly at 24h is Tired (inclusive)', () => {
+    expect(isCompanionTired(hoursAgoSql(TIRED_THRESHOLD_HOURS), NOW)).toBe(true);
+  });
+});
+
+describe('applyTiredBondMultiplier — Tired halves non-sleep bond', () => {
+  it('halves bond for feed/pet/talk/play when Tired', () => {
+    expect(applyTiredBondMultiplier(1.0, 'feed', true)).toBe(0.5);
+    expect(applyTiredBondMultiplier(0.4, 'pet', true)).toBeCloseTo(0.2);
+    expect(applyTiredBondMultiplier(0.3, 'talk', true)).toBeCloseTo(0.15);
+    expect(applyTiredBondMultiplier(0.5, 'play', true)).toBe(0.25);
+  });
+
+  it('does not halve sleep action (already trying to rest)', () => {
+    expect(applyTiredBondMultiplier(1.0, 'sleep', true)).toBe(1.0);
+  });
+
+  it('returns bond unchanged when not Tired', () => {
+    expect(applyTiredBondMultiplier(1.0, 'feed', false)).toBe(1.0);
+    expect(applyTiredBondMultiplier(0.3, 'talk', false)).toBe(0.3);
+  });
+
+  it('multiplier matches the published constant', () => {
+    expect(TIRED_BOND_MULTIPLIER).toBe(0.5);
+  });
+});
+
+describe('classifySleepTransition', () => {
+  it('classifies awake → sleeping as started_sleep', () => {
+    expect(classifySleepTransition({ wasSleeping: false, nowSleeping: true, action: 'sleep' }))
+      .toBe('started_sleep');
+  });
+
+  it('classifies sleeping → awake on sleep action as full_cycle', () => {
+    expect(classifySleepTransition({ wasSleeping: true, nowSleeping: false, action: 'sleep' }))
+      .toBe('full_cycle');
+  });
+
+  it('classifies sleeping → awake on non-sleep action as early_wake', () => {
+    expect(classifySleepTransition({ wasSleeping: true, nowSleeping: false, action: 'feed' }))
+      .toBe('early_wake');
+    expect(classifySleepTransition({ wasSleeping: true, nowSleeping: false, action: 'pet' }))
+      .toBe('early_wake');
+    expect(classifySleepTransition({ wasSleeping: true, nowSleeping: false, action: 'play' }))
+      .toBe('early_wake');
+  });
+
+  it('classifies sleeping → sleeping as still_sleeping', () => {
+    expect(classifySleepTransition({ wasSleeping: true, nowSleeping: true, action: 'sleep' }))
+      .toBe('still_sleeping');
+  });
+
+  it('classifies awake → awake as no_change', () => {
+    expect(classifySleepTransition({ wasSleeping: false, nowSleeping: false, action: 'feed' }))
+      .toBe('no_change');
+  });
+});
+
+describe('computeDreamReward — full cycle floor (Acceptance #2)', () => {
+  it('grants the ≥ 1 STAR + 1 bond floor for the baseline case', () => {
+    const reward = computeDreamReward();
+    expect(reward.star).toBeGreaterThanOrEqual(DREAM_REWARD_STAR_FLOOR);
+    expect(reward.bond).toBeGreaterThanOrEqual(DREAM_REWARD_BOND_FLOOR);
+    expect(reward.star).toBe(1);
+    expect(reward.bond).toBe(1);
+    expect(reward.journalMessage).toBe(DREAM_JOURNAL_MESSAGE);
+  });
+
+  it('boosts above the floor for Star-holder bonus', () => {
+    const boosted = computeDreamReward({ starBonus: true });
+    expect(boosted.star).toBeGreaterThan(DREAM_REWARD_STAR_FLOOR);
+    expect(boosted.bond).toBeGreaterThan(DREAM_REWARD_BOND_FLOOR);
+  });
+
+  it('the floor itself is non-zero', () => {
+    expect(DREAM_REWARD_STAR_FLOOR).toBeGreaterThan(0);
+    expect(DREAM_REWARD_BOND_FLOOR).toBeGreaterThan(0);
+  });
+});
+
+describe('computeEarlyWakeOutcome — fires −2 bond + journal (Acceptance #3)', () => {
+  it('returns the −2 bond delta', () => {
+    const outcome = computeEarlyWakeOutcome();
+    expect(outcome.bondDelta).toBe(EARLY_WAKE_BOND_PENALTY);
+    expect(outcome.bondDelta).toBe(-2);
+  });
+
+  it('returns a non-empty journal entry message', () => {
+    const outcome = computeEarlyWakeOutcome();
+    expect(outcome.journalMessage).toBe(EARLY_WAKE_JOURNAL_MESSAGE);
+    expect(outcome.journalMessage.length).toBeGreaterThan(0);
+  });
+});
+
+describe('end-to-end scenario — Tired → full cycle clears Tired', () => {
+  it('Tired companion completes full cycle → reward fires + new last_full_sleep_at clears Tired', () => {
+    const oldSleep = hoursAgoSql(30);
+    expect(isCompanionTired(oldSleep, NOW)).toBe(true);
+
+    // After a full cycle, route handler stamps last_full_sleep_at = now.
+    const justWoke = hoursAgoSql(0, NOW);
+    expect(isCompanionTired(justWoke, NOW)).toBe(false);
+
+    const reward = computeDreamReward();
+    expect(reward.star + reward.bond).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/lib/sanctuary/companionAction.ts
+++ b/lib/sanctuary/companionAction.ts
@@ -8,6 +8,7 @@ import {
   NEED_BOOST_MULTIPLIER,
   type PreferenceLevel,
 } from './preferences';
+import { TIRED_BOND_MULTIPLIER } from './sleepDynamics';
 
 export type CompanionActionId = 'feed' | 'pet' | 'talk' | 'sleep' | 'play';
 
@@ -182,21 +183,28 @@ export function companionActionPreferenceBadge(
 }
 
 /**
- * [SWO_V2_SANCTUARY_PREFERENCE_PROFILE]
+ * [SWO_V2_SANCTUARY_PREFERENCE_PROFILE] + [SWO_V2_SANCTUARY_SLEEP_DYNAMICS]
  *
  * Compute the bond-delta preview the UI shows when hovering an action
- * tile. Combines the action's baseline bond gain with the preference and
- * need-state multipliers. Returns a number — formatting (sign, rounding) is
- * left to the consuming component.
+ * tile. Combines the action's baseline bond gain with the preference,
+ * need-state, and Tired multipliers. The Tired multiplier matches the
+ * server-side bond computation in `interactWithCompanion` so the previewed
+ * number tracks what the user will actually receive. Returns a number —
+ * formatting (sign, rounding) is left to the consuming component.
  */
 export function previewBondDelta(input: {
   baseline: number;
   preference: PreferenceLevel;
   needBoosted?: boolean;
+  isTired?: boolean;
+  action?: CompanionActionId;
 }): number {
   const prefMult = PREFERENCE_BOND_MULTIPLIER[input.preference];
   const needMult = input.needBoosted ? NEED_BOOST_MULTIPLIER : 1;
-  return input.baseline * prefMult * needMult;
+  // Sleep action is never penalised by Tired (mirrors sleepDynamics.ts).
+  const tiredMult =
+    input.isTired && input.action !== 'sleep' ? TIRED_BOND_MULTIPLIER : 1;
+  return input.baseline * prefMult * needMult * tiredMult;
 }
 
 /** Round a cooldown to a compact label like "12s" / "1m" / "1h". */

--- a/lib/sanctuary/sleepDynamics.ts
+++ b/lib/sanctuary/sleepDynamics.ts
@@ -1,0 +1,135 @@
+/**
+ * [SWO_V2_SANCTUARY_SLEEP_DYNAMICS] — sleep that matters (PR4 of 7).
+ *
+ * Pure helpers for the sleep-cycle economy. Three behaviours:
+ *
+ *   1. **Tired gate.** A companion that has not had a full sleep cycle in
+ *      the last 24h becomes `Tired`. While Tired, all non-sleep bond gains
+ *      are halved.
+ *   2. **Dream reward.** Completing a full sleep cycle (sleep action ends
+ *      with auto-wake at SLEEP_AUTO_WAKE_THRESHOLD) clears Tired and grants
+ *      a non-zero floor of ≥ 1 STAR + 1 bond.
+ *   3. **Early-wake penalty.** Interrupting a sleeping companion with any
+ *      non-sleep action (which forces them awake once energy ≥ block
+ *      threshold) costs −2 bond and writes a journal entry.
+ *
+ * No DB / Phaser / React imports — keeps the module trivially unit-testable
+ * and reusable by the API handler, the UI preview, and the future sleep
+ * endpoint.
+ */
+import type { CompanionStatAction } from './companionStats';
+import { parseSqlDateMs } from './companionStats';
+
+/** Hours awake (no full sleep) before the companion becomes Tired. */
+export const TIRED_THRESHOLD_HOURS = 24;
+/** Multiplier applied to non-sleep bond gains while Tired. */
+export const TIRED_BOND_MULTIPLIER = 0.5;
+/** Non-zero floor for the dream reward (per §3.2 of the V2 plan). */
+export const DREAM_REWARD_STAR_FLOOR = 1;
+export const DREAM_REWARD_BOND_FLOOR = 1;
+/** Bond delta when a non-sleep action wakes a sleeping companion. */
+export const EARLY_WAKE_BOND_PENALTY = -2;
+
+export const TIRED_JOURNAL_TAG = 'sleep_dynamics';
+export const DREAM_JOURNAL_MESSAGE =
+  'Drifted through a full dream cycle — felt rested and recharged.';
+export const EARLY_WAKE_JOURNAL_MESSAGE =
+  'Roused mid-dream. They blinked, a little wobbly, and the bond felt thinner.';
+
+/**
+ * True when ≥ 24h have elapsed since the companion's last full sleep cycle.
+ * A null timestamp (legacy companion or never-slept) returns `false` — the
+ * caller should backfill `last_full_sleep_at` to a sensible default before
+ * relying on this gate.
+ */
+export function isCompanionTired(
+  lastFullSleepAt: string | null,
+  now: Date,
+): boolean {
+  if (!lastFullSleepAt) return false;
+  const startedMs = parseSqlDateMs(lastFullSleepAt);
+  if (startedMs === null) return false;
+  const elapsedHours = (now.getTime() - startedMs) / 3_600_000;
+  return elapsedHours >= TIRED_THRESHOLD_HOURS;
+}
+
+/**
+ * Apply the Tired multiplier to a raw bond gain. Sleep actions are never
+ * penalised (the user is already trying to rest the companion). Returns
+ * the original gain when not Tired.
+ */
+export function applyTiredBondMultiplier(
+  bondGain: number,
+  action: CompanionStatAction,
+  isTired: boolean,
+): number {
+  if (!isTired || action === 'sleep') return bondGain;
+  return bondGain * TIRED_BOND_MULTIPLIER;
+}
+
+export type SleepTransition =
+  | 'started_sleep'
+  | 'full_cycle'
+  | 'early_wake'
+  | 'still_sleeping'
+  | 'no_change';
+
+/**
+ * Classify what happened to the sleep state across an interaction. Encodes
+ * the contract emitted by `applyInteractionStats` in companionStats.ts:
+ *
+ *   - awake → sleeping     : `started_sleep`
+ *   - sleeping → awake (sleep action, energy hit auto-wake threshold)
+ *                          : `full_cycle`
+ *   - sleeping → awake (non-sleep action, energy passed block threshold)
+ *                          : `early_wake`
+ *   - sleeping → sleeping  : `still_sleeping` (refreshed energy, did not max)
+ *   - awake → awake        : `no_change`
+ */
+export function classifySleepTransition(input: {
+  wasSleeping: boolean;
+  nowSleeping: boolean;
+  action: CompanionStatAction;
+}): SleepTransition {
+  if (!input.wasSleeping && input.nowSleeping) return 'started_sleep';
+  if (input.wasSleeping && !input.nowSleeping) {
+    return input.action === 'sleep' ? 'full_cycle' : 'early_wake';
+  }
+  if (input.wasSleeping && input.nowSleeping) return 'still_sleeping';
+  return 'no_change';
+}
+
+export interface DreamReward {
+  star: number;
+  bond: number;
+  journalMessage: string;
+}
+
+/**
+ * Guaranteed non-zero dream payout: 1 STAR + 1 bond floor. The caller may
+ * boost above the floor (e.g. for Star-holder companions), but never below.
+ */
+export function computeDreamReward(boost: { starBonus?: boolean } = {}): DreamReward {
+  return {
+    star: DREAM_REWARD_STAR_FLOOR + (boost.starBonus ? 1 : 0),
+    bond: DREAM_REWARD_BOND_FLOOR + (boost.starBonus ? 0.5 : 0),
+    journalMessage: DREAM_JOURNAL_MESSAGE,
+  };
+}
+
+export interface EarlyWakeOutcome {
+  bondDelta: number;
+  journalMessage: string;
+}
+
+/**
+ * Outcome applied when a non-sleep action forces a sleeping companion
+ * awake. Fixed −2 bond + a journal line; the route handler is responsible
+ * for persisting both.
+ */
+export function computeEarlyWakeOutcome(): EarlyWakeOutcome {
+  return {
+    bondDelta: EARLY_WAKE_BOND_PENALTY,
+    journalMessage: EARLY_WAKE_JOURNAL_MESSAGE,
+  };
+}


### PR DESCRIPTION
## Summary
Implements [SWO_V2_SANCTUARY_SLEEP_DYNAMICS] (PR4 of 7) per §3.2 of the V2 plan:
- **Tired gate** — 24h+ without a full sleep cycle marks the companion `Tired`. While Tired, all non-sleep bond gains are halved (sleep is exempt).
- **Dream reward** — A full sleep cycle (auto-wake at `SLEEP_AUTO_WAKE_THRESHOLD` on the `sleep` action) clears Tired and grants a non-zero floor of **≥ 1 STAR + 1 bond** plus a dedicated `sleep_dynamics` journal entry.
- **Early-wake penalty** — Interrupting a sleeping companion with any non-sleep action (which forces them awake once energy ≥ block threshold) costs **−2 bond** and writes a dedicated journal entry.

## Implementation
- **`lib/sanctuary/sleepDynamics.ts`** (new, pure) — `isCompanionTired`, `applyTiredBondMultiplier`, `classifySleepTransition`, `computeDreamReward`, `computeEarlyWakeOutcome`. No DB / React / Phaser imports.
- **`lib/db.ts`** — `interactWithCompanion` reads `last_full_sleep_at`, applies the Tired multiplier, classifies the sleep transition, mints the dream STAR via a new `'dream'` `StarEarnSource` (min:1, max:3), writes the sleep_dynamics journal entries, and clamps `bond_score ≥ 0` so the −2 early-wake delta can't drive it negative on the persisted row.
- **Migration** — `ALTER TABLE sanctuary_companions ADD COLUMN last_full_sleep_at DATETIME`, backfilled to `created_at` so existing companions aren't retroactively Tired.
- **`lib/sanctuary/companionAction.ts`** — `previewBondDelta` now factors `isTired` + `action` so the UI hover preview tracks what the server actually awards.

## Tests
- **`lib/sanctuary/__tests__/sleepDynamics.test.ts`** — 20 vitest cases covering the three acceptance criteria directly:
  1. **Tired gate after 24h no sleep** — `isCompanionTired` returns true at 24h boundary, false at 23h, false for null/legacy companions.
  2. **Full cycle clears Tired + grants ≥ floor** — `computeDreamReward` guarantees `star ≥ 1 && bond ≥ 1`; the end-to-end scenario verifies a 30h-old `last_full_sleep_at` reports Tired before, and a freshly-stamped one does not.
  3. **Early-wake fires −2 + journal** — `computeEarlyWakeOutcome` returns exactly `{ bondDelta: -2, journalMessage: non-empty }`.
- **`companionAction.test.ts`** — 2 new cases covering the Tired-aware preview path + the sleep-action exemption.
- Full sanctuary scope: **68 tests pass**.

## Test plan
- [x] `npx vitest run lib/sanctuary/__tests__/sleepDynamics.test.ts` — 20/20 pass
- [x] `npx vitest run lib/sanctuary/__tests__/companionAction.test.ts` — 20/20 pass (existing 18 + 2 new)
- [x] `npx vitest run lib/sanctuary/__tests__/companionStats.test.ts` — 28/28 pass (regression for sleep-state contract)
- [x] `npm run type-check` — no new errors from this diff (pre-existing `game/scenes/*` errors only)
- [x] `npx eslint` on touched files — no new errors (pre-existing warnings only)

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS (36 pre-existing errors excluded — note: 2 of the 36 are PROD-only `expeditionDefs` import errors because PR2/PR3 haven't been promoted to the PROD mirror yet; overlaying those PR2/PR3 files alongside this diff restores the count to baseline 36)
- **vitest run** (sleepDynamics + companionAction): PASS — 40/40
- Overall: PASS

## Follow-ups
- **Playwright E2E** — the task brief calls for an E2E spec covering the three cases via a test-only time-skip helper. The sanctuary surface currently has no Playwright project in `playwright.config.ts` (only the casino-connected project exists). Tracked as the next PR: add a `sanctuary-connected` project + a test-only `?__test_now=` query-param hook on `/api/sanctuary/companion/interact` so the spec can simulate the 24h time skip end-to-end. The pure-helper unit tests above fully cover the deterministic logic in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)