### PR TITLE
feat(sanctuary): compassionate streak counter [SWO_V2_SANCTUARY_STREAKS]

### DIFF
--- a/components/sanctuary/overlays/CompanionHUD.tsx
+++ b/components/sanctuary/overlays/CompanionHUD.tsx
@@ -11,6 +11,7 @@ import {
   newlyCrossed,
   type NeedStats,
 } from '@/lib/sanctuary/needs';
+import { streakChipLabel, type StreakStatus } from '@/lib/sanctuary/streaks';
 
 interface CompanionData {
   nickname: string | null;
@@ -32,6 +33,10 @@ interface CompanionData {
   happiness: number | null;
   energy: number | null;
   is_sleeping: number | null;
+  // [SWO_V2_SANCTUARY_STREAKS] Daily-visit streak (null when the companion
+  // endpoint pre-dates the v2.7 migration — chip simply hides).
+  streak_current: number | null;
+  streak_status: StreakStatus | null;
 }
 
 interface CompanionHUDProps {
@@ -148,6 +153,8 @@ export default function CompanionHUD({ walletAddress }: CompanionHUDProps) {
           happiness: data.companion.happiness ?? null,
           energy: data.companion.energy ?? null,
           is_sleeping: data.companion.is_sleeping ?? null,
+          streak_current: data.companion.streak_current ?? null,
+          streak_status: (data.companion.streak_status ?? null) as StreakStatus | null,
         });
         // Push the loadout into the Phaser scene so cosmetic layers render.
         EventBus.emit('companion-cosmetics', equipped);
@@ -327,6 +334,15 @@ export default function CompanionHUD({ walletAddress }: CompanionHUDProps) {
   // touch tick so linter treats it as used for countdown re-render
   void tick;
 
+  const streakLabel =
+    companion.streak_current !== null && companion.streak_current > 0
+      ? streakChipLabel(
+          companion.streak_current,
+          companion.streak_status ?? 'active',
+        )
+      : null;
+  const streakPaused = companion.streak_status === 'paused';
+
   return (
     <>
       {/* STAR currency badge */}
@@ -339,6 +355,34 @@ export default function CompanionHUD({ walletAddress }: CompanionHUDProps) {
           <span className="text-[10px] leading-none">⭐</span>
           <span className="text-[8px] text-[#ffd700] font-['Press_Start_2P'] tabular-nums">
             {starBalance.toLocaleString()}
+          </span>
+        </div>
+      )}
+
+      {/* [SWO_V2_SANCTUARY_STREAKS] Compassionate streak chip — identity, not
+          power. Shows current day count + a "paused" indicator after a single
+          missed day. Renders nothing until the companion endpoint emits a
+          streak field (post v2.7 migration). */}
+      {streakLabel && (
+        <div
+          className={`absolute top-2 right-24 z-20 flex items-center gap-1.5 bg-black/80 rounded px-2.5 py-1 pointer-events-none select-none border ${
+            streakPaused
+              ? 'border-[#9966ff]/50 shadow-[0_0_8px_rgba(153,102,255,0.2)]'
+              : 'border-[#ff8855]/50 shadow-[0_0_8px_rgba(255,136,85,0.2)]'
+          }`}
+          aria-label={`Visit streak: ${streakLabel}`}
+          title={
+            streakPaused
+              ? 'Streak paused — you missed a day. Visit again tomorrow to resume.'
+              : `Visit streak: ${streakLabel}`
+          }
+        >
+          <span
+            className={`text-[8px] font-['Press_Start_2P'] tabular-nums ${
+              streakPaused ? 'text-[#b099ff]' : 'text-[#ffaa66]'
+            }`}
+          >
+            {streakLabel}
           </span>
         </div>
       )}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -5890,6 +5890,11 @@ function initializeSanctuary(database: Database.Database): void {
     const sql = fs.readFileSync(v26Path, 'utf-8');
     database.exec(sql);
   }
+  const v27Path = path.join(process.cwd(), 'scripts', 'init-sanctuary-v2.7.sql');
+  if (fs.existsSync(v27Path)) {
+    const sql = fs.readFileSync(v27Path, 'utf-8');
+    database.exec(sql);
+  }
   // V1.7: per-companion XP/level columns (Training Grounds). ALTER TABLE IF NOT
   // EXISTS is not portable across SQLite versions, so wrap in try/catch.
   try { database.exec('ALTER TABLE sanctuary_companions ADD COLUMN xp INTEGER NOT NULL DEFAULT 0'); }

--- a/lib/sanctuary/__tests__/streaks.test.ts
+++ b/lib/sanctuary/__tests__/streaks.test.ts
@@ -1,0 +1,370 @@
+import { describe, it, expect } from 'vitest';
+import {
+  applyVisit,
+  crossedMilestones,
+  highestStreakMilestone,
+  streakChipLabel,
+  streakMilestoneJournal,
+  utcDayDelta,
+  STREAK_MILESTONES,
+  STREAK_PAUSE_GAP_DAYS,
+  STREAK_RESET_GAP_DAYS,
+  type StreakRow,
+} from '../streaks';
+
+// Anchor mid-day in UTC so day-boundary maths are unambiguous.
+const D0 = new Date('2026-05-01T12:00:00Z');
+
+function plusDays(base: Date, n: number): Date {
+  return new Date(base.getTime() + n * 86_400_000);
+}
+
+function toSql(d: Date): string {
+  return d.toISOString().replace('T', ' ').slice(0, 19);
+}
+
+function row(overrides: Partial<StreakRow> = {}): StreakRow {
+  return {
+    current_streak: 0,
+    longest_streak: 0,
+    last_visit_at: null,
+    paused_since_at: null,
+    ...overrides,
+  };
+}
+
+describe('utcDayDelta', () => {
+  it('returns 0 for same UTC day', () => {
+    expect(utcDayDelta(toSql(D0), new Date('2026-05-01T23:59:00Z'))).toBe(0);
+  });
+
+  it('returns 1 for next day', () => {
+    expect(utcDayDelta(toSql(D0), plusDays(D0, 1))).toBe(1);
+  });
+
+  it('returns 2 for one missed day', () => {
+    expect(utcDayDelta(toSql(D0), plusDays(D0, 2))).toBe(2);
+  });
+
+  it('returns null for null input', () => {
+    expect(utcDayDelta(null, D0)).toBeNull();
+  });
+
+  it('returns null for unparseable input', () => {
+    expect(utcDayDelta('not-a-date', D0)).toBeNull();
+  });
+});
+
+describe('applyVisit — first visit bootstraps streak at 1', () => {
+  it('initialises current_streak=1 from a null row', () => {
+    const out = applyVisit(null, D0);
+    expect(out.next.current_streak).toBe(1);
+    expect(out.next.longest_streak).toBe(1);
+    expect(out.next.paused_since_at).toBeNull();
+    expect(out.status).toBe('active');
+    expect(out.gapDays).toBeNull();
+    expect(out.incremented).toBe(true);
+    expect(out.reset).toBe(false);
+    expect(out.milestonesCrossed).toEqual([]);
+  });
+
+  it('initialises from a row where last_visit_at is null', () => {
+    const out = applyVisit(row(), D0);
+    expect(out.next.current_streak).toBe(1);
+  });
+});
+
+describe('applyVisit — same-day revisit is a no-op for the streak', () => {
+  it('keeps current_streak unchanged across multiple opens in one UTC day', () => {
+    const prev: StreakRow = row({
+      current_streak: 5,
+      longest_streak: 5,
+      last_visit_at: toSql(D0),
+    });
+    const later = new Date('2026-05-01T22:00:00Z');
+    const out = applyVisit(prev, later);
+    expect(out.next.current_streak).toBe(5);
+    expect(out.incremented).toBe(false);
+    expect(out.gapDays).toBe(0);
+    expect(out.milestonesCrossed).toEqual([]);
+  });
+});
+
+describe('applyVisit — Acceptance #1: 1 missed day pauses the streak', () => {
+  it('does NOT increment, does NOT reset — sets paused_since_at', () => {
+    const prev: StreakRow = row({
+      current_streak: 6,
+      longest_streak: 6,
+      last_visit_at: toSql(D0),
+    });
+    // Visit on D+2 (i.e. one missed UTC day in between).
+    const visit = plusDays(D0, STREAK_PAUSE_GAP_DAYS);
+    const out = applyVisit(prev, visit);
+    expect(out.gapDays).toBe(2);
+    expect(out.status).toBe('paused');
+    expect(out.next.current_streak).toBe(6); // unchanged
+    expect(out.next.longest_streak).toBe(6); // unchanged
+    expect(out.next.paused_since_at).not.toBeNull();
+    expect(out.incremented).toBe(false);
+    expect(out.reset).toBe(false);
+    expect(out.milestonesCrossed).toEqual([]);
+  });
+
+  it('resumes (increments) on the next consecutive day after a pause', () => {
+    const prev: StreakRow = row({
+      current_streak: 6,
+      longest_streak: 6,
+      last_visit_at: toSql(plusDays(D0, 2)),
+      paused_since_at: toSql(plusDays(D0, 1)),
+    });
+    const visit = plusDays(D0, 3);
+    const out = applyVisit(prev, visit);
+    expect(out.next.current_streak).toBe(7);
+    expect(out.next.longest_streak).toBe(7);
+    expect(out.next.paused_since_at).toBeNull();
+    expect(out.status).toBe('active');
+    expect(out.incremented).toBe(true);
+  });
+});
+
+describe('applyVisit — Acceptance #2: 2 consecutive misses reset the streak', () => {
+  it('resets current_streak to 1 when the gap is ≥ 3 UTC days', () => {
+    const prev: StreakRow = row({
+      current_streak: 12,
+      longest_streak: 12,
+      last_visit_at: toSql(D0),
+    });
+    const visit = plusDays(D0, STREAK_RESET_GAP_DAYS);
+    const out = applyVisit(prev, visit);
+    expect(out.gapDays).toBe(3);
+    expect(out.reset).toBe(true);
+    expect(out.next.current_streak).toBe(1);
+    expect(out.next.longest_streak).toBe(12); // retained — identity is preserved
+    expect(out.next.paused_since_at).toBeNull();
+    expect(out.status).toBe('active');
+  });
+
+  it('resets on much-longer absences (e.g. 14-day gap)', () => {
+    const prev: StreakRow = row({
+      current_streak: 30,
+      longest_streak: 30,
+      last_visit_at: toSql(D0),
+    });
+    const out = applyVisit(prev, plusDays(D0, 14));
+    expect(out.reset).toBe(true);
+    expect(out.next.current_streak).toBe(1);
+    expect(out.next.longest_streak).toBe(30);
+  });
+
+  it('reports no milestones on reset beyond the new day-1 cross-of-0', () => {
+    const prev: StreakRow = row({
+      current_streak: 30,
+      longest_streak: 30,
+      last_visit_at: toSql(D0),
+    });
+    const out = applyVisit(prev, plusDays(D0, 5));
+    expect(out.milestonesCrossed).toEqual([]); // 1 is not a milestone
+  });
+});
+
+describe('applyVisit — Acceptance #3: milestones fire once', () => {
+  it('reports the 7-day milestone exactly when current_streak crosses to 7', () => {
+    const prev: StreakRow = row({
+      current_streak: 6,
+      longest_streak: 6,
+      last_visit_at: toSql(D0),
+    });
+    const out = applyVisit(prev, plusDays(D0, 1));
+    expect(out.next.current_streak).toBe(7);
+    expect(out.milestonesCrossed).toEqual([7]);
+  });
+
+  it('reports the 14-day milestone exactly when current_streak crosses to 14', () => {
+    const prev: StreakRow = row({
+      current_streak: 13,
+      longest_streak: 13,
+      last_visit_at: toSql(D0),
+    });
+    const out = applyVisit(prev, plusDays(D0, 1));
+    expect(out.milestonesCrossed).toEqual([14]);
+  });
+
+  it('reports the 30-day milestone exactly when current_streak crosses to 30', () => {
+    const prev: StreakRow = row({
+      current_streak: 29,
+      longest_streak: 29,
+      last_visit_at: toSql(D0),
+    });
+    const out = applyVisit(prev, plusDays(D0, 1));
+    expect(out.milestonesCrossed).toEqual([30]);
+  });
+
+  it('does NOT re-fire a milestone already in lastMilestoneReported', () => {
+    // Simulate: streak is 7, milestone 7 already journaled. Next day → streak 8.
+    const prev: StreakRow = row({
+      current_streak: 7,
+      longest_streak: 7,
+      last_visit_at: toSql(D0),
+    });
+    const out = applyVisit(prev, plusDays(D0, 1), { lastMilestoneReported: 7 });
+    expect(out.next.current_streak).toBe(8);
+    expect(out.milestonesCrossed).toEqual([]);
+  });
+
+  it('does NOT re-fire if streak wobbles down then back through a milestone', () => {
+    // Streak hit 7, then was paused, then resumed and crossed 7 again on the
+    // way up. The guard prevents a second journal entry.
+    const prev: StreakRow = row({
+      current_streak: 6,
+      longest_streak: 7,
+      last_visit_at: toSql(D0),
+    });
+    const out = applyVisit(prev, plusDays(D0, 1), { lastMilestoneReported: 7 });
+    expect(out.next.current_streak).toBe(7);
+    expect(out.milestonesCrossed).toEqual([]);
+  });
+
+  it('reports all crossed milestones in a single jump (sorted ascending)', () => {
+    // Edge case: degenerate caller jumps streak from 6 → 14 in one apply.
+    // crossedMilestones is the source of truth.
+    expect(crossedMilestones(6, 14, null)).toEqual([7, 14]);
+  });
+});
+
+describe('highestStreakMilestone', () => {
+  it('returns the largest milestone in the list', () => {
+    expect(highestStreakMilestone([7, 14])).toBe(14);
+    expect(highestStreakMilestone([7])).toBe(7);
+  });
+
+  it('returns null for empty input', () => {
+    expect(highestStreakMilestone([])).toBeNull();
+  });
+});
+
+describe('streakChipLabel', () => {
+  it('renders pluralised day counts', () => {
+    expect(streakChipLabel(1, 'active')).toContain('1 day');
+    expect(streakChipLabel(7, 'active')).toContain('7 days');
+  });
+
+  it('shows paused state explicitly', () => {
+    expect(streakChipLabel(6, 'paused')).toContain('paused');
+  });
+
+  it('shows a start hint when streak is 0', () => {
+    expect(streakChipLabel(0, 'active')).toMatch(/start/i);
+  });
+});
+
+describe('streakMilestoneJournal', () => {
+  it('returns identity-shaped copy that mentions the companion name', () => {
+    const entry = streakMilestoneJournal(7, 'Lumi');
+    expect(entry).toContain('Lumi');
+    expect(entry.length).toBeGreaterThan(0);
+  });
+
+  it('uses different copy at each milestone', () => {
+    const e7 = streakMilestoneJournal(7, 'Lumi');
+    const e14 = streakMilestoneJournal(14, 'Lumi');
+    const e30 = streakMilestoneJournal(30, 'Lumi');
+    expect(new Set([e7, e14, e30]).size).toBe(3);
+  });
+
+  it('falls back gracefully on blank names', () => {
+    expect(streakMilestoneJournal(7, '   ').length).toBeGreaterThan(0);
+  });
+});
+
+describe('STREAK_MILESTONES constant', () => {
+  it('matches the V2 plan: 7 / 14 / 30', () => {
+    expect([...STREAK_MILESTONES]).toEqual([7, 14, 30]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration-level scenario — Playwright stand-in for the 9-day timeline.
+// Simulates the player visiting on days 1-7, missing day 8, returning day 9.
+// Asserts: streak still active on day 9, 7-day milestone journal fired once.
+// ---------------------------------------------------------------------------
+describe('[E2E shape] 9-day timeline with one missed day', () => {
+  it('keeps the streak active on day 9 and journals the 7-day milestone once', () => {
+    const day1 = new Date('2026-05-01T10:00:00Z');
+    const days = (n: number) => plusDays(day1, n - 1);
+
+    let state: StreakRow = row();
+    let lastMilestoneReported: number | null = null;
+    const journal: number[] = [];
+
+    function tick(now: Date) {
+      const out = applyVisit(state, now, { lastMilestoneReported });
+      state = out.next;
+      for (const m of out.milestonesCrossed) {
+        journal.push(m);
+        if (lastMilestoneReported === null || m > lastMilestoneReported) {
+          lastMilestoneReported = m;
+        }
+      }
+      return out;
+    }
+
+    // Days 1-7: consecutive visits → streak hits 7 on day 7.
+    for (let d = 1; d <= 7; d++) {
+      tick(days(d));
+    }
+    expect(state.current_streak).toBe(7);
+    expect(state.longest_streak).toBe(7);
+    expect(state.paused_since_at).toBeNull();
+    expect(journal).toEqual([7]); // milestone fired once on day 7
+
+    // Day 8: skipped (no tick).
+
+    // Day 9: returns. Gap = 2 → streak pauses at 7.
+    const out9 = tick(days(9));
+    expect(out9.gapDays).toBe(2);
+    expect(out9.status).toBe('paused');
+    expect(state.current_streak).toBe(7); // still alive — identity preserved
+    expect(state.paused_since_at).not.toBeNull();
+
+    // Journal not re-fired by the pause day.
+    expect(journal).toEqual([7]);
+
+    // Sanity: Day 10 resumes → streak goes to 8.
+    const out10 = tick(days(10));
+    expect(out10.status).toBe('active');
+    expect(state.current_streak).toBe(8);
+    expect(journal).toEqual([7]); // still single-fire
+  });
+
+  it('a 2-missed-day gap (days 8-9 skipped, return day 10) resets to 1', () => {
+    const day1 = new Date('2026-05-01T10:00:00Z');
+    const days = (n: number) => plusDays(day1, n - 1);
+
+    let state: StreakRow = row();
+    let lastMilestoneReported: number | null = null;
+    const journal: number[] = [];
+
+    function tick(now: Date) {
+      const out = applyVisit(state, now, { lastMilestoneReported });
+      state = out.next;
+      for (const m of out.milestonesCrossed) {
+        journal.push(m);
+        if (lastMilestoneReported === null || m > lastMilestoneReported) {
+          lastMilestoneReported = m;
+        }
+      }
+      return out;
+    }
+
+    for (let d = 1; d <= 7; d++) tick(days(d));
+    expect(state.current_streak).toBe(7);
+
+    // Skip days 8 AND 9. Return day 10 → gap = 3 → reset.
+    const out10 = tick(days(10));
+    expect(out10.reset).toBe(true);
+    expect(out10.gapDays).toBe(3);
+    expect(state.current_streak).toBe(1);
+    expect(state.longest_streak).toBe(7); // identity preserved
+    expect(journal).toEqual([7]); // still only the original milestone
+  });
+});

--- a/lib/sanctuary/streaks.ts
+++ b/lib/sanctuary/streaks.ts
@@ -1,0 +1,252 @@
+/**
+ * [SWO_V2_SANCTUARY_STREAKS] — compassionate streak counter (PR5 of 7).
+ *
+ * Pure helpers for a "show up, but life happens" daily visit streak:
+ *
+ *   1. **Same-day revisit.** No change — opening the Sanctuary twice on the
+ *      same UTC day keeps the streak as it was. We track visits, not opens.
+ *   2. **Next-day visit.** Streak increments by 1. If the previous visit
+ *      paused the streak (one missed day), the pause clears.
+ *   3. **One missed day → pause.** When the gap is exactly two UTC days,
+ *      the streak is paused (kept at its current value, `paused_since_at`
+ *      stamps the missed day). Visiting the next day after a pause resumes
+ *      and increments the streak.
+ *   4. **Two consecutive missed days → reset.** A gap of ≥ 3 UTC days resets
+ *      `current_streak` to 1 (today counts as the new day-1) and clears the
+ *      pause.
+ *
+ * Milestones at 7 / 14 / 30 days fire once per crossing — they unlock a
+ * journal entry, never a stat lift. The caller persists the highest reported
+ * milestone (`lastMilestoneReported`) and passes it back to guard against
+ * double-fire across surfaces / refresh.
+ *
+ * No DB / Phaser / React imports — keeps the module trivially unit-testable
+ * and reusable by route handlers, the HUD chip, and any future surface.
+ */
+import { parseSqlDateMs } from './companionStats';
+
+/** Milestones (days) that unlock identity-shaped journal entries. */
+export const STREAK_MILESTONES: readonly number[] = [7, 14, 30] as const;
+export type StreakMilestone = (typeof STREAK_MILESTONES)[number];
+
+/** Day-gap thresholds. Numbers are UTC-day deltas, not hours. */
+export const STREAK_PAUSE_GAP_DAYS = 2;
+export const STREAK_RESET_GAP_DAYS = 3;
+
+export const STREAK_JOURNAL_TAG = 'streak_milestone';
+
+export interface StreakRow {
+  current_streak: number;
+  longest_streak: number;
+  last_visit_at: string | null;
+  paused_since_at: string | null;
+}
+
+export type StreakStatus = 'fresh' | 'active' | 'paused';
+
+export interface StreakOutcome {
+  next: StreakRow;
+  /** Status after this visit, for the HUD chip and journal copy. */
+  status: StreakStatus;
+  /** Day-delta vs the prior visit (0 = same day, null = first visit). */
+  gapDays: number | null;
+  /** Whether `current_streak` increased on this tick. */
+  incremented: boolean;
+  /** Whether the streak was reset to 1 by a long gap. */
+  reset: boolean;
+  /** Milestones newly crossed by this visit (sorted ascending, deduped). */
+  milestonesCrossed: StreakMilestone[];
+}
+
+/**
+ * Number of whole UTC days between two SQLite-style timestamps. Uses UTC
+ * midnight as the day boundary so timezone drift cannot artificially churn
+ * the streak. Returns null on unparseable input so the caller can degrade
+ * gracefully (treating the row as a first visit).
+ */
+export function utcDayDelta(
+  fromSql: string | null,
+  to: Date,
+): number | null {
+  if (!fromSql) return null;
+  const ms = parseSqlDateMs(fromSql);
+  if (ms === null) return null;
+  const fromDay = Math.floor(ms / 86_400_000);
+  const toDay = Math.floor(to.getTime() / 86_400_000);
+  return toDay - fromDay;
+}
+
+/**
+ * Apply a "visit recorded at `now`" event to the row. Pure — no DB / no
+ * side effects. The caller decides whether to persist `outcome.next` and
+ * whether to write `outcome.milestonesCrossed` into the journal.
+ */
+export function applyVisit(
+  prev: StreakRow | null,
+  now: Date,
+  guard: { lastMilestoneReported?: number | null } = {},
+): StreakOutcome {
+  const lastReported = clampGuard(guard.lastMilestoneReported);
+  const nowSql = toSqlUtc(now);
+
+  // First-ever visit: streak = 1, no milestones reported, gap is null.
+  if (!prev || prev.last_visit_at === null) {
+    const next: StreakRow = {
+      current_streak: 1,
+      longest_streak: Math.max(1, prev?.longest_streak ?? 0),
+      last_visit_at: nowSql,
+      paused_since_at: null,
+    };
+    return {
+      next,
+      status: 'active',
+      gapDays: null,
+      incremented: true,
+      reset: false,
+      milestonesCrossed: crossedMilestones(0, 1, lastReported),
+    };
+  }
+
+  const gap = utcDayDelta(prev.last_visit_at, now);
+
+  // Unparseable timestamp — degrade by treating this visit as same-day so
+  // we never accidentally reset on bad data.
+  if (gap === null) {
+    return {
+      next: { ...prev, last_visit_at: nowSql },
+      status: prev.paused_since_at ? 'paused' : 'active',
+      gapDays: null,
+      incremented: false,
+      reset: false,
+      milestonesCrossed: [],
+    };
+  }
+
+  // Same UTC day — no change to streak or pause state. We still bump
+  // last_visit_at so subsequent ticks compare against the latest visit.
+  if (gap <= 0) {
+    return {
+      next: { ...prev, last_visit_at: nowSql },
+      status: prev.paused_since_at ? 'paused' : 'active',
+      gapDays: gap,
+      incremented: false,
+      reset: false,
+      milestonesCrossed: [],
+    };
+  }
+
+  // Next-day visit — increment streak, clear any pause, ratchet longest.
+  if (gap === 1) {
+    const beforeStreak = prev.current_streak;
+    const afterStreak = beforeStreak + 1;
+    const next: StreakRow = {
+      current_streak: afterStreak,
+      longest_streak: Math.max(prev.longest_streak, afterStreak),
+      last_visit_at: nowSql,
+      paused_since_at: null,
+    };
+    return {
+      next,
+      status: 'active',
+      gapDays: gap,
+      incremented: true,
+      reset: false,
+      milestonesCrossed: crossedMilestones(beforeStreak, afterStreak, lastReported),
+    };
+  }
+
+  // Exactly one missed UTC day — pause (don't increment, don't reset).
+  // Stamp `paused_since_at` with the missed day so the HUD can show how
+  // long the streak has been paused. We keep `current_streak` unchanged.
+  if (gap === STREAK_PAUSE_GAP_DAYS) {
+    const pausedSince = prev.paused_since_at ?? toSqlUtc(addDays(now, -1));
+    const next: StreakRow = {
+      ...prev,
+      last_visit_at: nowSql,
+      paused_since_at: pausedSince,
+    };
+    return {
+      next,
+      status: 'paused',
+      gapDays: gap,
+      incremented: false,
+      reset: false,
+      milestonesCrossed: [],
+    };
+  }
+
+  // Two or more missed UTC days — reset to 1, clear pause. Today is the
+  // new day-1 of a fresh streak. longest_streak is retained.
+  const next: StreakRow = {
+    current_streak: 1,
+    longest_streak: Math.max(prev.longest_streak, 1),
+    last_visit_at: nowSql,
+    paused_since_at: null,
+  };
+  return {
+    next,
+    status: 'active',
+    gapDays: gap,
+    incremented: true,
+    reset: true,
+    milestonesCrossed: crossedMilestones(0, 1, lastReported),
+  };
+}
+
+/**
+ * Milestones crossed strictly between `before` and `after`, guarded against
+ * already-reported ones via `lastReported`. Always ascending + deduped.
+ */
+export function crossedMilestones(
+  before: number,
+  after: number,
+  lastReported: number | null,
+): StreakMilestone[] {
+  if (!Number.isFinite(before) || !Number.isFinite(after)) return [];
+  if (after <= before) return [];
+  const guard = lastReported === null ? -Infinity : lastReported;
+  return STREAK_MILESTONES.filter((m) => m > before && m <= after && m > guard);
+}
+
+/** Highest milestone in a list (or null). */
+export function highestStreakMilestone(
+  milestones: readonly StreakMilestone[],
+): StreakMilestone | null {
+  if (milestones.length === 0) return null;
+  return milestones.reduce((a, b) => (b > a ? b : a));
+}
+
+/** Player-facing journal copy for a streak milestone. Identity over power. */
+export function streakMilestoneJournal(milestone: StreakMilestone, name: string): string {
+  const safe = name && name.trim().length > 0 ? name.trim() : 'we';
+  switch (milestone) {
+    case 7:
+      return `One full week together. ${safe} settled into a rhythm — I think they were waiting for me.`;
+    case 14:
+      return `Two weeks in. ${safe} greets me before I even sit down. This is who we are now.`;
+    case 30:
+      return `Thirty days. The sanctuary feels like our place. ${safe} is no longer "the new one".`;
+    default:
+      return `${safe} and I keep showing up for each other.`;
+  }
+}
+
+/** HUD chip label — concise, glanceable. */
+export function streakChipLabel(streak: number, status: StreakStatus): string {
+  if (status === 'paused') return `🔥 ${streak} · paused`;
+  if (streak <= 0) return '✨ start a streak';
+  return `🔥 ${streak} day${streak === 1 ? '' : 's'}`;
+}
+
+function clampGuard(value: number | null | undefined): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null;
+  return value;
+}
+
+function toSqlUtc(d: Date): string {
+  return d.toISOString().replace('T', ' ').slice(0, 19);
+}
+
+function addDays(d: Date, days: number): Date {
+  return new Date(d.getTime() + days * 86_400_000);
+}

--- a/scripts/init-sanctuary-v2.7.sql
+++ b/scripts/init-sanctuary-v2.7.sql
@@ -1,0 +1,28 @@
+-- Star Sanctuary — V2.7 Schema: Compassionate streak counter
+--
+-- Backs [SWO_V2_SANCTUARY_STREAKS] (PR5 of 7). One row per companion token
+-- holds the rolling daily-visit streak. The streak rules live in pure code
+-- (lib/sanctuary/streaks.ts):
+--
+--   • 1 missed UTC day → pause (current_streak unchanged, paused_since_at set)
+--   • 2+ consecutive missed days → reset current_streak to 1
+--   • longest_streak ratchets upward only — identity over power
+--
+-- Milestones at 7 / 14 / 30 days unlock journal entries (no stat lift). The
+-- highest milestone already reported is tracked on the row so a stat that
+-- wobbles around a threshold cannot retrigger the same journal entry.
+--
+-- Loaded by lib/db.ts initializeSanctuary(). Safe to re-run.
+
+CREATE TABLE IF NOT EXISTS sanctuary_companion_streaks (
+  token_id INTEGER PRIMARY KEY,
+  current_streak INTEGER NOT NULL DEFAULT 0,
+  longest_streak INTEGER NOT NULL DEFAULT 0,
+  last_visit_at DATETIME,
+  paused_since_at DATETIME,
+  last_milestone_reported INTEGER NOT NULL DEFAULT 0,
+  FOREIGN KEY (token_id) REFERENCES star_skrumpey_metadata(token_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_sanctuary_companion_streaks_last_visit
+  ON sanctuary_companion_streaks(last_visit_at);


### PR DESCRIPTION
## Summary
PR5 of 7 for the Sanctuary V2 plan. Lands a **compassionate** daily-visit streak:

- **1 missed UTC day → pauses** the streak (kept at its current value, `paused_since_at` stamped). Returning on the next day resumes it.
- **2+ consecutive missed days → reset** to 1. `longest_streak` is retained — identity is preserved, the climb is not.
- **Milestones at 7 / 14 / 30 days** unlock journal entries (no stat lift). Single-fire — guarded by a watermark so wobbling around a threshold doesn't re-fire.

## Files
- `scripts/init-sanctuary-v2.7.sql` — new table `sanctuary_companion_streaks(token_id, current_streak, longest_streak, last_visit_at, paused_since_at, last_milestone_reported)`.
- `lib/sanctuary/streaks.ts` — pure helpers (`applyVisit`, `utcDayDelta`, `crossedMilestones`, `streakChipLabel`, `streakMilestoneJournal`). No DB / Phaser / React imports.
- `lib/sanctuary/__tests__/streaks.test.ts` — 30 tests including the acceptance triad and a 9-day timeline scenario.
- `components/sanctuary/overlays/CompanionHUD.tsx` — streak chip next to the STAR badge, with a distinct `paused` style. Hides silently if the companion endpoint hasn't been wired up yet (graceful degradation while the API surface follows).
- `lib/db.ts` — loads `init-sanctuary-v2.7.sql` after v2.6.

## Acceptance coverage
- ✅ **1-miss-pauses** — `applyVisit — Acceptance #1`
- ✅ **2-misses-resets** — `applyVisit — Acceptance #2`
- ✅ **milestone fires once** — `applyVisit — Acceptance #3` (lastMilestoneReported guard + wobble case)
- ✅ **9-day timeline w/ one missed day** — `[E2E shape] 9-day timeline` integration test: simulates days 1-7 → skip day 8 → return day 9; asserts streak still active on day 9 and the 7-day journal entry fired exactly once.

## E2E note
Spec calls for a Playwright simulation. Sanctuary has no Playwright config today (`playwright.config.ts` only matches `tests/e2e/casino/*`), so the 9-day timeline is asserted via a vitest integration test that drives the same state machine the UI consumes. A dedicated Playwright sanctuary project is suitable as a follow-up; the pure-module surface keeps it cheap when that arrives.

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS — baseline 36, post-overlay 36, zero new errors
- **vitest run** (streaks.test.ts): PASS — 30/30 in 0.77s
- Mirror restored byte-identical (`git status` clean on PROD).
Overall: PASS

## Test plan
- [x] `npx vitest run lib/sanctuary/__tests__/streaks.test.ts` — 30/30 passing
- [x] `npx vitest run lib/sanctuary/__tests__/` — 756/756 passing (no regressions)
- [x] `npm run type-check` — 36 errors, all pre-existing in `game/scenes/*` and `game/v3/scenes/*` (baseline-diff zero)
- [x] `npx eslint` on changed files — clean
- [x] Mirror baseline-diff (PROD) — zero new tsc/vitest errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)