### PR TITLE
fix(sanctuary): stop rooms insta-exiting + use polished interior art

### DIFF
--- a/game/scenes/BootScene.ts
+++ b/game/scenes/BootScene.ts
@@ -19,7 +19,12 @@ export class BootScene extends Phaser.Scene {
     this.load.image('player-sheet', '/sanctuary/Male_Grey_Sprite_transparent.png');
 
     for (const room of ROOMS) {
-      this.load.image(`room-bg-${room}`, `/sanctuary/${encodeURI(room)}.png`);
+      // Polished interior art lives under /sanctuary-v3/interiors as the
+      // kebab-case of the room key (e.g. "Aura Forge" -> "aura-forge.png").
+      // These replaced the earlier flat /sanctuary/{Room}.png backgrounds,
+      // which rendered with washed-out / inverted-looking colors.
+      const slug = room.toLowerCase().replace(/\s+/g, '-');
+      this.load.image(`room-bg-${room}`, `/sanctuary-v3/interiors/${slug}.png`);
     }
 
     for (const def of NPC_DEFINITIONS) {

--- a/game/scenes/RoomScene.ts
+++ b/game/scenes/RoomScene.ts
@@ -11,7 +11,9 @@ import { getRoomNPCDefinitions } from '../config/npcDefinitions';
 
 const ROOM_W = 1448;
 const ROOM_H = 1086;
-const SOUTHERN_SPAWN_Y = ROOM_H - 60;
+// Spawn well clear of the southern exit zone (at the very bottom edge) so the
+// player's feet-anchored physics body does not start inside it.
+const SOUTHERN_SPAWN_Y = ROOM_H - 180;
 const EXIT_ZONE_W = 120;
 const EXIT_ZONE_H = 30;
 // Ignore exit triggers (E, ESC, exit-zone overlap) for this many ms after entry,
@@ -32,6 +34,10 @@ export class RoomScene extends Phaser.Scene {
   private clickMarker: Phaser.GameObjects.Graphics | null = null;
   private exiting = false;
   private exitArmedAt = 0;
+  private exitZone!: Phaser.GameObjects.Zone;
+  // The exit zone only fires once the player has been clear of it at least
+  // once after entry — prevents the southern spawn from instantly re-exiting.
+  private exitZoneArmed = false;
   private npcManager: NPCManager | null = null;
 
   constructor() {
@@ -43,6 +49,7 @@ export class RoomScene extends Phaser.Scene {
     this.returnTo = data.returnTo;
     this.exiting = false;
     this.exitArmedAt = this.time.now + EXIT_GRACE_MS;
+    this.exitZoneArmed = false;
 
     const bgKey = `room-bg-${this.room}`;
     const bg = this.textures.exists(bgKey)
@@ -225,7 +232,10 @@ export class RoomScene extends Phaser.Scene {
     const zoneCenterY = ROOM_H - EXIT_ZONE_H / 2;
     const zone = this.add.zone(zoneCenterX, zoneCenterY, EXIT_ZONE_W, EXIT_ZONE_H);
     this.physics.add.existing(zone, true);
-    this.physics.add.overlap(this.player, zone, () => this.exit());
+    this.exitZone = zone;
+    this.physics.add.overlap(this.player, zone, () => {
+      if (this.exitZoneArmed) this.exit();
+    });
 
     const hint = this.add
       .text(zoneCenterX, zoneCenterY - 28, '[E] EXIT', {
@@ -267,6 +277,16 @@ export class RoomScene extends Phaser.Scene {
 
   update() {
     if (!this.player || this.exiting) return;
+    // Arm the exit zone only after the entry grace has passed AND the player
+    // is clear of it, so spawning near the southern exit can't kick them out.
+    if (
+      !this.exitZoneArmed &&
+      this.exitZone &&
+      this.time.now >= this.exitArmedAt &&
+      !this.physics.overlap(this.player, this.exitZone)
+    ) {
+      this.exitZoneArmed = true;
+    }
     const keyboardActive = this.player.handleKeyboardInput();
     if (!keyboardActive) this.player.updatePathMovement();
     this.companion.followPlayer(this.player.x, this.player.y, this.player.getDirection());


### PR DESCRIPTION
Two bugs in the V2 world hub (`game/scenes/`), surfaced now that the V2 consolidation (#357) made the world hub the canonical explore mode.

## 1. Rooms insta-exit on entry
Player spawns at the southern edge and its physics body is anchored at the feet (`PlayerSprite` `setOffset(35,190)`), so it starts **inside** the bottom exit zone. Once the 700ms entry grace elapses, the overlap fires `exit()` immediately → you get kicked back to the map.

**Fix:** exit zone is now **armed-on-leave** (only triggers after the player has been clear of it once post-entry), and the spawn is moved up (`ROOM_H-180`) so you start well inside the room.

## 2. "Inverted/horrendous" room colors
`BootScene` loaded the old flat `/sanctuary/{Room}.png` art. Switched to the **polished interiors** at `/sanctuary-v3/interiors/{kebab}.png` — all 8 rooms map 1:1 and the assets are already in `public/` (kept during the consolidation). These are the "better images" that existed.

## Verification
- type-check unchanged at 18 (all pre-existing `game/scenes` EventBus 3-arg errors; **none new**).
- All 8 interior assets serve `200` on 3081.
- Room transition + visuals to be confirmed visually on `test.starworldorder.com/sanctuary?world=1`.

## ⚠️ Separate finding (not fixed here): the gacha shop has no in-world entry point
`ShopDialog` only opens for NPC ids `npc-shopkeeper`/`shop-keeper`/`npc-shop` (or the `shop-overlay-open` event) — **none of those NPCs exist** in `npcDefinitions.ts`, and only the E2E harness emits the event. So the cosmetic shop (PR6) is built + mounted but **unreachable by players**. Needs a shopkeeper NPC added (sprite + room placement) or a HUD button. Flagging for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)