### PR TITLE
feat(casino): Cloudflare WAF edge layer for /casino/* geo blocklist [SWO_CASINO_GEO_BLOCKLIST]

### DIFF
--- a/docs/casino/CASINO_GEO_WAF.md
+++ b/docs/casino/CASINO_GEO_WAF.md
@@ -1,0 +1,126 @@
+# Casino geo blocklist — Cloudflare WAF (edge layer)
+
+> Task: `[SWO_CASINO_GEO_BLOCKLIST]` (G3) — OFAC + 9-country block at the
+> `/casino/*` route layer **+ Cloudflare WAF**. This doc covers the WAF
+> (edge) half. The application (route) half is the Next.js middleware in
+> [`middleware.ts`](../../middleware.ts).
+
+## Why two layers
+
+The blocklist is enforced in **two independent places** (defense in depth):
+
+| Layer | Where it runs | What it catches |
+|-------|---------------|-----------------|
+| **Application** — `middleware.ts` + `lib/casino/geo.ts` | Origin / Vercel edge function | Normal traffic; renders `/region-not-supported` copy. |
+| **Network** — Cloudflare WAF custom rule (this doc) | Cloudflare CDN, before the origin | Drops blocked regions at the edge so a misconfigured rewrite, a cold-started middleware, or a direct-to-origin request can't slip a blocked jurisdiction through. |
+
+Both layers read the **same** `BLOCKED_COUNTRIES` set in
+[`lib/casino/geo.ts`](../../lib/casino/geo.ts). The WAF rule is **generated**
+from that set — it is never hand-maintained — so the edge can't silently drift
+from the in-app blocklist. A test
+(`lib/casino/__tests__/geo.test.ts` → "Cloudflare WAF rule") asserts the
+generated rule covers every blocked country and nothing else.
+
+## The blocklist
+
+14 jurisdictions, carried over verbatim from the BunnyBagz reference:
+
+- **9 licensed/regulated** (we don't hold a local licence): `US GB FR IT ES NL SG AU IL`
+- **5 OFAC-sanctioned** (review quarterly): `IR KP SY CU RU`
+
+`UNKNOWN` (CDN couldn't resolve a country) is intentionally **allowed** — we
+log a false-negative rather than 403 a legit player whose request wasn't tagged.
+
+## Regenerating the rule
+
+The blocklist lives in code. Whenever it changes, regenerate:
+
+```sh
+npm run casino:waf-rule              # human-readable summary
+npm run casino:waf-rule -- --expr        # bare filter expression
+npm run casino:waf-rule -- --terraform   # cloudflare_ruleset resource
+npm run casino:waf-rule -- --json        # Rulesets API request body
+```
+
+Current filter expression (Cloudflare Rules language):
+
+```
+(http.request.uri.path matches "^/casino(/|$)") and (ip.geoip.country in {"AU" "CU" "ES" "FR" "GB" "IL" "IR" "IT" "KP" "NL" "RU" "SG" "SY" "US"})
+```
+
+`ip.geoip.country` is Cloudflare's edge-resolved ISO-3166-1 alpha-2 code — the
+same value Cloudflare forwards to the origin as the `cf-ipcountry` header that
+`countryFromHeaders()` reads. The path is anchored so `/casino` and
+`/casino/<game>` match but `/casinox` does not.
+
+## Deploying the rule
+
+### Option A — Dashboard
+
+1. Cloudflare dashboard → your zone → **Security → WAF → Custom rules**.
+2. **Create rule** → name `SWO casino geo blocklist`.
+3. Switch the expression builder to **Edit expression** and paste the filter
+   expression above (regenerate with `--expr` if the blocklist changed).
+4. Action: **Block**. Deploy.
+
+### Option B — Terraform (recommended; matches the rest of infra-as-code)
+
+```sh
+npm run casino:waf-rule -- --terraform
+```
+
+produces a `cloudflare_ruleset` resource for the
+`http_request_firewall_custom` phase. Commit it to the infra repo and
+`terraform apply`. Example shape:
+
+```hcl
+resource "cloudflare_ruleset" "casino_geo_block" {
+  zone_id     = var.cloudflare_zone_id
+  name        = "SWO casino geo blocklist"
+  description = "OFAC + 9 licensed jurisdictions blocked at the edge for /casino/*"
+  kind        = "zone"
+  phase       = "http_request_firewall_custom"
+
+  rules {
+    action      = "block"
+    description = "SWO casino geo blocklist (OFAC + 9 licensed jurisdictions)"
+    expression  = "..."   # from --terraform / --expr
+    enabled     = true
+  }
+}
+```
+
+### Option C — Rulesets API
+
+```sh
+ZONE_ID=...   # Cloudflare zone id
+CF_TOKEN=...  # API token with Zone WAF:Edit
+
+npm run casino:waf-rule -- --json > /tmp/casino-waf.json
+
+curl -sS -X PUT \
+  "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/rulesets/phases/http_request_firewall_custom/entrypoint" \
+  -H "Authorization: Bearer $CF_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data @/tmp/casino-waf.json
+```
+
+## Soft-launch / counsel gate
+
+The **application** layer ships in `log` mode by default and only enforces
+when an operator sets `SWO_CASINO_GEO_MODE=enforce` after counsel signs off on
+the current blocklist (see the header note in `lib/casino/geo.ts`).
+
+The **WAF** rule has no `log` mode of its own — deploying it with action
+`block` enforces immediately at the edge. Before enabling it in production:
+
+1. Confirm the blocklist is current and counsel-reviewed (same gate as the app
+   layer).
+2. Optionally stage with action **Log** first to observe match volume in the
+   Cloudflare Security Events dashboard, then flip to **Block**.
+
+## Keeping the two layers in sync
+
+- Edit the blocklist **only** in `lib/casino/geo.ts` (`BLOCKED_COUNTRIES`).
+- Re-run `npm run casino:waf-rule -- --terraform` (or `--json`) and redeploy.
+- `npm run test` fails if the generated WAF rule and the blocklist diverge.

--- a/lib/casino/__tests__/geo.test.ts
+++ b/lib/casino/__tests__/geo.test.ts
@@ -25,12 +25,16 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
   BLOCKED_COUNTRIES,
+  blockedCountryList,
+  casinoWafExpression,
+  casinoWafRule,
   countryFromHeaders,
   decide,
   geoGuard,
   isBlockedCountry,
   modeFromEnv,
   normalizeCountry,
+  WAF_CASINO_PATH_PREFIX,
 } from '../geo';
 
 function makeRequest(
@@ -257,6 +261,50 @@ describe('geo blocklist', () => {
       const blocked = geoGuard(makeRequest('US'));
       expect(blocked).not.toBeNull();
       expect(blocked!.status).toBe(403);
+    });
+  });
+
+  describe('Cloudflare WAF rule (edge layer)', () => {
+    it('blockedCountryList() returns every blocked country, sorted + deduped', () => {
+      const list = blockedCountryList();
+      // Same membership as the source-of-truth set (no drift).
+      expect(new Set(list)).toEqual(BLOCKED_COUNTRIES);
+      // Sorted ascending for deterministic WAF output.
+      expect(list).toEqual([...list].sort());
+      // No duplicates.
+      expect(list.length).toBe(new Set(list).size);
+      expect(list.length).toBe(BLOCKED_COUNTRIES.size);
+    });
+
+    it('casinoWafExpression() includes every blocked country code', () => {
+      const expr = casinoWafExpression();
+      for (const cc of BLOCKED_COUNTRIES) {
+        expect(expr).toContain(`"${cc}"`);
+      }
+    });
+
+    it('casinoWafExpression() scopes to the /casino path prefix only', () => {
+      const expr = casinoWafExpression();
+      expect(WAF_CASINO_PATH_PREFIX).toBe('/casino');
+      expect(expr).toContain(
+        `http.request.uri.path matches "^${WAF_CASINO_PATH_PREFIX}(/|$)"`,
+      );
+      expect(expr).toContain('ip.geoip.country in {');
+      expect(expr).toContain(') and (');
+    });
+
+    it('casinoWafExpression() does not list neutral jurisdictions', () => {
+      const expr = casinoWafExpression();
+      for (const cc of ['DE', 'JP', 'BR', 'CA', 'CH']) {
+        expect(expr).not.toContain(`"${cc}"`);
+      }
+    });
+
+    it('casinoWafRule() is a blocking rule mirroring the expression', () => {
+      const rule = casinoWafRule();
+      expect(rule.action).toBe('block');
+      expect(rule.expression).toBe(casinoWafExpression());
+      expect(rule.description).toMatch(/OFAC/);
     });
   });
 });

--- a/lib/casino/geo.ts
+++ b/lib/casino/geo.ts
@@ -153,3 +153,66 @@ export function geoGuard(req: Request): Response | null {
 
 export const GEO_BLOCKED_HEADER = 'x-swo-geo-blocked';
 export const GEO_COUNTRY_HEADER = 'x-swo-geo-country';
+
+// --- Edge (Cloudflare WAF) layer -------------------------------------------
+//
+// Defense-in-depth. The Next.js middleware above is the *application* line of
+// defence (it runs at the origin / Vercel edge fn). The Cloudflare WAF rule
+// below is the *network* line of defence: it drops blocked-jurisdiction
+// traffic at the CDN before it ever reaches our origin, so a misconfigured
+// rewrite, a cold-started middleware, or a direct-to-origin request can't slip
+// a blocked region through. Both layers read the SAME `BLOCKED_COUNTRIES` set
+// here, so the edge rule can never silently drift from the in-app blocklist —
+// `scripts/casino/print-waf-rule.ts` regenerates the rule from this module and
+// the geo test asserts the two stay in sync.
+
+/** URI path prefix the WAF rule scopes to — mirrors the middleware matcher. */
+export const WAF_CASINO_PATH_PREFIX = '/casino';
+
+/**
+ * Blocked ISO-3166-1 alpha-2 codes as a sorted, deduped array. The `Set`
+ * iteration order is insertion-driven; sorting makes the generated WAF
+ * expression deterministic (stable diffs, stable test snapshots).
+ */
+export function blockedCountryList(): string[] {
+  return [...BLOCKED_COUNTRIES].sort();
+}
+
+/**
+ * Build the Cloudflare WAF custom-rule filter expression from the blocklist.
+ * Uses the Cloudflare Rules language: `ip.geoip.country` is the edge-resolved
+ * alpha-2 code (the same value Cloudflare forwards as `cf-ipcountry`), and the
+ * path is matched with an RE2 anchor so `/casino` and `/casino/<game>` match
+ * but `/casinox` does not.
+ *
+ * Example:
+ *   (http.request.uri.path matches "^/casino(/|$)") and
+ *   (ip.geoip.country in {"AU" "CU" "ES" ...})
+ */
+export function casinoWafExpression(): string {
+  const countries = blockedCountryList()
+    .map((cc) => `"${cc}"`)
+    .join(' ');
+  const pathMatch = `(http.request.uri.path matches "^${WAF_CASINO_PATH_PREFIX}(/|$)")`;
+  const countryMatch = `(ip.geoip.country in {${countries}})`;
+  return `${pathMatch} and ${countryMatch}`;
+}
+
+export interface CasinoWafRule {
+  description: string;
+  expression: string;
+  action: 'block';
+}
+
+/**
+ * The full Cloudflare WAF custom rule object. Shape mirrors the
+ * `cloudflare_ruleset` Terraform `rules[]` entry and the Rulesets API
+ * `PUT /rulesets/{id}` payload — see `docs/casino/CASINO_GEO_WAF.md`.
+ */
+export function casinoWafRule(): CasinoWafRule {
+  return {
+    description: 'SWO casino geo blocklist (OFAC + 9 licensed jurisdictions)',
+    expression: casinoWafExpression(),
+    action: 'block',
+  };
+}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:e2e:install": "playwright install --with-deps chromium",
     "compile": "node scripts/compile-contracts.js",
     "test:network": "node scripts/test-connection.js",
+    "casino:waf-rule": "npx tsx scripts/casino/print-waf-rule.ts",
     "db:init": "mkdir -p data && sqlite3 data/swo.db < scripts/init-db.sql",
     "db:fetch-metadata": "npx tsx scripts/fetch-metadata-to-db.ts",
     "colyseus:start": "npx tsx server/colyseus/index.ts",

--- a/scripts/casino/print-waf-rule.ts
+++ b/scripts/casino/print-waf-rule.ts
@@ -1,0 +1,90 @@
+/**
+ * Print the Cloudflare WAF custom rule for the `/casino/*` geo blocklist.
+ *
+ * Single source of truth: the rule is generated from `BLOCKED_COUNTRIES` in
+ * `lib/casino/geo.ts`, the same set the Next.js middleware enforces. Run this
+ * whenever the blocklist changes and paste the output into the Cloudflare
+ * dashboard / Terraform / Rulesets API as documented in
+ * `docs/casino/CASINO_GEO_WAF.md`.
+ *
+ *   npx tsx scripts/casino/print-waf-rule.ts            # human-readable
+ *   npx tsx scripts/casino/print-waf-rule.ts --expr     # bare expression
+ *   npx tsx scripts/casino/print-waf-rule.ts --terraform # cloudflare_ruleset
+ *   npx tsx scripts/casino/print-waf-rule.ts --json      # Rulesets API body
+ */
+
+import {
+  blockedCountryList,
+  casinoWafExpression,
+  casinoWafRule,
+} from '../../lib/casino/geo';
+
+function terraform(): string {
+  const rule = casinoWafRule();
+  return [
+    'resource "cloudflare_ruleset" "casino_geo_block" {',
+    '  zone_id     = var.cloudflare_zone_id',
+    '  name        = "SWO casino geo blocklist"',
+    '  description = "OFAC + 9 licensed jurisdictions blocked at the edge for /casino/*"',
+    '  kind        = "zone"',
+    '  phase       = "http_request_firewall_custom"',
+    '',
+    '  rules {',
+    `    action      = "${rule.action}"`,
+    `    description = "${rule.description}"`,
+    `    expression  = ${JSON.stringify(rule.expression)}`,
+    '    enabled     = true',
+    '  }',
+    '}',
+  ].join('\n');
+}
+
+function apiJson(): string {
+  const rule = casinoWafRule();
+  return JSON.stringify(
+    {
+      name: 'SWO casino geo blocklist',
+      kind: 'zone',
+      phase: 'http_request_firewall_custom',
+      rules: [
+        {
+          action: rule.action,
+          description: rule.description,
+          expression: rule.expression,
+          enabled: true,
+        },
+      ],
+    },
+    null,
+    2,
+  );
+}
+
+function main(): void {
+  const arg = process.argv[2];
+  switch (arg) {
+    case '--expr':
+      console.log(casinoWafExpression());
+      return;
+    case '--terraform':
+      console.log(terraform());
+      return;
+    case '--json':
+      console.log(apiJson());
+      return;
+    default: {
+      const list = blockedCountryList();
+      console.log('Cloudflare WAF custom rule — /casino/* geo blocklist');
+      console.log('='.repeat(56));
+      console.log(`Blocked countries (${list.length}): ${list.join(', ')}`);
+      console.log('');
+      console.log('Filter expression:');
+      console.log(`  ${casinoWafExpression()}`);
+      console.log('Action: block');
+      console.log('');
+      console.log('Flags: --expr | --terraform | --json');
+    }
+  }
+}
+
+main();


### PR DESCRIPTION
## Task
`[SWO_CASINO_GEO_BLOCKLIST]` (G3) — OFAC + 9-country block at the `/casino/*` route layer **+ Cloudflare WAF (or chosen edge)**.

## What was already done vs. this PR
The **application / route layer** (Next.js `middleware.ts` + `lib/casino/geo.ts` + `/region-not-supported`) was implemented and merged earlier in `7aaa241`. The remaining, undelivered half of G3 was the **"+ Cloudflare WAF"** edge layer — there was no edge ruleset anywhere in the repo. This PR adds it.

## Defense in depth
Two independent enforcement layers, both reading the **same** `BLOCKED_COUNTRIES` set:
- **Application** (already merged): origin/Vercel middleware → renders `/region-not-supported`.
- **Network** (this PR): Cloudflare WAF custom rule drops blocked jurisdictions at the CDN before they reach the origin, covering misconfigured rewrites, cold-started middleware, and direct-to-origin requests.

The WAF rule is **generated** from `BLOCKED_COUNTRIES`, never hand-maintained, so the edge can't silently drift from the in-app blocklist. A test enforces the sync.

## Changes
- `lib/casino/geo.ts`: `casinoWafExpression()`, `casinoWafRule()`, `blockedCountryList()`, `WAF_CASINO_PATH_PREFIX` — build the Cloudflare Rules-language filter `(http.request.uri.path matches "^/casino(/|$)") and (ip.geoip.country in {...})`.
- `scripts/casino/print-waf-rule.ts` + `npm run casino:waf-rule`: regenerate the bare expression / `cloudflare_ruleset` Terraform / Rulesets API JSON.
- `docs/casino/CASINO_GEO_WAF.md`: operator runbook (dashboard / Terraform / API deploy steps, counsel gate, sync procedure).
- `lib/casino/__tests__/geo.test.ts`: +5 drift-guard tests (covers every blocked country, scopes to `/casino`, excludes neutral jurisdictions, stays in sync with `BLOCKED_COUNTRIES`).

## Blocklist (unchanged, 14 jurisdictions, carried over verbatim from BB)
- 9 licensed: `US GB FR IT ES NL SG AU IL`
- 5 OFAC: `IR KP SY CU RU`

## Validation
- `npx vitest run lib/casino/__tests__/geo.test.ts` → **29 passed** (24 prior + 5 new).
- Full `npx vitest run` → 1229 passed; 1 pre-existing failure in `game/__tests__/roomScene.test.ts` (unrelated to this change, untouched files).
- `npx tsc --noEmit` → no new errors in changed files (pre-existing errors confined to `game/scenes/*`).
- `npx eslint` on changed files → clean.

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS — baseline 18 errors, post-overlay 18 errors (zero new; pre-existing excluded)
- **vitest run (geo)**: PASS — baseline 24, post-overlay 29 (+5 new passing)
- Mirror restored byte-identical (new files removed, originals restored).
Overall: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)