### PR TITLE
feat(casino): index CasinoBankroll as 4th indexer contract [SWO_CASINO_INDEXER_PORT]

### DIFF
--- a/services/casino-indexer/README.md
+++ b/services/casino-indexer/README.md
@@ -23,9 +23,13 @@ TypeScript so vitest can drive them without a live RPC or Ponder install.
 - **CasinoDice** — `BetPlaced`, `BetSettled`, `BetRefunded`
 - **CasinoHiLo** — `SessionOpened`, `StepPlayed`, `SessionCashedOut`,
   `SessionRefunded`, `SessionPushed`
+- **CasinoBankroll** — `Deposited`, `Withdrawn`, `GamePayout`, `GameSettled`,
+  `CircuitBreakerTripped`, `CircuitBreakerReset` (append-only event log;
+  consumers roll up at query time for the treasury view and
+  `/api/casino/health`).
 
-A fourth contract (slots) is a planned follow-up — slots placement is still
-out-of-protocol, so its handler set will land alongside the on-chain slots
+Slots is intentionally out of scope — slots placement is still off-chain
+in Phase 1, so its handler set will land alongside the on-chain slots
 contract.
 
 ## Environment
@@ -39,6 +43,7 @@ SWO_CHAIN_ID=10143                                     # default; override for a
 SWO_COINFLIP_ADDRESS=0x...
 SWO_DICE_ADDRESS=0x...
 SWO_HILO_ADDRESS=0x...
+SWO_BANKROLL_ADDRESS=0x...
 
 # Optional — speed up reindex on a fresh DB.
 SWO_INDEXER_FROM_BLOCK=0

--- a/services/casino-indexer/__tests__/bankroll-handlers.test.ts
+++ b/services/casino-indexer/__tests__/bankroll-handlers.test.ts
@@ -1,0 +1,146 @@
+// Coverage for CasinoBankroll handlers — one row per event, idempotent on
+// (txHash, logIndex). The handlers are append-only so each test asserts
+// the shape of a single row rather than a state machine.
+
+import { describe, expect, test } from 'vitest';
+
+import { inMemoryBankrollStore } from '../src/bankroll-store';
+import {
+  onCircuitBreakerReset,
+  onCircuitBreakerTripped,
+  onDeposited,
+  onGamePayout,
+  onGameSettled,
+  onWithdrawn,
+} from '../src/bankroll-handlers';
+
+const ALICE = '0x000000000000000000000000000000000000a11c' as const;
+const BOB = '0x000000000000000000000000000000000000b0b0' as const;
+const GAME = '0x000000000000000000000000000000000000bbbb' as const;
+const TX = ('0x' + 'fe'.repeat(32)) as `0x${string}`;
+const TX2 = ('0x' + 'de'.repeat(32)) as `0x${string}`;
+
+describe('CasinoBankroll handlers', () => {
+  test('Deposited writes a deposit row keyed on (txHash, logIndex)', async () => {
+    const store = inMemoryBankrollStore();
+    await onDeposited(
+      store,
+      { from: ALICE, amount: 5_000_000_000_000_000_000n },
+      { blockNumber: 100n, blockTimestamp: 1_700_000_000n, txHash: TX, logIndex: 2 },
+    );
+    const row = await store.get(`${TX}-2`);
+    expect(row).not.toBeNull();
+    expect(row?.kind).toBe('deposit');
+    expect(row?.counterparty).toBe(ALICE);
+    expect(row?.recipient).toBeNull();
+    expect(row?.amount).toBe('5000000000000000000');
+    expect(row?.blockNumber).toBe('100');
+    expect(row?.timestamp).toBe('1700000000');
+    expect(row?.txHash).toBe(TX);
+  });
+
+  test('Withdrawn writes a withdraw row', async () => {
+    const store = inMemoryBankrollStore();
+    await onWithdrawn(
+      store,
+      { to: BOB, amount: 250n },
+      { blockNumber: 101n, blockTimestamp: 1_700_000_010n, txHash: TX, logIndex: 0 },
+    );
+    const row = await store.get(`${TX}-0`);
+    expect(row?.kind).toBe('withdraw');
+    expect(row?.counterparty).toBe(BOB);
+    expect(row?.amount).toBe('250');
+  });
+
+  test('GamePayout captures both game and recipient', async () => {
+    const store = inMemoryBankrollStore();
+    await onGamePayout(
+      store,
+      { game: GAME, recipient: ALICE, amount: 1_960_000_000_000_000n },
+      { blockNumber: 102n, blockTimestamp: 1_700_000_020n, txHash: TX, logIndex: 1 },
+    );
+    const row = await store.get(`${TX}-1`);
+    expect(row?.kind).toBe('gamePayout');
+    expect(row?.counterparty).toBe(GAME);
+    expect(row?.recipient).toBe(ALICE);
+    expect(row?.amount).toBe('1960000000000000');
+  });
+
+  test('GameSettled records the credited stake', async () => {
+    const store = inMemoryBankrollStore();
+    await onGameSettled(
+      store,
+      { game: GAME, amount: 1_000_000_000_000_000n },
+      { blockNumber: 103n, blockTimestamp: 1_700_000_030n, txHash: TX, logIndex: 3 },
+    );
+    const row = await store.get(`${TX}-3`);
+    expect(row?.kind).toBe('gameSettled');
+    expect(row?.counterparty).toBe(GAME);
+    expect(row?.recipient).toBeNull();
+    expect(row?.amount).toBe('1000000000000000');
+  });
+
+  test('CircuitBreakerTripped stores drawdown delta and event timestamp', async () => {
+    const store = inMemoryBankrollStore();
+    await onCircuitBreakerTripped(
+      store,
+      {
+        windowStartBalance: 10_000_000_000_000_000_000n,
+        currentBalance: 6_000_000_000_000_000_000n,
+        maxDrawdown24hWei: 3_000_000_000_000_000_000n,
+        timestamp: 1_700_000_100n,
+      },
+      { blockNumber: 200n, blockTimestamp: 1_700_000_111n, txHash: TX2, logIndex: 0 },
+    );
+    const row = await store.get(`${TX2}-0`);
+    expect(row?.kind).toBe('circuitBreakerTripped');
+    expect(row?.counterparty).toBeNull();
+    expect(row?.recipient).toBeNull();
+    // 10e18 − 6e18 = 4e18 drawdown delta
+    expect(row?.amount).toBe('4000000000000000000');
+    // Prefers event-payload timestamp over the envelope.
+    expect(row?.timestamp).toBe('1700000100');
+  });
+
+  test('CircuitBreakerReset stores currentBalance snapshot', async () => {
+    const store = inMemoryBankrollStore();
+    await onCircuitBreakerReset(
+      store,
+      { currentBalance: 7_500_000_000_000_000_000n, timestamp: 1_700_086_400n },
+      { blockNumber: 250n, blockTimestamp: 1_700_086_500n, txHash: TX2, logIndex: 1 },
+    );
+    const row = await store.get(`${TX2}-1`);
+    expect(row?.kind).toBe('circuitBreakerReset');
+    expect(row?.amount).toBe('7500000000000000000');
+    expect(row?.timestamp).toBe('1700086400');
+  });
+
+  test('list returns rows newest-first', async () => {
+    const store = inMemoryBankrollStore();
+    await onDeposited(
+      store,
+      { from: ALICE, amount: 1n },
+      { blockNumber: 100n, blockTimestamp: 1n, txHash: TX, logIndex: 0 },
+    );
+    await onWithdrawn(
+      store,
+      { to: BOB, amount: 2n },
+      { blockNumber: 200n, blockTimestamp: 2n, txHash: TX2, logIndex: 0 },
+    );
+    const rows = await store.list(10);
+    expect(rows.map((r) => r.kind)).toEqual(['withdraw', 'deposit']);
+  });
+
+  test('replaying the same (txHash, logIndex) is idempotent', async () => {
+    const store = inMemoryBankrollStore();
+    const ev = {
+      blockNumber: 100n,
+      blockTimestamp: 1n,
+      txHash: TX,
+      logIndex: 0,
+    };
+    await onDeposited(store, { from: ALICE, amount: 1n }, ev);
+    await onDeposited(store, { from: ALICE, amount: 1n }, ev);
+    expect(await store.count()).toBe(1);
+  });
+});

--- a/services/casino-indexer/__tests__/ponder-config.test.ts
+++ b/services/casino-indexer/__tests__/ponder-config.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, test } from 'vitest';
 import indexerConfig, {
   MONAD_TESTNET_CHAIN_ID,
   MONAD_TESTNET_DEFAULT_RPC,
+  resolveBankrollAddress,
   resolveChainId,
   resolveRpcUrl,
   resolveStartBlock,
@@ -52,6 +53,7 @@ describe('ponder.config (Monad testnet retarget)', () => {
     expect(Object.keys(indexerConfig.networks)).toEqual(['monadTestnet']);
     expect(indexerConfig.networks.monadTestnet.chainId).toBe(10143);
     expect(Object.keys(indexerConfig.contracts).sort()).toEqual([
+      'CasinoBankroll',
       'CasinoCoinflip',
       'CasinoDice',
       'CasinoHiLo',
@@ -59,5 +61,20 @@ describe('ponder.config (Monad testnet retarget)', () => {
     for (const c of Object.values(indexerConfig.contracts)) {
       expect(c.network).toBe('monadTestnet');
     }
+  });
+
+  test('bankroll address falls through to placeholder and accepts overrides', () => {
+    expect(resolveBankrollAddress({})).toMatch(/^0x[0-9a-fA-F]{40}$/);
+    expect(
+      resolveBankrollAddress({
+        SWO_BANKROLL_ADDRESS: '0x000000000000000000000000000000000000bA17',
+      }),
+    ).toBe('0x000000000000000000000000000000000000bA17');
+    expect(
+      resolveBankrollAddress({
+        BUNNYBAGZ_BANKROLL_ADDRESS:
+          '0x000000000000000000000000000000000000bB18',
+      }),
+    ).toBe('0x000000000000000000000000000000000000bB18');
   });
 });

--- a/services/casino-indexer/abis/CasinoBankroll.ts
+++ b/services/casino-indexer/abis/CasinoBankroll.ts
@@ -1,0 +1,65 @@
+// Minimal ABI for the SWO CasinoBankroll events the indexer cares about.
+//
+// CasinoBankroll is the single shared liquidity pool funding all Cosmic
+// Casino game contracts. We index the events that materially affect
+// bankroll health so /api/casino/health and the public treasury view can
+// reconstruct cash-flow + circuit-breaker state from the indexer alone
+// (no archive RPC required).
+//
+// Hand-curated to avoid pulling Foundry into the indexer build path; see
+// CasinoCoinflip.ts for the rationale. Source contract:
+// contracts/casino/src/CasinoBankroll.sol.
+
+export const BANKROLL_EVENT_ABI = [
+  {
+    type: 'event',
+    name: 'Deposited',
+    inputs: [
+      { name: 'from', type: 'address', indexed: true },
+      { name: 'amount', type: 'uint256', indexed: false },
+    ],
+  },
+  {
+    type: 'event',
+    name: 'Withdrawn',
+    inputs: [
+      { name: 'to', type: 'address', indexed: true },
+      { name: 'amount', type: 'uint256', indexed: false },
+    ],
+  },
+  {
+    type: 'event',
+    name: 'GamePayout',
+    inputs: [
+      { name: 'game', type: 'address', indexed: true },
+      { name: 'recipient', type: 'address', indexed: true },
+      { name: 'amount', type: 'uint256', indexed: false },
+    ],
+  },
+  {
+    type: 'event',
+    name: 'GameSettled',
+    inputs: [
+      { name: 'game', type: 'address', indexed: true },
+      { name: 'amount', type: 'uint256', indexed: false },
+    ],
+  },
+  {
+    type: 'event',
+    name: 'CircuitBreakerTripped',
+    inputs: [
+      { name: 'windowStartBalance', type: 'uint256', indexed: false },
+      { name: 'currentBalance', type: 'uint256', indexed: false },
+      { name: 'maxDrawdown24hWei', type: 'uint256', indexed: false },
+      { name: 'timestamp', type: 'uint256', indexed: false },
+    ],
+  },
+  {
+    type: 'event',
+    name: 'CircuitBreakerReset',
+    inputs: [
+      { name: 'currentBalance', type: 'uint256', indexed: false },
+      { name: 'timestamp', type: 'uint256', indexed: false },
+    ],
+  },
+] as const;

--- a/services/casino-indexer/ponder.config.ts
+++ b/services/casino-indexer/ponder.config.ts
@@ -13,6 +13,7 @@
 
 import type { Address } from 'viem';
 
+import { BANKROLL_EVENT_ABI } from './abis/CasinoBankroll';
 import { COINFLIP_EVENT_ABI } from './abis/CasinoCoinflip';
 import { DICE_EVENT_ABI } from './abis/CasinoDice';
 import { HILO_EVENT_ABI } from './abis/CasinoHiLo';
@@ -71,6 +72,12 @@ export function resolveHiLoAddress(env: EnvBag = process.env): Address {
     PLACEHOLDER) as Address;
 }
 
+export function resolveBankrollAddress(env: EnvBag = process.env): Address {
+  return (env.SWO_BANKROLL_ADDRESS ??
+    env.BUNNYBAGZ_BANKROLL_ADDRESS ??
+    PLACEHOLDER) as Address;
+}
+
 // Plain config object — keeps the file consumable without a Ponder install.
 // When Ponder is added, `ponder.schema.ts` + `createConfig` can wrap this
 // directly: `export default createConfig(indexerConfig)`.
@@ -115,6 +122,20 @@ export const indexerConfig = {
         { event: 'SessionCashedOut' },
         { event: 'SessionRefunded' },
         { event: 'SessionPushed' },
+      ],
+    },
+    CasinoBankroll: {
+      network: 'monadTestnet' as const,
+      abi: BANKROLL_EVENT_ABI,
+      address: resolveBankrollAddress(),
+      startBlock: resolveStartBlock(),
+      filter: [
+        { event: 'Deposited' },
+        { event: 'Withdrawn' },
+        { event: 'GamePayout' },
+        { event: 'GameSettled' },
+        { event: 'CircuitBreakerTripped' },
+        { event: 'CircuitBreakerReset' },
       ],
     },
   },

--- a/services/casino-indexer/schema.graphql
+++ b/services/casino-indexer/schema.graphql
@@ -92,6 +92,32 @@ type HiLoSession @entity {
   stepCount: Int!         # number of StepPlayed events for this session
 }
 
+# Append-only bankroll event log. Each on-chain event (deposit, withdraw,
+# game payout, game settle, circuit-breaker trip/reset) becomes one row,
+# keyed on the composite "<txHash>-<logIndex>" so reorgs are idempotent.
+# Consumers (treasury view, /api/casino/health) roll up at query time.
+type BankrollEvent @entity {
+  id: String!             # "<txHash>-<logIndex>"
+
+  # One of: "deposit" | "withdraw" | "gamePayout" | "gameSettled"
+  #         | "circuitBreakerTripped" | "circuitBreakerReset"
+  kind: String!
+
+  # Depositor / withdrawer / game address; null for circuit-breaker rows.
+  counterparty: String
+
+  # GamePayout recipient (the winning player). Null on all other kinds.
+  recipient: String
+
+  # Wei delta for cash-flow kinds; window-drawdown delta for `circuitBreakerTripped`;
+  # currentBalance snapshot for `circuitBreakerReset`.
+  amount: BigInt!
+
+  blockNumber: BigInt!
+  timestamp: BigInt!      # block timestamp (or event-payload timestamp for breaker rows)
+  txHash: Bytes!          # 0x transaction hash for explorer cross-reference
+}
+
 # Append-only StepPlayed records. `id` is the composite "<sessionId>-<stepIdx>"
 # so the verifier can replay deterministically.
 type HiLoStep @entity {

--- a/services/casino-indexer/src/bankroll-handlers.ts
+++ b/services/casino-indexer/src/bankroll-handlers.ts
@@ -1,0 +1,161 @@
+// Pure event handlers for CasinoBankroll.
+//
+// Append-only translation: each event becomes a row in the bankroll table.
+// The store is runtime-agnostic (see bankroll-store.ts) so vitest can drive
+// the handlers without Ponder + a live RPC.
+
+import type { Address, Hex } from 'viem';
+
+import type { BankrollStore } from './bankroll-store';
+
+export interface BankrollEventEnvelope {
+  blockNumber: bigint;
+  /** Block timestamp; required because bankroll cash-flow is time-series. */
+  blockTimestamp: bigint;
+  txHash: Hex;
+  logIndex: number;
+}
+
+export interface DepositedArgs {
+  from: Address;
+  amount: bigint;
+}
+
+export interface WithdrawnArgs {
+  to: Address;
+  amount: bigint;
+}
+
+export interface GamePayoutArgs {
+  game: Address;
+  recipient: Address;
+  amount: bigint;
+}
+
+export interface GameSettledArgs {
+  game: Address;
+  amount: bigint;
+}
+
+export interface CircuitBreakerTrippedArgs {
+  windowStartBalance: bigint;
+  currentBalance: bigint;
+  maxDrawdown24hWei: bigint;
+  timestamp: bigint;
+}
+
+export interface CircuitBreakerResetArgs {
+  currentBalance: bigint;
+  timestamp: bigint;
+}
+
+function rowId(ev: BankrollEventEnvelope): string {
+  return `${ev.txHash}-${ev.logIndex}`;
+}
+
+export async function onDeposited(
+  store: BankrollStore,
+  args: DepositedArgs,
+  ev: BankrollEventEnvelope,
+): Promise<void> {
+  await store.create({
+    id: rowId(ev),
+    kind: 'deposit',
+    counterparty: args.from,
+    recipient: null,
+    amount: args.amount.toString(),
+    blockNumber: ev.blockNumber.toString(),
+    timestamp: ev.blockTimestamp.toString(),
+    txHash: ev.txHash,
+  });
+}
+
+export async function onWithdrawn(
+  store: BankrollStore,
+  args: WithdrawnArgs,
+  ev: BankrollEventEnvelope,
+): Promise<void> {
+  await store.create({
+    id: rowId(ev),
+    kind: 'withdraw',
+    counterparty: args.to,
+    recipient: null,
+    amount: args.amount.toString(),
+    blockNumber: ev.blockNumber.toString(),
+    timestamp: ev.blockTimestamp.toString(),
+    txHash: ev.txHash,
+  });
+}
+
+export async function onGamePayout(
+  store: BankrollStore,
+  args: GamePayoutArgs,
+  ev: BankrollEventEnvelope,
+): Promise<void> {
+  await store.create({
+    id: rowId(ev),
+    kind: 'gamePayout',
+    counterparty: args.game,
+    recipient: args.recipient,
+    amount: args.amount.toString(),
+    blockNumber: ev.blockNumber.toString(),
+    timestamp: ev.blockTimestamp.toString(),
+    txHash: ev.txHash,
+  });
+}
+
+export async function onGameSettled(
+  store: BankrollStore,
+  args: GameSettledArgs,
+  ev: BankrollEventEnvelope,
+): Promise<void> {
+  await store.create({
+    id: rowId(ev),
+    kind: 'gameSettled',
+    counterparty: args.game,
+    recipient: null,
+    amount: args.amount.toString(),
+    blockNumber: ev.blockNumber.toString(),
+    timestamp: ev.blockTimestamp.toString(),
+    txHash: ev.txHash,
+  });
+}
+
+export async function onCircuitBreakerTripped(
+  store: BankrollStore,
+  args: CircuitBreakerTrippedArgs,
+  ev: BankrollEventEnvelope,
+): Promise<void> {
+  await store.create({
+    id: rowId(ev),
+    kind: 'circuitBreakerTripped',
+    counterparty: null,
+    recipient: null,
+    // Repurpose `amount` as the drawdown delta — windowStart minus current.
+    // Treasury consumers can read `windowStartBalance - currentBalance` to
+    // see how much was lost in the rolling window.
+    amount: (args.windowStartBalance - args.currentBalance).toString(),
+    blockNumber: ev.blockNumber.toString(),
+    // Event payload carries its own timestamp; prefer it over the envelope
+    // because the contract captures `block.timestamp` at the trip site.
+    timestamp: args.timestamp.toString(),
+    txHash: ev.txHash,
+  });
+}
+
+export async function onCircuitBreakerReset(
+  store: BankrollStore,
+  args: CircuitBreakerResetArgs,
+  ev: BankrollEventEnvelope,
+): Promise<void> {
+  await store.create({
+    id: rowId(ev),
+    kind: 'circuitBreakerReset',
+    counterparty: null,
+    recipient: null,
+    amount: args.currentBalance.toString(),
+    blockNumber: ev.blockNumber.toString(),
+    timestamp: args.timestamp.toString(),
+    txHash: ev.txHash,
+  });
+}

--- a/services/casino-indexer/src/bankroll-store.ts
+++ b/services/casino-indexer/src/bankroll-store.ts
@@ -1,0 +1,70 @@
+// Persistence abstraction for the bankroll event log.
+//
+// Unlike the game tables (one row per bet, updated on settle), the bankroll
+// table is append-only: every event is a row. This keeps the schema simple
+// (no state machine to reconcile) and lets the public treasury view do its
+// own roll-up at query time.
+//
+// Schema-of-record: `BankrollEvent` in `schema.graphql`.
+
+import type { Address } from 'viem';
+
+export type BankrollEventKind =
+  | 'deposit'
+  | 'withdraw'
+  | 'gamePayout'
+  | 'gameSettled'
+  | 'circuitBreakerTripped'
+  | 'circuitBreakerReset';
+
+export interface BankrollEventRow {
+  /** Composite id: "<txHash>-<logIndex>" — keeps the row idempotent under reorgs. */
+  id: string;
+  kind: BankrollEventKind;
+  /** Counterparty address (depositor / withdrawer / game / recipient). May be zero for breaker events. */
+  counterparty: Address | null;
+  /** For GamePayout, the player who received the funds (game is `counterparty`). */
+  recipient: Address | null;
+  /** Wei delta for cash-flow events; 0 for breaker rows. */
+  amount: string;
+  /** Block number the log was mined in. */
+  blockNumber: string;
+  /** Unix timestamp captured from the log envelope (or breaker event payload). */
+  timestamp: string;
+  /** Originating transaction hash for explorer cross-reference. */
+  txHash: string;
+}
+
+export interface BankrollStore {
+  create(row: BankrollEventRow): Promise<void>;
+  list(limit: number): Promise<BankrollEventRow[]>;
+  get(id: string): Promise<BankrollEventRow | null>;
+  count(): Promise<number>;
+}
+
+export function inMemoryBankrollStore(): BankrollStore {
+  const rows = new Map<string, BankrollEventRow>();
+  return {
+    async create(row) {
+      // Idempotent on (txHash, logIndex): re-running the indexer on a reorg
+      // should not duplicate rows. Last write wins on the same composite id.
+      rows.set(row.id, { ...row });
+    },
+    async list(limit) {
+      const all = Array.from(rows.values());
+      all.sort((a, b) => {
+        const aBlk = BigInt(a.blockNumber);
+        const bBlk = BigInt(b.blockNumber);
+        if (aBlk !== bBlk) return aBlk > bBlk ? -1 : 1;
+        return a.id < b.id ? 1 : -1;
+      });
+      return all.slice(0, limit);
+    },
+    async get(id) {
+      return rows.get(id) ?? null;
+    },
+    async count() {
+      return rows.size;
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Adds the CasinoBankroll event surface (Deposited, Withdrawn, GamePayout, GameSettled, CircuitBreakerTripped, CircuitBreakerReset) to the Ponder indexer at `services/casino-indexer/`.
- Closes the acceptance gap from PR #322 where the indexer only covered the three game contracts. The existing `ponder-config.test.ts` assertion "the four casino contracts on monadTestnet" now matches its description (was previously only checking three).
- Handlers are append-only (one row per event, keyed on `<txHash>-<logIndex>` for reorg idempotency) — no state machine to reconcile; treasury view and `/api/casino/health` roll up at query time.

## Files
- `abis/CasinoBankroll.ts` — hand-curated event ABI (matches `contracts/casino/src/CasinoBankroll.sol`).
- `src/bankroll-store.ts` — append-only store + `inMemoryBankrollStore()` for tests.
- `src/bankroll-handlers.ts` — pure handlers (runtime-agnostic; vitest-drivable).
- `schema.graphql` — new `BankrollEvent` entity (string `kind` discriminator + bigint amount/timestamp + bytes txHash).
- `ponder.config.ts` — registers `CasinoBankroll` on `monadTestnet` with the 6 event filters; `resolveBankrollAddress` falls through `SWO_BANKROLL_ADDRESS` → `BUNNYBAGZ_BANKROLL_ADDRESS` → placeholder.
- `__tests__/bankroll-handlers.test.ts` — 9 new tests (one per event + list ordering + idempotency).
- `__tests__/ponder-config.test.ts` — assertion now lists 4 contracts; adds bankroll address env-cascade coverage.
- `README.md` — updated indexed-contracts list + env section.

## Original task linkage
- `Original task:` [SWO_CASINO_INDEXER_PORT] Port `mega-house/apps/indexer/...` to `services/casino-indexer/`. Acceptance (b): indexes the 4 contracts.
- Prior PR #322 (merged 2026-05-19) landed the indexer scaffold with 3 game contracts; PR #335 wired `RecentBets` to the GraphQL endpoint. This PR closes acceptance (b)'s "4 contracts" gap.

## Test plan
- [x] `npx vitest run services/casino-indexer/__tests__` — 33 passing (was 24; +9 from bankroll-handlers).
- [x] `npm run type-check` — 36 errors, all pre-existing in `game/scenes/*` and `game/v3/scenes/*`; none introduced by this change.
- [x] `npm run lint` — no new lint issues in the touched files.

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS (36 pre-existing errors excluded; 0 new errors)
- **vitest run services/casino-indexer/__tests__**: PASS (33 tests, was 24 baseline)
- PROD mirror restored byte-identical after overlay.
Overall: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)