### PR TITLE
feat(casino): OFAC + 9-country geo blocklist guard for /casino/* [SWO_CASINO_GEO_BLOCKLIST]

### DIFF
--- a/app/region-not-supported/page.tsx
+++ b/app/region-not-supported/page.tsx
@@ -1,0 +1,25 @@
+// /region-not-supported — copy page rendered for blocked jurisdictions
+// when `SWO_CASINO_GEO_MODE=enforce`.
+//
+// `middleware.ts` rewrites blocked traffic to this path so the URL bar
+// stays meaningful even when the original request was for `/casino/dice`
+// or `/casino/coinflip`. The headers set by the middleware
+// (`x-swo-geo-blocked`, `x-swo-geo-country`) are forwarded straight
+// through and read here to render a country-specific notice when
+// available.
+
+import { headers } from 'next/headers';
+
+import { GeoBlockedNotice } from '@/components/casino/GeoBlockedNotice';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata = {
+  title: 'Region not supported | Star World Order',
+};
+
+export default async function RegionNotSupportedPage() {
+  const h = await headers();
+  const country = h.get('x-swo-geo-country');
+  return <GeoBlockedNotice country={country} />;
+}

--- a/components/casino/GeoBlockedNotice.tsx
+++ b/components/casino/GeoBlockedNotice.tsx
@@ -1,0 +1,91 @@
+// GeoBlockedNotice — placeholder rendered when the request carries the
+// `x-swo-geo-blocked` header (set by `middleware.ts` for blocklisted
+// countries while `SWO_CASINO_GEO_MODE=enforce`).
+//
+// UX rule: no game UI, no wallet modal, no CTA into a paid surface —
+// just a polite "this region is not yet supported" copy block and a
+// link back to the home page so the operator never has to 404 a
+// legitimate visitor who happens to be in the wrong country.
+
+import Link from 'next/link';
+
+export const GEO_BLOCKED_FLAG_HEADER = 'x-swo-geo-blocked';
+
+export interface GeoBlockedNoticeProps {
+  /** ISO 3166-1 alpha-2 code surfaced by the edge — purely informational. */
+  country?: string | null;
+}
+
+export function GeoBlockedNotice({ country }: GeoBlockedNoticeProps) {
+  return (
+    <main style={pageStyle} data-testid="geo-blocked-notice">
+      <header style={headerStyle}>
+        <h1 style={titleStyle}>This region isn&apos;t supported yet</h1>
+        <p style={copyStyle}>
+          The Cosmic Casino isn&apos;t available in your jurisdiction
+          {country && country !== 'UNKNOWN' ? ` (${country})` : ''}.
+          We&apos;re sorry for the inconvenience — keep an eye on the
+          roadmap, and reach out if you&apos;d like to know when we
+          expand coverage.
+        </p>
+        <p style={copyStyle}>
+          Provably-fair verification of past bets is open to anyone: you
+          can still inspect any settled bet at{' '}
+          <Link href="/verify" style={linkStyle}>
+            /verify
+          </Link>
+          .
+        </p>
+      </header>
+      <nav style={navStyle} aria-label="Geo-blocked navigation">
+        <Link href="/" style={linkStyle}>
+          Back to home
+        </Link>
+      </nav>
+    </main>
+  );
+}
+
+const pageStyle: React.CSSProperties = {
+  minHeight: 'calc(100vh - 56px)',
+  padding: '1.5rem 1.25rem 3rem',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1.25rem',
+  fontFamily: 'system-ui, -apple-system, sans-serif',
+  maxWidth: 560,
+  margin: '0 auto',
+  width: '100%',
+};
+
+const headerStyle: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.75rem',
+};
+
+const titleStyle: React.CSSProperties = {
+  margin: 0,
+  fontSize: '1.6rem',
+  letterSpacing: '-0.01em',
+  color: 'var(--swo-fg-strong, #f5f5f5)',
+};
+
+const copyStyle: React.CSSProperties = {
+  margin: 0,
+  color: 'var(--swo-fg-muted, #a3a3a3)',
+  fontSize: '0.95rem',
+  lineHeight: 1.5,
+};
+
+const linkStyle: React.CSSProperties = {
+  color: 'var(--swo-link-fg, #7dd3fc)',
+  textDecoration: 'underline',
+  textUnderlineOffset: '2px',
+};
+
+const navStyle: React.CSSProperties = {
+  display: 'flex',
+  gap: '0.75rem',
+  flexWrap: 'wrap',
+};

--- a/lib/casino/__tests__/geo.test.ts
+++ b/lib/casino/__tests__/geo.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Coverage for the casino geo blocklist + `geoGuard()`. Ported from the
+ * BunnyBagz `apps/api/geo/index.test.ts` reference with the env-var
+ * prefix swapped to `SWO_CASINO_GEO_MODE` and the runner adapted to
+ * vitest (the SWO casino project uses vitest, not node:test).
+ *
+ *   * `SWO_CASINO_GEO_MODE=enforce` → blocked countries get HTTP 403
+ *     with `{regulatory_block: true, country, reason, mode}` from
+ *     `decide()`.
+ *   * mode unset (default `log`) → blocked country still gets 200 +
+ *     telemetry, so production stays in soft-launch until counsel signs
+ *     off on the blocklist.
+ *   * `SWO_CASINO_GEO_MODE=log` (explicit) → same as unset.
+ *   * Allowed-country callers always pass through (200 + telemetry).
+ *   * Missing country header → resolves to "UNKNOWN" → not blocked.
+ *   * `geoGuard()` returns the 403 Response in enforce mode for blocked
+ *     callers; `null` in log mode (no behaviour change until enforcement
+ *     is flipped on).
+ *   * Cloudflare WAF (`cf-ipcountry`) is honoured equally with Vercel
+ *     (`x-vercel-ip-country`) — same module sits behind either edge.
+ *   * Legacy `GEO_ENFORCE=1` still flips to enforce (back-compat).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  BLOCKED_COUNTRIES,
+  countryFromHeaders,
+  decide,
+  geoGuard,
+  isBlockedCountry,
+  modeFromEnv,
+  normalizeCountry,
+} from '../geo';
+
+function makeRequest(
+  country: string,
+  header: 'x-vercel-ip-country' | 'cf-ipcountry' = 'x-vercel-ip-country',
+): Request {
+  return new Request('https://swo.example/casino/dice', {
+    headers: { [header]: country },
+  });
+}
+
+const TOUCHED_ENV = ['SWO_CASINO_GEO_MODE', 'GEO_ENFORCE'] as const;
+
+describe('geo blocklist', () => {
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const k of TOUCHED_ENV) saved[k] = process.env[k];
+    for (const k of TOUCHED_ENV) delete process.env[k];
+  });
+
+  afterEach(() => {
+    for (const k of TOUCHED_ENV) {
+      const v = saved[k];
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  describe('BLOCKED_COUNTRIES set', () => {
+    it('includes the OFAC-sanctioned jurisdictions', () => {
+      for (const cc of ['IR', 'KP', 'SY', 'CU', 'RU']) {
+        expect(BLOCKED_COUNTRIES.has(cc)).toBe(true);
+      }
+    });
+
+    it('includes the 9 licensed jurisdictions on the blocklist', () => {
+      for (const cc of [
+        'US',
+        'GB',
+        'FR',
+        'IT',
+        'ES',
+        'NL',
+        'SG',
+        'AU',
+        'IL',
+      ]) {
+        expect(BLOCKED_COUNTRIES.has(cc)).toBe(true);
+      }
+    });
+
+    it('does not block neutral jurisdictions', () => {
+      for (const cc of ['DE', 'JP', 'BR', 'CA', 'CH']) {
+        expect(BLOCKED_COUNTRIES.has(cc)).toBe(false);
+      }
+    });
+
+    it('totals 14 entries (9 licensed + 5 OFAC)', () => {
+      expect(BLOCKED_COUNTRIES.size).toBe(14);
+    });
+  });
+
+  describe('normalizeCountry()', () => {
+    it('uppercases the input', () => {
+      expect(normalizeCountry('us')).toBe('US');
+      expect(normalizeCountry('kp')).toBe('KP');
+    });
+
+    it('returns UNKNOWN for missing input', () => {
+      expect(normalizeCountry(null)).toBe('UNKNOWN');
+      expect(normalizeCountry(undefined)).toBe('UNKNOWN');
+      expect(normalizeCountry('')).toBe('UNKNOWN');
+    });
+  });
+
+  describe('isBlockedCountry()', () => {
+    it('matches case-insensitively', () => {
+      expect(isBlockedCountry('us')).toBe(true);
+      expect(isBlockedCountry('Us')).toBe(true);
+      expect(isBlockedCountry('US')).toBe(true);
+    });
+
+    it('treats UNKNOWN as allowed (best-effort headers)', () => {
+      expect(isBlockedCountry(null)).toBe(false);
+      expect(isBlockedCountry(undefined)).toBe(false);
+      expect(isBlockedCountry('UNKNOWN')).toBe(false);
+    });
+  });
+
+  describe('modeFromEnv()', () => {
+    it('defaults to log when unset', () => {
+      expect(modeFromEnv({})).toBe('log');
+    });
+
+    it('honours SWO_CASINO_GEO_MODE=enforce', () => {
+      expect(modeFromEnv({ SWO_CASINO_GEO_MODE: 'enforce' })).toBe('enforce');
+      expect(modeFromEnv({ SWO_CASINO_GEO_MODE: 'ENFORCE' })).toBe('enforce');
+    });
+
+    it('honours SWO_CASINO_GEO_MODE=log explicitly', () => {
+      expect(modeFromEnv({ SWO_CASINO_GEO_MODE: 'log' })).toBe('log');
+    });
+
+    it('honours legacy GEO_ENFORCE=1 fallback', () => {
+      expect(modeFromEnv({ GEO_ENFORCE: '1' })).toBe('enforce');
+    });
+
+    it('SWO_CASINO_GEO_MODE wins over GEO_ENFORCE', () => {
+      expect(
+        modeFromEnv({ SWO_CASINO_GEO_MODE: 'log', GEO_ENFORCE: '1' }),
+      ).toBe('log');
+    });
+  });
+
+  describe('countryFromHeaders()', () => {
+    it('reads x-vercel-ip-country (Vercel edge)', () => {
+      const h = new Headers({ 'x-vercel-ip-country': 'de' });
+      expect(countryFromHeaders(h)).toBe('DE');
+    });
+
+    it('reads cf-ipcountry (Cloudflare WAF)', () => {
+      const h = new Headers({ 'cf-ipcountry': 'jp' });
+      expect(countryFromHeaders(h)).toBe('JP');
+    });
+
+    it('prefers Vercel header when both are present', () => {
+      const h = new Headers({
+        'x-vercel-ip-country': 'de',
+        'cf-ipcountry': 'us',
+      });
+      expect(countryFromHeaders(h)).toBe('DE');
+    });
+
+    it('falls back to UNKNOWN when neither header is set', () => {
+      expect(countryFromHeaders(new Headers())).toBe('UNKNOWN');
+    });
+  });
+
+  describe('decide()', () => {
+    it('log mode always returns 200 + wouldBlock telemetry', () => {
+      const blocked = decide('US', 'log');
+      expect(blocked.status).toBe(200);
+      expect(blocked.body).toEqual({
+        country: 'US',
+        mode: 'log',
+        allowed: true,
+        wouldBlock: true,
+        reason: 'country-on-blocklist',
+      });
+
+      const allowed = decide('DE', 'log');
+      expect(allowed.status).toBe(200);
+      expect(allowed.body).toEqual({
+        country: 'DE',
+        mode: 'log',
+        allowed: true,
+        wouldBlock: false,
+        reason: null,
+      });
+    });
+
+    it('enforce mode returns 403 + regulatory_block JSON for blocked countries', () => {
+      const blocked = decide('KP', 'enforce');
+      expect(blocked.status).toBe(403);
+      expect(blocked.body).toEqual({
+        regulatory_block: true,
+        country: 'KP',
+        reason: 'country-on-blocklist',
+        mode: 'enforce',
+      });
+    });
+
+    it('enforce mode preserves the 200 telemetry shape for non-blocked countries', () => {
+      const allowed = decide('DE', 'enforce');
+      expect(allowed.status).toBe(200);
+      expect(allowed.body).toEqual({
+        country: 'DE',
+        mode: 'enforce',
+        allowed: true,
+        wouldBlock: false,
+        reason: null,
+      });
+    });
+  });
+
+  describe('geoGuard()', () => {
+    it('log mode returns null for both blocked and allowed callers', () => {
+      process.env.SWO_CASINO_GEO_MODE = 'log';
+      expect(geoGuard(makeRequest('US'))).toBeNull();
+      expect(geoGuard(makeRequest('DE'))).toBeNull();
+      expect(geoGuard(new Request('https://swo.example/casino'))).toBeNull();
+    });
+
+    it('enforce mode short-circuits with 403 for blocked countries only', async () => {
+      process.env.SWO_CASINO_GEO_MODE = 'enforce';
+      const blocked = geoGuard(makeRequest('KP'));
+      expect(blocked).not.toBeNull();
+      expect(blocked!.status).toBe(403);
+      const body = await blocked!.json();
+      expect(body).toEqual({
+        regulatory_block: true,
+        country: 'KP',
+        reason: 'country-on-blocklist',
+        mode: 'enforce',
+      });
+
+      // Allowed country (and unknown country) → null so handler runs.
+      expect(geoGuard(makeRequest('DE'))).toBeNull();
+      expect(geoGuard(new Request('https://swo.example/casino'))).toBeNull();
+    });
+
+    it('enforce mode honours Cloudflare WAF cf-ipcountry header', async () => {
+      process.env.SWO_CASINO_GEO_MODE = 'enforce';
+      const blocked = geoGuard(makeRequest('RU', 'cf-ipcountry'));
+      expect(blocked).not.toBeNull();
+      expect(blocked!.status).toBe(403);
+      const body = await blocked!.json();
+      expect(body.country).toBe('RU');
+    });
+
+    it('legacy GEO_ENFORCE=1 still flips to enforce', () => {
+      process.env.GEO_ENFORCE = '1';
+      const blocked = geoGuard(makeRequest('US'));
+      expect(blocked).not.toBeNull();
+      expect(blocked!.status).toBe(403);
+    });
+  });
+});

--- a/lib/casino/geo.ts
+++ b/lib/casino/geo.ts
@@ -1,0 +1,155 @@
+// Regulatory blocklist for `/casino/*` — single source of truth.
+//
+// Carried over verbatim from the BunnyBagz reference implementation
+// (`packages/chain/src/geo.ts`). Strict / common-crypto-casino posture: we
+// lean on the conservative side and match what mature crypto casinos
+// (Stake-international, Roobet, BC.Game) block today.
+//
+// Counsel review gate: before flipping `SWO_CASINO_GEO_MODE=enforce` in
+// production, the operator MUST file an inline review note (signed off by
+// outside counsel) confirming this list is current. The env var defaults
+// to `log` so a forgotten review never silently turns into a 403 for live
+// users.
+//
+// Country codes are ISO 3166-1 alpha-2, uppercase. The set is exposed as
+// `BLOCKED_COUNTRIES`; helpers `isBlockedCountry()` and `normalizeCountry()`
+// keep callers from sprinkling `.toUpperCase()` everywhere.
+
+export const BLOCKED_COUNTRIES: ReadonlySet<string> = new Set<string>([
+  // --- Licensed / regulated jurisdictions we don't hold a licence in. ---
+  'US', // United States — all states; US-resident wallets blocked at edge.
+  'GB', // United Kingdom — Gambling Commission requires local licence.
+  'FR', // France — ARJEL.
+  'IT', // Italy — ADM monopoly.
+  'ES', // Spain — DGOJ.
+  'NL', // Netherlands — KSA.
+  'SG', // Singapore — broad gambling prohibition for residents.
+  'AU', // Australia — IGA.
+  'IL', // Israel — broad online-gambling restrictions.
+  // --- OFAC-sanctioned jurisdictions (review quarterly). ---
+  'IR', // Iran.
+  'KP', // North Korea.
+  'SY', // Syria.
+  'CU', // Cuba.
+  'RU', // Russia.
+]);
+
+/**
+ * Normalize a header-derived country code to the canonical uppercase form.
+ * Returns `"UNKNOWN"` for missing / falsy input so callers never have to
+ * special-case `null`/`undefined` before the membership check.
+ */
+export function normalizeCountry(country: string | null | undefined): string {
+  if (!country) return 'UNKNOWN';
+  return country.toUpperCase();
+}
+
+/**
+ * Pure membership test against the blocklist. `"UNKNOWN"` is intentionally
+ * allowed (not blocked) — geo headers are best-effort at the edge and we'd
+ * rather log a false-negative than 403 a legit player whose CDN didn't tag
+ * the request.
+ */
+export function isBlockedCountry(country: string | null | undefined): boolean {
+  return BLOCKED_COUNTRIES.has(normalizeCountry(country));
+}
+
+export type GeoMode = 'log' | 'enforce';
+
+/**
+ * Resolve the active geo enforcement mode from env. Default is `log` so
+ * production stays in soft-launch shape until counsel signs off and the
+ * operator flips `SWO_CASINO_GEO_MODE=enforce`. Legacy `GEO_ENFORCE=1`
+ * is honoured as a back-compat fallback.
+ */
+export function modeFromEnv(
+  env: Record<string, string | undefined> = process.env,
+): GeoMode {
+  const explicit = env.SWO_CASINO_GEO_MODE?.toLowerCase();
+  if (explicit === 'enforce') return 'enforce';
+  if (explicit === 'log') return 'log';
+  if (env.GEO_ENFORCE === '1') return 'enforce';
+  return 'log';
+}
+
+/**
+ * Read the caller's country from edge headers. Supports Vercel
+ * (`x-vercel-ip-country`) and Cloudflare WAF (`cf-ipcountry`), so the
+ * same module can sit behind either edge.
+ */
+export function countryFromHeaders(headers: Headers): string {
+  return normalizeCountry(
+    headers.get('x-vercel-ip-country') ??
+      headers.get('cf-ipcountry') ??
+      'UNKNOWN',
+  );
+}
+
+interface BlockBody {
+  regulatory_block: true;
+  country: string;
+  reason: 'country-on-blocklist';
+  mode: 'enforce';
+}
+
+interface AllowBody {
+  country: string;
+  mode: GeoMode;
+  allowed: true;
+  wouldBlock: boolean;
+  reason: 'country-on-blocklist' | null;
+}
+
+export type DecideResult =
+  | { status: 403; body: BlockBody }
+  | { status: 200; body: AllowBody };
+
+export function decide(country: string, mode: GeoMode): DecideResult {
+  const wouldBlock = isBlockedCountry(country);
+  if (mode === 'enforce' && wouldBlock) {
+    return {
+      status: 403,
+      body: {
+        regulatory_block: true,
+        country,
+        reason: 'country-on-blocklist',
+        mode: 'enforce',
+      },
+    };
+  }
+  return {
+    status: 200,
+    body: {
+      country,
+      mode,
+      allowed: true,
+      wouldBlock,
+      reason: wouldBlock ? 'country-on-blocklist' : null,
+    },
+  };
+}
+
+/**
+ * Edge-fn guard. Returns a `Response` if the caller should be blocked
+ * (or if telemetry needs to short-circuit), else `null` so the inner
+ * handler can run.
+ *
+ * Only emits a `Response` in `enforce` mode for blocked countries; in
+ * `log` mode it always returns `null` so existing behaviour is preserved.
+ */
+export function geoGuard(req: Request): Response | null {
+  const mode = modeFromEnv();
+  if (mode !== 'enforce') return null;
+  const country = countryFromHeaders(req.headers);
+  if (!isBlockedCountry(country)) return null;
+  const body: BlockBody = {
+    regulatory_block: true,
+    country,
+    reason: 'country-on-blocklist',
+    mode: 'enforce',
+  };
+  return Response.json(body, { status: 403 });
+}
+
+export const GEO_BLOCKED_HEADER = 'x-swo-geo-blocked';
+export const GEO_COUNTRY_HEADER = 'x-swo-geo-country';

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,65 @@
+// Next.js middleware — guards `/casino/*` against blocked jurisdictions.
+//
+// Carried over from the BunnyBagz reference (`apps/web/src/middleware.ts`)
+// with the matcher narrowed to the casino surface and the blocklist sourced
+// from `@/lib/casino/geo`. Reads the same `SWO_CASINO_GEO_MODE` env var as
+// the in-process geo helpers so production has a single switch. Compatible
+// with both Vercel and Cloudflare WAF edges (geo lookup falls back to
+// `cf-ipcountry`).
+//
+// Mode semantics:
+//
+//   * **log** (default): every request passes through unchanged. We attach
+//     `x-swo-geo-blocked: 0|1` so downstream surfaces can read what the
+//     enforcer *would* have done.
+//   * **enforce** (env: `SWO_CASINO_GEO_MODE=enforce`): blocked-country
+//     requests are rewritten to `/region-not-supported` so the page tree
+//     renders the polite placeholder (no game UI, no wallet modal). The
+//     status code stays 200 — surfacing a 403 here would break the
+//     `<Link>` prefetcher and bake a Vercel error page in the user's
+//     browser instead of our copy.
+
+import { NextResponse, type NextRequest } from 'next/server';
+
+import {
+  GEO_BLOCKED_HEADER,
+  GEO_COUNTRY_HEADER,
+  isBlockedCountry,
+  modeFromEnv,
+  normalizeCountry,
+} from '@/lib/casino/geo';
+
+function countryFromRequest(req: NextRequest): string {
+  const geoCountry = (req as unknown as { geo?: { country?: string } }).geo
+    ?.country;
+  return normalizeCountry(
+    geoCountry ??
+      req.headers.get('x-vercel-ip-country') ??
+      req.headers.get('cf-ipcountry') ??
+      'UNKNOWN',
+  );
+}
+
+export function middleware(req: NextRequest) {
+  const country = countryFromRequest(req);
+  const blocked = isBlockedCountry(country);
+  const mode = modeFromEnv();
+
+  if (mode === 'enforce' && blocked) {
+    const url = req.nextUrl.clone();
+    url.pathname = '/region-not-supported';
+    const res = NextResponse.rewrite(url);
+    res.headers.set(GEO_BLOCKED_HEADER, '1');
+    res.headers.set(GEO_COUNTRY_HEADER, country);
+    return res;
+  }
+
+  const res = NextResponse.next();
+  res.headers.set(GEO_BLOCKED_HEADER, blocked ? '1' : '0');
+  res.headers.set(GEO_COUNTRY_HEADER, country);
+  return res;
+}
+
+export const config = {
+  matcher: ['/casino/:path*'],
+};


### PR DESCRIPTION
## Summary

Implements **[SWO_CASINO_GEO_BLOCKLIST]** (G3): OFAC + 9-country block at the `/casino/*` route layer, carried over verbatim from the BunnyBagz reference (`packages/chain/src/geo.ts` + `apps/web/src/middleware.ts`).

- **Blocklist (`lib/casino/geo.ts`)** — 14 ISO 3166-1 alpha-2 codes split between regulated jurisdictions (US, GB, FR, IT, ES, NL, SG, AU, IL) and OFAC-sanctioned (IR, KP, SY, CU, RU). Exposes `BLOCKED_COUNTRIES`, `isBlockedCountry()`, `normalizeCountry()`, `decide()`, and an edge-fn-friendly `geoGuard()`.
- **Middleware (`middleware.ts`)** — Next.js matcher narrowed to `/casino/:path*`. Reads geo from `next/server` `req.geo`, with header fallbacks for both **Vercel** (`x-vercel-ip-country`) and **Cloudflare WAF** (`cf-ipcountry`). Sets diagnostic headers `x-swo-geo-blocked` and `x-swo-geo-country` so downstream surfaces can branch on the soft-launch telemetry.
- **Placeholder route (`app/region-not-supported/page.tsx` + `components/casino/GeoBlockedNotice.tsx`)** — polite copy block (no game UI, no wallet modal) that the middleware rewrites blocked traffic to.

### Modes (single env switch)
- **`log` (default)** — every request passes through; the `x-swo-geo-blocked: 0|1` header records what the enforcer *would* have done. Stays in this mode until counsel signs off.
- **`SWO_CASINO_GEO_MODE=enforce`** — blocked-country requests are rewritten to `/region-not-supported` (200 status preserved so `<Link>` prefetcher stays sane; surfacing 403 here would bake a Vercel error page in the user's browser).
- Legacy `GEO_ENFORCE=1` is honoured as a back-compat fallback.

### Cloudflare WAF
The middleware reads `cf-ipcountry` so the same module sits behind either Vercel's geo header or Cloudflare's WAF — operators picking Cloudflare as the chosen edge get the same enforcement without code changes.

## Test plan
- [x] 24 new vitest tests in `lib/casino/__tests__/geo.test.ts` cover: blocklist contents (14 entries; 9 licensed + 5 OFAC), `normalizeCountry()` casing & null handling, `isBlockedCountry()` UNKNOWN-pass policy, `modeFromEnv()` precedence (`SWO_CASINO_GEO_MODE` > `GEO_ENFORCE`), `countryFromHeaders()` Vercel/Cloudflare fallback, `decide()` 200/403 shapes, `geoGuard()` log/enforce behaviour
- [x] `npx vitest run --project casino` — **227/227 passing** locally (no regressions)
- [x] `npx vitest run --project default` — **930/930 passing** locally
- [x] `npx tsc --noEmit` — 36 errors (baseline, unchanged)
- [ ] `npm run lint`
- [ ] Counsel review note before flipping `SWO_CASINO_GEO_MODE=enforce` in prod (out of scope here; gate documented in `lib/casino/geo.ts`)

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS — baseline 36, post-overlay 36, zero new errors
- **vitest run --project casino lib/casino/__tests__/geo.test.ts**: PASS (547ms, 24/24)
- Full PROD casino vitest run is pre-existing hung/timing out independent of this change (verified by reproducing with overlay files removed). Targeted run of the new file under PROD passes cleanly.

Overall: **PASS**

🤖 Generated with [Claude Code](https://claude.com/claude-code)