### PR TITLE
feat(casino): /responsible-gaming page + lobby footer link [SWO_CASINO_RESPONSIBLE_GAMING_PAGE]

### DIFF
--- a/app/casino/CasinoContent.tsx
+++ b/app/casino/CasinoContent.tsx
@@ -463,6 +463,20 @@ export default function CasinoContent() {
             </div>
           </div>
         </CasinoAccessGate>
+
+        {/* Casino Footer */}
+        <footer className="mt-10 pt-6 border-t border-[#2a2a4e] text-center">
+          <p className="text-gray-500 text-[10px] mb-2 tracking-wider">
+            ✦ 18+ ONLY · PLAY RESPONSIBLY ✦
+          </p>
+          <Link
+            href="/casino/responsible-gaming"
+            className="text-[#9966ff] hover:text-[#ff00ff] text-xs underline transition-colors"
+            data-testid="casino-footer-responsible-gaming-link"
+          >
+            Responsible Gaming
+          </Link>
+        </footer>
       </div>
 
       {/* CSS Animations */}

--- a/app/casino/responsible-gaming/__tests__/page.test.tsx
+++ b/app/casino/responsible-gaming/__tests__/page.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment happy-dom
+//
+// Acceptance test for [SWO_CASINO_RESPONSIBLE_GAMING_PAGE] (G4), ported
+// from the BunnyBagz [BB_PHASE3_LEGAL_PAGES] /responsible-gaming suite
+// and adapted to the SWO casino test harness (raw `react-dom/client` +
+// happy-dom; SWO does not ship @testing-library). Covers:
+//   (a) routing entry point + key copy,
+//   (b) the three required link/guidance touchpoints (BeGambleAware,
+//       in-app self-exclusion channel, session-time-limit guidance),
+//   (e) the draft / counsel-review ribbon,
+//   (UX) heading hierarchy + safe rel attrs on the external link.
+
+import React from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import ResponsibleGamingPage, {
+  BEGAMBLEAWARE_URL,
+  RG_LAST_UPDATED,
+  SELF_EXCLUSION_EMAIL,
+  SESSION_LIMIT_DEFAULT_MINUTES,
+} from '../page';
+
+(
+  globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLElement;
+let root: Root;
+
+function render(node: React.ReactElement) {
+  act(() => {
+    root.render(node);
+  });
+}
+
+function byTestId(id: string): HTMLElement {
+  const el = container.querySelector<HTMLElement>(`[data-testid="${id}"]`);
+  if (!el) throw new Error(`no element with data-testid="${id}"`);
+  return el;
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+describe('/casino/responsible-gaming — routing + key copy', () => {
+  it('renders the page title and key copy', () => {
+    render(<ResponsibleGamingPage />);
+    expect(byTestId('responsible-gaming-page-title').textContent).toBe(
+      'Responsible gaming',
+    );
+    expect(byTestId('responsible-gaming-page-body').textContent).toMatch(
+      /entertainment with a transparent house edge/i,
+    );
+    expect(
+      byTestId('responsible-gaming-last-updated').textContent ?? '',
+    ).toContain(RG_LAST_UPDATED);
+  });
+});
+
+describe('/casino/responsible-gaming — acceptance (b) link/guidance touchpoints', () => {
+  it('links BeGambleAware.org as an external resource with safe rel attrs', () => {
+    render(<ResponsibleGamingPage />);
+    const link = byTestId('responsible-gaming-begambleaware-link');
+    expect(link.getAttribute('href')).toBe(BEGAMBLEAWARE_URL);
+    expect(link.getAttribute('target')).toBe('_blank');
+    expect(link.getAttribute('rel') ?? '').toMatch(/noopener/);
+    expect(link.getAttribute('rel') ?? '').toMatch(/noreferrer/);
+    expect(link.textContent ?? '').toMatch(/begambleaware/i);
+  });
+
+  it('exposes the in-app self-exclusion channel as a mailto', () => {
+    render(<ResponsibleGamingPage />);
+    const link = byTestId('responsible-gaming-self-exclusion-link');
+    expect(link.getAttribute('href') ?? '').toContain(
+      `mailto:${SELF_EXCLUSION_EMAIL}`,
+    );
+    expect(link.textContent ?? '').toContain(SELF_EXCLUSION_EMAIL);
+  });
+
+  it('surfaces the session-time-limit guidance with the explicit minute cap', () => {
+    render(<ResponsibleGamingPage />);
+    expect(
+      byTestId('responsible-gaming-session-limit').textContent ?? '',
+    ).toMatch(new RegExp(`${SESSION_LIMIT_DEFAULT_MINUTES} minutes`));
+  });
+});
+
+describe('/casino/responsible-gaming — draft ribbon (acceptance e)', () => {
+  it("surfaces the 'Draft — counsel review pending' ribbon with role=status", () => {
+    render(<ResponsibleGamingPage />);
+    const ribbon = byTestId('responsible-gaming-draft-ribbon');
+    expect(ribbon.getAttribute('role')).toBe('status');
+    expect(ribbon.textContent ?? '').toMatch(/draft — counsel review pending/i);
+  });
+});
+
+describe('/casino/responsible-gaming — accessibility', () => {
+  it('uses a single h1 and >=5 h2 sections (heading hierarchy)', () => {
+    render(<ResponsibleGamingPage />);
+    const h1s = container.querySelectorAll('h1');
+    expect(h1s).toHaveLength(1);
+    expect(h1s[0]).toBe(byTestId('responsible-gaming-page-title'));
+
+    const h2s = container.querySelectorAll('h2');
+    expect(h2s.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it('every link is a real <a> with default tab order', () => {
+    render(<ResponsibleGamingPage />);
+    const linkIds = [
+      'responsible-gaming-casino-link',
+      'responsible-gaming-begambleaware-link',
+      'responsible-gaming-self-exclusion-link',
+      'responsible-gaming-terms-link',
+    ];
+    for (const id of linkIds) {
+      const el = byTestId(id);
+      expect(el.tagName.toLowerCase()).toBe('a');
+      expect(el.getAttribute('href')).toBeTruthy();
+      expect(el.getAttribute('tabindex') ?? '0').toBe('0');
+    }
+  });
+});

--- a/app/casino/responsible-gaming/page.tsx
+++ b/app/casino/responsible-gaming/page.tsx
@@ -1,0 +1,197 @@
+// /casino/responsible-gaming — responsible-gaming notice for the Cosmic
+// Casino. Ported from the BunnyBagz [BB_PHASE3_LEGAL_PAGES]
+// `/responsible-gaming` page and re-skinned to the SWO casino theme
+// (Tailwind neon instead of the BB `--bb-*` CSS vars). Task:
+// [SWO_CASINO_RESPONSIBLE_GAMING_PAGE] (G4).
+//
+// Acceptance carried over from BB:
+//   (b) links to (1) BeGambleAware.org, (2) the in-app self-exclusion
+//       request channel (mailto until the wallet-signed flow ships),
+//       (3) session-time-limit guidance.
+//   (e) the `Draft — counsel review pending` ribbon stays until the
+//       operator clears counsel signoff (legal review).
+
+import Link from 'next/link';
+
+export const metadata = {
+  title: 'Responsible Gaming | Cosmic Casino',
+  description:
+    'Cosmic Casino responsible-gaming resources — BeGambleAware, ' +
+    'self-exclusion, and session-time-limit guidance. Draft — counsel ' +
+    'review pending.',
+};
+
+export const RG_LAST_UPDATED = '2026-05-25';
+export const SELF_EXCLUSION_EMAIL = 'self-exclusion@starworldorder.com';
+export const BEGAMBLEAWARE_URL = 'https://www.begambleaware.org';
+export const SESSION_LIMIT_DEFAULT_MINUTES = 60;
+
+export default function ResponsibleGamingPage() {
+  return (
+    <main
+      className="min-h-screen max-w-3xl mx-auto px-5 py-8 flex flex-col gap-4 text-gray-300"
+      data-testid="responsible-gaming-page-main"
+    >
+      <p
+        role="status"
+        className="m-0 px-3 py-2 rounded-lg text-sm leading-relaxed text-[#ffb86b] bg-[#ffb86b]/15 border border-[#ffb86b]/40"
+        data-testid="responsible-gaming-draft-ribbon"
+      >
+        Draft — counsel review pending. The text below is the operator&apos;s
+        first-draft responsible-gaming notice and may change before public
+        launch.
+      </p>
+
+      <h1
+        className="m-0 text-2xl font-bold text-[#ff00ff]"
+        data-testid="responsible-gaming-page-title"
+      >
+        Responsible gaming
+      </h1>
+      <p
+        className="m-0 text-sm text-gray-500"
+        data-testid="responsible-gaming-last-updated"
+      >
+        Last updated {RG_LAST_UPDATED}.
+      </p>
+
+      <section aria-labelledby="rg-intro-heading" className="flex flex-col gap-2">
+        <h2 id="rg-intro-heading" className="m-0 text-lg font-bold text-[#00ffff]">
+          Bet for fun, not for income
+        </h2>
+        <p
+          className="m-0 text-[0.95rem] leading-relaxed"
+          data-testid="responsible-gaming-page-body"
+        >
+          The Cosmic Casino is built to be entertainment with a transparent
+          house edge — not a way to make money. Every game discloses its edge,
+          every bet uses commit-reveal randomness that is re-derivable on the
+          Monad chain, and the resources on this page exist so you can keep
+          play in healthy bounds. Return to the{' '}
+          <Link
+            href="/casino"
+            className="text-[#44ff88] underline"
+            data-testid="responsible-gaming-casino-link"
+          >
+            casino lobby
+          </Link>{' '}
+          any time.
+        </p>
+      </section>
+
+      <section aria-labelledby="rg-warning-signs-heading" className="flex flex-col gap-2">
+        <h2 id="rg-warning-signs-heading" className="m-0 text-lg font-bold text-[#00ffff]">
+          Warning signs
+        </h2>
+        <ul className="m-0 pl-5 flex flex-col gap-2 list-disc" data-testid="rg-warning-signs-list">
+          <li className="text-[0.95rem] leading-snug">
+            Betting more than you can afford to lose, or betting with money you
+            owe.
+          </li>
+          <li className="text-[0.95rem] leading-snug">
+            Chasing losses with bigger bets, or feeling you need to win back
+            what you lost.
+          </li>
+          <li className="text-[0.95rem] leading-snug">
+            Hiding play from people you live with, lying about time spent, or
+            feeling guilt afterwards.
+          </li>
+          <li className="text-[0.95rem] leading-snug">
+            Play interfering with sleep, work, relationships, or financial
+            obligations.
+          </li>
+        </ul>
+      </section>
+
+      <section aria-labelledby="rg-begambleaware-heading" className="flex flex-col gap-2">
+        <h2 id="rg-begambleaware-heading" className="m-0 text-lg font-bold text-[#00ffff]">
+          Free, confidential help: BeGambleAware
+        </h2>
+        <p className="m-0 text-[0.95rem] leading-relaxed">
+          If gambling is causing harm, free and confidential support is
+          available 24/7 from BeGambleAware. They are independent of every
+          operator, including this one.
+        </p>
+        <p className="m-0 text-[0.95rem] leading-relaxed">
+          <a
+            href={BEGAMBLEAWARE_URL}
+            rel="noopener noreferrer"
+            target="_blank"
+            className="text-[#44ff88] underline"
+            data-testid="responsible-gaming-begambleaware-link"
+          >
+            BeGambleAware.org
+          </a>{' '}
+          — international helpline directory and live chat.
+        </p>
+      </section>
+
+      <section aria-labelledby="rg-self-exclusion-heading" className="flex flex-col gap-2">
+        <h2 id="rg-self-exclusion-heading" className="m-0 text-lg font-bold text-[#00ffff]">
+          Self-exclusion request
+        </h2>
+        <p className="m-0 text-[0.95rem] leading-relaxed">
+          Self-exclusion blocks the front end from accepting bets from your
+          wallet for the duration you choose. Because the Cosmic Casino is
+          non-custodial, the on-chain contract cannot force-block a wallet — but
+          the front end (this site) will refuse to assist further bets, and the
+          operator commits to honouring the exclusion across all official Star
+          World Order surfaces.
+        </p>
+        <p className="m-0 text-[0.95rem] leading-relaxed">
+          To request self-exclusion, email{' '}
+          <a
+            href={`mailto:${SELF_EXCLUSION_EMAIL}?subject=Cosmic%20Casino%20self-exclusion%20request`}
+            className="text-[#44ff88] underline"
+            data-testid="responsible-gaming-self-exclusion-link"
+          >
+            {SELF_EXCLUSION_EMAIL}
+          </a>{' '}
+          from any address with the wallet you want excluded and the duration
+          (24 hours, 7 days, 30 days, 6 months, permanent). We acknowledge
+          within 24 hours.
+        </p>
+      </section>
+
+      <section aria-labelledby="rg-session-limit-heading" className="flex flex-col gap-2">
+        <h2 id="rg-session-limit-heading" className="m-0 text-lg font-bold text-[#00ffff]">
+          Session-time-limit guidance
+        </h2>
+        <p
+          className="m-0 text-[0.95rem] leading-relaxed"
+          data-testid="responsible-gaming-session-limit"
+        >
+          A healthy session is bounded. The default guidance is to cap any
+          single session at {SESSION_LIMIT_DEFAULT_MINUTES} minutes and step
+          away for at least the same length of time before coming back. Use a
+          phone timer, set a per-session deposit cap, and stop on a win at least
+          as often as you stop on a loss.
+        </p>
+        <p className="m-0 text-[0.95rem] leading-relaxed">
+          A wallet-signed in-app session-limit prompt is on the roadmap; until
+          it ships, this guidance plus the self-exclusion channel above are the
+          operator-supported tools.
+        </p>
+      </section>
+
+      <section aria-labelledby="rg-related-heading" className="flex flex-col gap-2">
+        <h2 id="rg-related-heading" className="m-0 text-lg font-bold text-[#00ffff]">
+          Related
+        </h2>
+        <p className="m-0 text-[0.95rem] leading-relaxed">
+          Eligibility is gated to Star Skrumpey holders and is geo-restricted in
+          blocked jurisdictions. Provably-fair details and the current house
+          edge are shown on the{' '}
+          <Link
+            href="/casino"
+            className="text-[#44ff88] underline"
+            data-testid="responsible-gaming-terms-link"
+          >
+            Cosmic Casino lobby
+          </Link>
+          .
+        </p>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
Ports the BunnyBagz `[BB_PHASE3_LEGAL_PAGES]` `/responsible-gaming` page into SWO as **`/casino/responsible-gaming`**, re-skinned from the BB `--bb-*` CSS-var theme to SWO's Tailwind casino neon idiom, and adds a **Responsible Gaming** link to the Cosmic Casino lobby footer.

Task: `[SWO_CASINO_RESPONSIBLE_GAMING_PAGE]` (G4, PROJECT:SWO, P2). Depends on G1 (casino lobby) — satisfied.

## What's included
Carries over the BB acceptance touchpoints, adapted to SWO branding (Cosmic Casino, MON, Star Skrumpey holders, `starworldorder.com`):
- **(b1)** External help link to **BeGambleAware.org** with `target=_blank` + `rel="noopener noreferrer"`.
- **(b2)** In-app **self-exclusion** request channel via `mailto:self-exclusion@starworldorder.com`.
- **(b3)** **Session-time-limit guidance** (60-minute default cap).
- Warning-signs list + "bet for fun, not income" framing.
- **(e)** `Draft — counsel review pending` ribbon (`role=status`) retained pending **legal review** — flips off once counsel signs off.
- Footer link from `/casino` lobby → `/casino/responsible-gaming` (`18+ ONLY · PLAY RESPONSIBLY`).

Placed under `app/casino/` so the SWO casino vitest project + tsc cover it. Dead `/verify` `/terms` `/privacy` links from the BB original (those routes don't exist in SWO) were re-pointed to the existing `/casino` lobby.

## Tests
New `app/casino/responsible-gaming/__tests__/page.test.tsx`, ported from the BB acceptance suite and adapted to SWO's harness (raw `react-dom/client` + happy-dom; SWO ships no `@testing-library`). Covers routing/copy, the three required touchpoints, draft ribbon, and accessibility (single h1, ≥5 h2, real `<a>` links).

```
npx vitest run --project casino app/casino/responsible-gaming  →  7 passed
npx tsc --noEmit  →  clean (no new errors)
npx eslint <changed files>  →  0 errors (2 pre-existing warnings in CasinoContent)
```

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS (~22s) — no new errors introduced by these files.
- **vitest run**: N/A in PROD mirror — PROD's `node_modules` does not have `happy-dom` installed, so **every** existing happy-dom `.tsx` test (`useAccessGate`, `TrustStrip`, `ChainGate`, …) fails identically with `ERR_MODULE_NOT_FOUND: happy-dom`. This is a pre-existing PROD environment gap (excluded by baseline-diff), not a regression. The suite passes 7/7 in the workspace where happy-dom is present.
- Mirror restored byte-identical (CasinoContent reverted, new dir removed).

Overall: PASS

## PR Class
**Class A** — feature implemented, validated, footer wired, draft ribbon left for the pending legal review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)