### PR TITLE
test(casino): regression guard for 143.predicted.json [SWO_CASINO_MAINNET_ADDRESS_PREDICTION]

### DIFF
--- a/lib/casino/__tests__/predictedMainnet.test.ts
+++ b/lib/casino/__tests__/predictedMainnet.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Regression guard for the Monad-mainnet (143) CREATE3 prediction artifact.
+ *
+ * `contracts/casino/deployments/143.predicted.json` is the published prediction
+ * for the live mainnet addresses the operator WILL get when they broadcast
+ * `Deploy.s.sol` with the prod deployer + unchanged default salts.
+ *
+ * CREATE3 addresses depend only on `(deployer, salt)` and CreateX sits at the
+ * same address on every Monad chain, so the predicted mainnet addresses MUST
+ * be identical to the live testnet (10143) artifact. If they ever drift,
+ * something rotated without re-running the dry-run — this test trips before
+ * anyone can ship a stale prediction to docs or to mainnet.
+ *
+ * Also pins the deployer and salt format so anyone reaching for a new salt
+ * value has to update this test in lock-step.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import testnet from '../../../contracts/casino/deployments/10143.json';
+import predicted from '../../../contracts/casino/deployments/143.predicted.json';
+
+const PROD_DEPLOYER = '0xb29e6735629539cEd64F0d6f0c476Fe92539fD7B';
+const SALT_REGEX = /^0xb29e6735629539ced64f0d6f0c476fe92539fd7b00[0-9a-f]{22}$/;
+const ADDRESS_REGEX = /^0x[0-9a-fA-F]{40}$/;
+
+describe('143.predicted.json', () => {
+  it('is marked as a non-live prediction for chain 143', () => {
+    expect(predicted.status).toBe('predicted');
+    expect(predicted.chainId).toBe(143);
+  });
+
+  it('uses the production deployer', () => {
+    expect(predicted.deployer).toBe(PROD_DEPLOYER);
+    expect(testnet.deployer).toBe(PROD_DEPLOYER);
+  });
+
+  it('matches the testnet (10143) addresses byte-for-byte', () => {
+    expect(predicted.bankroll).toBe(testnet.bankroll);
+    expect(predicted.cosmicFlip).toBe(testnet.cosmicFlip);
+    expect(predicted.gravityDice).toBe(testnet.gravityDice);
+    expect(predicted.constellationClimb).toBe(testnet.constellationClimb);
+  });
+
+  it('matches the testnet salts byte-for-byte', () => {
+    expect(predicted.bankrollSalt).toBe(testnet.bankrollSalt);
+    expect(predicted.cosmicFlipSalt).toBe(testnet.cosmicFlipSalt);
+    expect(predicted.gravityDiceSalt).toBe(testnet.gravityDiceSalt);
+    expect(predicted.constellationClimbSalt).toBe(testnet.constellationClimbSalt);
+  });
+
+  it('encodes salts with the prod-deployer permissioned-deploy prefix', () => {
+    expect(predicted.bankrollSalt).toMatch(SALT_REGEX);
+    expect(predicted.cosmicFlipSalt).toMatch(SALT_REGEX);
+    expect(predicted.gravityDiceSalt).toMatch(SALT_REGEX);
+    expect(predicted.constellationClimbSalt).toMatch(SALT_REGEX);
+  });
+
+  it('publishes valid 20-byte addresses for every contract', () => {
+    expect(predicted.bankroll).toMatch(ADDRESS_REGEX);
+    expect(predicted.cosmicFlip).toMatch(ADDRESS_REGEX);
+    expect(predicted.gravityDice).toMatch(ADDRESS_REGEX);
+    expect(predicted.constellationClimb).toMatch(ADDRESS_REGEX);
+  });
+
+  it('references the canonical CreateX singleton', () => {
+    expect(predicted.createX).toBe('0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed');
+  });
+
+  it('assigns a distinct address to each contract', () => {
+    const addrs = [
+      predicted.bankroll,
+      predicted.cosmicFlip,
+      predicted.gravityDice,
+      predicted.constellationClimb,
+    ];
+    expect(new Set(addrs).size).toBe(addrs.length);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a vitest regression guard for `contracts/casino/deployments/143.predicted.json`, the published Monad-mainnet (143) CREATE3 prediction artifact shipped in #325.

CREATE3 addresses depend only on `(deployer, salt)` and CreateX (`0xba5Ed0…ba5Ed`) sits at the same address on both Monad chains, so the four predicted mainnet addresses MUST equal the live testnet (10143) addresses. If anyone rotates the deployer or salt entropy without re-running the dry-run, this test trips immediately — before the stale prediction can ship to docs, env, or mainnet broadcast.

## Original task

`[SWO_CASINO_MAINNET_ADDRESS_PREDICTION]` Run `forge script Deploy --rpc-url \$MONAD_MAINNET_RPC --sender 0xb29e6735629539cEd64F0d6f0c476Fe92539fD7B --skip-simulation` in dry-run mode and publish predicted mainnet (143) CREATE3 addresses. Acceptance: (a) `143.predicted.json` committed; (b) `DEPLOYED.md` mainnet rows updated; (c) "predicted = …" clarifying note.

## Blocker

The three acceptance criteria are already satisfied by merged PR #325 (commit 69619aa):
- `contracts/casino/deployments/143.predicted.json` ✓
- `contracts/DEPLOYED.md` mainnet table with `Predicted (pending operator deploy)` rows ✓
- "Predicted = the address mainnet WILL have if deployer + salts are unchanged" note ✓

I re-derived the addresses from the live RPC dry-run for verification — they match the committed artifact byte-for-byte. There is nothing to change in the prediction itself.

## Unblocks

The original ship had no automated guard pinning the predicted-mainnet artifact to the testnet truth. Without one, any future PR that rotates a `CASINO_*_SALT` default, swaps the deployer, or edits one file but not the other can silently break the prediction — and the next operator broadcasts to the wrong address. This PR (Class C) ships the smallest enabling change: a vitest that locks both files together.

## What this test asserts

1. `status` is `"predicted"`, `chainId` is `143`.
2. Both files use the production deployer `0xb29e…fD7B`.
3. Every address in `143.predicted.json` matches `10143.json` byte-for-byte (cross-chain CREATE3 invariant).
4. Every salt in `143.predicted.json` matches `10143.json` byte-for-byte.
5. Salt encoding matches the prod-deployer permissioned-deploy prefix regex.
6. Every contract has a distinct address.
7. CreateX singleton field equals the canonical `0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed`.

If a future PR rotates `CASINO_BANKROLL_SALT` (or any sibling default), the test fails — caller has to re-run `bash scripts/casino/predict_addresses.sh 143` and update both JSONs in lock-step.

## Verification

```
$ npx vitest run --project casino lib/casino/__tests__/predictedMainnet.test.ts
✓ 8 passed
```

## Next PR

None required for this task — acceptance was already met by #325; this PR locks it down. The next forward motion on the casino mainnet rollout is operator broadcast (G1 audit firm selection RFC in 4c8bd26, then live deploy).

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS (baseline=36 errors, post-overlay=36, zero new)
- **vitest run --project casino lib/casino/__tests__/predictedMainnet.test.ts**: PASS (8/8, 385ms)

Overall: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)