### PR TITLE
feat(casino): useRecentBets hook bridging indexer GraphQL → RecentBets

### DIFF
--- a/lib/casino/__tests__/useRecentBets.test.tsx
+++ b/lib/casino/__tests__/useRecentBets.test.tsx
@@ -1,0 +1,228 @@
+// @vitest-environment happy-dom
+//
+// useRecentBets — acceptance contract for the indexer↔RecentBets wiring
+// from [SWO_CASINO_INDEXER_PORT] bullet (d). The hook is the canonical
+// consumer that turns a Ponder GraphQL endpoint + player address into
+// the `WalletBet[]` shape `components/casino/RecentBets` renders.
+
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  vi,
+} from 'vitest';
+import { act, useEffect } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { useRecentBets, type UseRecentBetsState } from '../useRecentBets';
+
+(
+  globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const ALICE = '0x000000000000000000000000000000000000a11c';
+
+let container: HTMLDivElement;
+let root: Root;
+const sink: { value: UseRecentBetsState | null } = { value: null };
+
+function Probe(props: {
+  endpoint?: string;
+  player?: string;
+  limit?: number;
+  fetchImpl?: typeof fetch;
+}) {
+  const state = useRecentBets(props);
+  useEffect(() => {
+    sink.value = state;
+  }, [state]);
+  return null;
+}
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function flush(): Promise<void> {
+  return act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+beforeEach(() => {
+  sink.value = null;
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+describe('useRecentBets', () => {
+  it('returns empty + idle when endpoint or player is missing', async () => {
+    await act(async () => {
+      root.render(<Probe />);
+    });
+    expect(sink.value?.bets).toEqual([]);
+    expect(sink.value?.loading).toBe(false);
+    expect(sink.value?.error).toBeNull();
+  });
+
+  it('fetches rows and maps them to the WalletBet shape', async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse({
+        data: {
+          bets: {
+            items: [
+              {
+                id: '1',
+                player: ALICE,
+                status: 'won',
+                stake: '1000',
+                payout: '2000',
+                blockPlaced: '100',
+                settledAt: '101',
+              },
+            ],
+          },
+          diceBets: { items: [] },
+          hiloSessions: {
+            items: [
+              {
+                id: '9',
+                player: ALICE,
+                status: 'cashed',
+                stake: '500',
+                payout: '1500',
+                blockOpened: '300',
+                settledAt: '301',
+              },
+            ],
+          },
+        },
+      }),
+    );
+
+    await act(async () => {
+      root.render(
+        <Probe
+          endpoint="https://indexer.example/graphql"
+          player={ALICE}
+          fetchImpl={fetchImpl as unknown as typeof fetch}
+        />,
+      );
+    });
+    await flush();
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(sink.value?.loading).toBe(false);
+    expect(sink.value?.error).toBeNull();
+    expect(sink.value?.bets.map((b) => b.game)).toEqual(['hilo', 'coinflip']);
+    expect(sink.value?.bets[0]).toMatchObject({
+      game: 'hilo',
+      betId: '9',
+      stakeWei: '500',
+      payoutWei: '1500',
+      outcome: 'cashed',
+      blockNumber: '300',
+    });
+  });
+
+  it('reports loading=true before the fetch resolves', async () => {
+    let resolveFetch: ((res: Response) => void) | null = null;
+    const fetchImpl = vi.fn(
+      () =>
+        new Promise<Response>((res) => {
+          resolveFetch = res;
+        }),
+    );
+    await act(async () => {
+      root.render(
+        <Probe
+          endpoint="https://indexer.example/graphql"
+          player={ALICE}
+          fetchImpl={fetchImpl as unknown as typeof fetch}
+        />,
+      );
+    });
+    // Effect has scheduled the fetch but it has not resolved yet.
+    expect(sink.value?.loading).toBe(true);
+    expect(sink.value?.bets).toEqual([]);
+    expect(sink.value?.error).toBeNull();
+    // Resolve so the effect cleanup doesn't leave a dangling promise.
+    await act(async () => {
+      resolveFetch?.(
+        jsonResponse({
+          data: {
+            bets: { items: [] },
+            diceBets: { items: [] },
+            hiloSessions: { items: [] },
+          },
+        }),
+      );
+      await Promise.resolve();
+    });
+    await flush();
+    expect(sink.value?.loading).toBe(false);
+  });
+
+  it('captures fetch errors without unmounting', async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response('boom', { status: 502, statusText: 'Bad Gateway' }),
+    );
+    await act(async () => {
+      root.render(
+        <Probe
+          endpoint="https://indexer.example/graphql"
+          player={ALICE}
+          fetchImpl={fetchImpl as unknown as typeof fetch}
+        />,
+      );
+    });
+    await flush();
+    expect(sink.value?.loading).toBe(false);
+    expect(sink.value?.error?.message).toMatch(/502/);
+    expect(sink.value?.bets).toEqual([]);
+  });
+
+  it('passes the player lowercased and the configured limit downstream', async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse({
+        data: {
+          bets: { items: [] },
+          diceBets: { items: [] },
+          hiloSessions: { items: [] },
+        },
+      }),
+    );
+    const MIXED = '0xAbCdEf0000000000000000000000000000000A11C';
+    await act(async () => {
+      root.render(
+        <Probe
+          endpoint="https://indexer.example/graphql"
+          player={MIXED}
+          limit={5}
+          fetchImpl={fetchImpl as unknown as typeof fetch}
+        />,
+      );
+    });
+    await flush();
+    const call = fetchImpl.mock.calls[0] as unknown as
+      | [string, RequestInit]
+      | undefined;
+    const body = JSON.parse(String(call?.[1]?.body));
+    expect(body.variables).toEqual({ player: MIXED.toLowerCase(), limit: 5 });
+  });
+});

--- a/lib/casino/useRecentBets.ts
+++ b/lib/casino/useRecentBets.ts
@@ -1,0 +1,118 @@
+// useRecentBets — React hook that drives `components/casino/RecentBets`
+// from the SWO casino-indexer GraphQL endpoint.
+//
+// Closes acceptance bullet (d) of [SWO_CASINO_INDEXER_PORT]: the
+// `RecentBets` component itself stays pure (parent-fed `bets` prop), and
+// this hook is the canonical consumer that turns an indexer endpoint +
+// player address into the `WalletBet[]` shape it already renders.
+//
+// Wiring contract:
+//   - `endpoint`  Ponder GraphQL URL. When undefined/empty the hook
+//                 short-circuits to an empty `bets` array — the wallet
+//                 sheet still renders the empty-state pill instead of
+//                 throwing during the pre-indexer window.
+//   - `player`    The wallet address (any case — lowercased before
+//                 hitting the indexer). Undefined → empty bets.
+//   - `limit`     Max rows to render (default 24).
+//   - `fetchImpl` Injectable for tests; defaults to `globalThis.fetch`.
+//
+// Returns `{ bets, loading, error }`. The fetch is aborted on unmount
+// or when any input changes so React 18 strict-mode double-mount does
+// not fire two concurrent requests. `loading` is derived from the
+// relationship between the current request key and the key of the most
+// recent resolved result — this keeps all `setState` calls inside async
+// callbacks rather than synchronously in the effect body.
+
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import type { WalletBet } from '@/components/casino/RecentBets';
+
+import {
+  fetchRecentBets,
+  mapRecentBetsToWallet,
+} from './recentBetsIndexer';
+
+export interface UseRecentBetsOptions {
+  endpoint?: string;
+  player?: string;
+  limit?: number;
+  fetchImpl?: typeof fetch;
+}
+
+export interface UseRecentBetsState {
+  bets: WalletBet[];
+  loading: boolean;
+  error: Error | null;
+}
+
+const EMPTY: WalletBet[] = [];
+
+interface ResolvedResult {
+  key: string | null;
+  bets: WalletBet[];
+  error: Error | null;
+}
+
+function requestKey(
+  endpoint: string | undefined,
+  player: string | undefined,
+  limit: number,
+): string | null {
+  if (!endpoint || !player) return null;
+  return `${endpoint}|${player.toLowerCase()}|${limit}`;
+}
+
+export function useRecentBets(opts: UseRecentBetsOptions): UseRecentBetsState {
+  const { endpoint, player, limit = 24, fetchImpl } = opts;
+  const key = requestKey(endpoint, player, limit);
+
+  const [result, setResult] = useState<ResolvedResult>({
+    key: null,
+    bets: EMPTY,
+    error: null,
+  });
+
+  useEffect(() => {
+    if (!endpoint || !player || !key) return;
+    const controller = new AbortController();
+    let cancelled = false;
+    fetchRecentBets({
+      endpoint,
+      player,
+      limit,
+      fetchImpl,
+      signal: controller.signal,
+    })
+      .then((rows) => {
+        if (cancelled) return;
+        setResult({
+          key,
+          bets: mapRecentBetsToWallet(rows),
+          error: null,
+        });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        if (err instanceof DOMException && err.name === 'AbortError') return;
+        setResult({
+          key,
+          bets: EMPTY,
+          error: err instanceof Error ? err : new Error(String(err)),
+        });
+      });
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [endpoint, player, limit, fetchImpl, key]);
+
+  if (!key) {
+    return { bets: EMPTY, loading: false, error: null };
+  }
+  if (result.key !== key) {
+    return { bets: EMPTY, loading: true, error: null };
+  }
+  return { bets: result.bets, loading: false, error: result.error };
+}

--- a/services/casino-indexer/README.md
+++ b/services/casino-indexer/README.md
@@ -72,3 +72,9 @@ The `RecentBets` component in `components/casino/RecentBets.tsx` is the
 canonical consumer for the per-wallet ticker; the client adapter in
 `lib/casino/recentBetsIndexer.ts` queries the Ponder GraphQL endpoint and
 maps `RecentBet` rows into the `WalletBet` shape `RecentBets` accepts.
+
+For React callers, `lib/casino/useRecentBets.ts` is the canonical hook —
+pass `{ endpoint, player }` and feed the returned `bets` into
+`<RecentBets bets={...} />`. The hook short-circuits to an empty list
+when the endpoint or player is missing so the wallet sheet still renders
+the empty-state pill during the pre-indexer window.


### PR DESCRIPTION
## Summary
- Adds `lib/casino/useRecentBets.ts` — the canonical React hook that turns the SWO casino-indexer GraphQL endpoint + player address into the `WalletBet[]` shape `components/casino/RecentBets` renders.
- Closes acceptance bullet **(d)** of [SWO_CASINO_INDEXER_PORT]: `RecentBets` now has a one-line consumer path from the live indexer (`const { bets } = useRecentBets({ endpoint, player });`) while the component itself stays pure (parent-fed `bets` prop).
- 5 new vitest specs cover idle/missing-args, fetch+map happy path, `loading=true` pre-resolution, error capture, and lowercased-player + custom-limit wire-through.

## Why this scope
The other three bullets — (a) directory at `services/casino-indexer/` exists, (b) `ponder.config.ts` retargeted to Monad testnet 10143 with env-driven addresses, (c) vitest in `__tests__/` covers handlers — were landed in prior runs. The remaining gap was the consumer side: the `recentBetsIndexer.ts` GraphQL client existed but had no React-side wrapper, so no caller could plausibly thread the indexer through `RecentBets` without rewriting fetch/cancel/loading plumbing inline. The hook closes that gap with no churn to the existing component contract.

Implementation notes:
- `loading` is **derived** from the relationship between the current request key and the last-resolved result key, which keeps every `setState` call inside async callbacks (passes `react-hooks/set-state-in-effect`).
- The fetch is aborted on unmount or input change via `AbortController`, so React 18 strict-mode double-mount doesn't fire two concurrent requests.
- `fetchImpl` is injectable for tests; the hook defaults to `globalThis.fetch` in production.

## Validations
- `npx vitest run lib/casino/__tests__/useRecentBets.test.tsx` → 5/5 pass
- `npx vitest run --project casino` → 176/176 pass (no regressions)
- `npx vitest run services/casino-indexer/__tests__` → 24/24 pass
- `npx eslint lib/casino/useRecentBets.ts lib/casino/__tests__/useRecentBets.test.tsx` → clean
- `npm run type-check` → 36 pre-existing errors in `game/v3/scenes/WorldSceneV3.ts`, **zero new** errors in this PR

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS (baseline 36 errors, post-overlay 36 errors, zero new)
- **vitest run**: SKIPPED — mirror lacks `happy-dom` in node_modules; pre-existing `useAccessGate.test.tsx` also hangs there, so the failure is unrelated to this PR.
Overall: PASS (tsc baseline-diff clean)

## Test plan
- [ ] `npx vitest run --project casino` locally — should remain 176/176
- [ ] Spot-check `services/casino-indexer/README.md` "GraphQL consumers" section reads cleanly
- [ ] (Smoke, post-indexer-deploy) Mount `<RecentBets bets={useRecentBets({ endpoint, player }).bets} />` against a live Ponder endpoint and confirm rows render with correct game/outcome chips

🤖 Generated with [Claude Code](https://claude.com/claude-code)