### PR TITLE
feat(outer-rim): Star Vault reward-mapping reducer (real-yield fold) [SWO_OUTER_RIM_REWARD_MAPPING_ENGINE]

### DIFF
--- a/lib/outer-rim/rewardMapping.test.ts
+++ b/lib/outer-rim/rewardMapping.test.ts
@@ -1,0 +1,296 @@
+/**
+ * Tests for the Star Vault reward-mapping reducer (memo 2 §5).
+ *
+ * Covers the three named invariants:
+ *   (a) parimutuel sub-pool closure,
+ *   (b) real PnL is the only term that breaks closure ("real yield"),
+ *   (c) negative Mode-B PnL floored at the loss budget → vault never negative,
+ * plus the named scenarios (all-synthetic, positive-Mode-B, loss-budget-clamp,
+ * Mode-C-rake-only), pro-rata correctness, purity, and input validation.
+ *
+ * Spec refs: docs/SANCTUARY_ADR_003_OUTER_RIM.md §4, docs/SANCTUARY_OUTER_RIM_HYBRID_RFC.md §3,
+ * docs/PERPL_INTEGRATION_REFERENCE.md.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  mapRewards,
+  parimutuelClosure,
+  DEFAULT_SKIM_RATE,
+  type SyntheticVaultCycle,
+  type RealYieldInputs,
+} from './rewardMapping';
+
+const cleaned3: SyntheticVaultCycle['cleaned'] = [
+  { id: 'a', cleaned: 100 },
+  { id: 'b', cleaned: 300 },
+  { id: 'c', cleaned: 600 },
+];
+
+function sumRewards(rewards: { reward: number }[]): number {
+  return rewards.reduce((acc, r) => acc + r.reward, 0);
+}
+
+describe('mapRewards — all-synthetic (Mode A only)', () => {
+  it('pool is the synthetic pool net of 2% skim, no real terms', () => {
+    const cycle: SyntheticVaultCycle = { syntheticParimutuelPool: 1000, cleaned: cleaned3 };
+    const r = mapRewards(cycle);
+    expect(r.grossInflow).toBe(1000);
+    expect(r.skim).toBeCloseTo(20, 9); // 2% of 1000
+    expect(r.cycleVaultPool).toBeCloseTo(980, 9);
+    expect(r.flooredModeBPnl).toBe(0);
+    expect(r.realYield).toBe(0); // no real yield when Mode-B PnL is 0
+  });
+
+  it('distributes the whole pool pro-rata across cleaned DUST', () => {
+    const cycle: SyntheticVaultCycle = { syntheticParimutuelPool: 1000, cleaned: cleaned3 };
+    const r = mapRewards(cycle);
+    // totalCleaned = 1000; shares 0.1 / 0.3 / 0.6 of 980
+    expect(r.rewards.find((x) => x.id === 'a')!.reward).toBeCloseTo(98, 9);
+    expect(r.rewards.find((x) => x.id === 'b')!.reward).toBeCloseTo(294, 9);
+    expect(r.rewards.find((x) => x.id === 'c')!.reward).toBeCloseTo(588, 9);
+    expect(sumRewards(r.rewards)).toBeCloseTo(r.cycleVaultPool, 9);
+  });
+
+  it('matches ADR-003 §4.2 reward formula exactly for a single cleaner', () => {
+    const cycle: SyntheticVaultCycle = {
+      syntheticParimutuelPool: 500,
+      cleaned: [{ id: 'solo', cleaned: 42 }],
+    };
+    const r = mapRewards(cycle);
+    expect(r.rewards[0].reward).toBeCloseTo(r.cycleVaultPool, 9); // share = 1
+  });
+});
+
+describe('mapRewards — casino house edge (ADR-003 §4.3 item 2)', () => {
+  it('casino house edge is folded into the gross inflow', () => {
+    const cycle: SyntheticVaultCycle = { syntheticParimutuelPool: 1000, cleaned: cleaned3 };
+    const r = mapRewards(cycle, { casinoHouseEdge: 250 });
+    expect(r.grossInflow).toBe(1250);
+    expect(r.cycleVaultPool).toBeCloseTo(1250 * (1 - DEFAULT_SKIM_RATE), 9);
+    expect(r.realYield).toBe(0); // casino edge is deterministic, not real yield
+  });
+});
+
+describe('mapRewards — positive Mode-B PnL (Hybrid-RFC §3.2)', () => {
+  it('positive hedge PnL increases the pool and is the real yield', () => {
+    const cycle: SyntheticVaultCycle = { syntheticParimutuelPool: 1000, cleaned: cleaned3 };
+    const r = mapRewards(cycle, { modeBPnl: 400, lossBudget: 500 });
+    expect(r.flooredModeBPnl).toBe(400); // positive PnL never floored
+    expect(r.grossInflow).toBe(1400);
+    expect(r.cycleVaultPool).toBeCloseTo(1400 * 0.98, 9);
+    expect(r.realYield).toBeCloseTo(400 * 0.98, 9);
+  });
+
+  it('real yield equals pool minus the closed deterministic pool (invariant b)', () => {
+    const cycle: SyntheticVaultCycle = { syntheticParimutuelPool: 1000, cleaned: cleaned3 };
+    const real: RealYieldInputs = { casinoHouseEdge: 200, modeCRake: 50, modeBPnl: 300, lossBudget: 1000 };
+    const withReal = mapRewards(cycle, real);
+    const withoutModeB = mapRewards(cycle, { ...real, modeBPnl: 0 });
+    expect(withReal.cycleVaultPool - withoutModeB.cycleVaultPool).toBeCloseTo(
+      withReal.realYield,
+      9,
+    );
+  });
+});
+
+describe('mapRewards — Mode-C rake only (Hybrid-RFC §3.3)', () => {
+  it('Mode-C rake is deterministic and does not register as real yield', () => {
+    const cycle: SyntheticVaultCycle = { syntheticParimutuelPool: 800, cleaned: cleaned3 };
+    const r = mapRewards(cycle, { modeCRake: 120 });
+    expect(r.grossInflow).toBe(920);
+    expect(r.cycleVaultPool).toBeCloseTo(920 * 0.98, 9);
+    expect(r.realYield).toBe(0);
+    expect(r.flooredModeBPnl).toBe(0);
+  });
+});
+
+describe('mapRewards — loss-budget clamp (invariant c)', () => {
+  it('negative Mode-B PnL is floored at -lossBudget', () => {
+    const cycle: SyntheticVaultCycle = { syntheticParimutuelPool: 1000, cleaned: cleaned3 };
+    const r = mapRewards(cycle, { modeBPnl: -800, lossBudget: 300 });
+    expect(r.flooredModeBPnl).toBe(-300); // floored, not -800
+    expect(r.grossInflow).toBe(700); // 1000 - 300
+    expect(r.realYield).toBeCloseTo(-300 * 0.98, 9); // real yield can be negative
+  });
+
+  it('loss exactly at the budget is not clamped further', () => {
+    const cycle: SyntheticVaultCycle = { syntheticParimutuelPool: 1000, cleaned: cleaned3 };
+    const r = mapRewards(cycle, { modeBPnl: -300, lossBudget: 300 });
+    expect(r.flooredModeBPnl).toBe(-300);
+    expect(r.grossInflow).toBe(700);
+  });
+
+  it('default loss budget of 0 absorbs no real loss', () => {
+    const cycle: SyntheticVaultCycle = { syntheticParimutuelPool: 1000, cleaned: cleaned3 };
+    const r = mapRewards(cycle, { modeBPnl: -500 });
+    expect(r.flooredModeBPnl).toBeCloseTo(0, 9); // floored at -lossBudget = 0
+    expect(r.grossInflow).toBe(1000);
+  });
+
+  it('vault never goes negative even with a catastrophic loss', () => {
+    const cycle: SyntheticVaultCycle = { syntheticParimutuelPool: 100, cleaned: cleaned3 };
+    // lossBudget intentionally larger than inflows → clamp must defend.
+    const r = mapRewards(cycle, { modeBPnl: -10_000, lossBudget: 10_000 });
+    expect(r.cycleVaultPool).toBe(0);
+    expect(r.cycleVaultPool).toBeGreaterThanOrEqual(0);
+    expect(sumRewards(r.rewards)).toBeCloseTo(0, 9);
+  });
+
+  it('correctly-sized loss budget keeps the pool non-negative without the clamp', () => {
+    const cycle: SyntheticVaultCycle = { syntheticParimutuelPool: 1000, cleaned: cleaned3 };
+    // lossBudget ≤ synthetic + casino + rake → gross stays ≥ 0.
+    const r = mapRewards(cycle, { modeBPnl: -2000, casinoHouseEdge: 200, modeCRake: 50, lossBudget: 1250 });
+    expect(r.flooredModeBPnl).toBe(-1250);
+    expect(r.grossInflow).toBe(0); // 1000 + 200 + 50 - 1250
+    expect(r.cycleVaultPool).toBe(0);
+  });
+});
+
+describe('parimutuelClosure — invariant (a) sub-pool stays closed', () => {
+  it('synthetic in equals synthetic out + skim + seed', () => {
+    const cycle: SyntheticVaultCycle = { syntheticParimutuelPool: 1000, cleaned: cleaned3 };
+    const c = parimutuelClosure(cycle);
+    expect(c.syntheticIn).toBe(1000);
+    expect(c.skim).toBeCloseTo(20, 9);
+    expect(c.seed).toBe(0);
+    expect(c.syntheticOut).toBeCloseTo(980, 9);
+    expect(c.residual).toBeCloseTo(0, 9);
+    expect(c.syntheticOut + c.skim + c.seed).toBeCloseTo(c.syntheticIn, 9);
+  });
+
+  it('closure holds with a retained seed', () => {
+    const cycle: SyntheticVaultCycle = { syntheticParimutuelPool: 1000, seed: 150, cleaned: cleaned3 };
+    const c = parimutuelClosure(cycle);
+    expect(c.seed).toBe(150);
+    expect(c.skim).toBeCloseTo(20, 9);
+    expect(c.syntheticOut).toBeCloseTo(830, 9); // 1000 - 20 - 150
+    expect(c.residual).toBeCloseTo(0, 9);
+  });
+
+  it('closure is independent of real PnL (b): real terms never enter it', () => {
+    const cycle: SyntheticVaultCycle = { syntheticParimutuelPool: 1000, cleaned: cleaned3 };
+    const c = parimutuelClosure(cycle);
+    // adding huge real PnL to mapRewards does not change the synthetic closure
+    mapRewards(cycle, { modeBPnl: 99999, lossBudget: 99999 });
+    const c2 = parimutuelClosure(cycle);
+    expect(c2).toEqual(c);
+    expect(c.residual).toBeCloseTo(0, 9);
+  });
+
+  it('rejects a seed larger than the pool', () => {
+    const cycle: SyntheticVaultCycle = { syntheticParimutuelPool: 100, seed: 200, cleaned: cleaned3 };
+    expect(() => parimutuelClosure(cycle)).toThrow(/seed/);
+  });
+});
+
+describe('mapRewards — combined / conservation invariant', () => {
+  it('sum of rewards equals the cycle pool when DUST is cleaned', () => {
+    const cycle: SyntheticVaultCycle = { syntheticParimutuelPool: 1234, cleaned: cleaned3 };
+    const r = mapRewards(cycle, { casinoHouseEdge: 321, modeBPnl: 111, modeCRake: 22, lossBudget: 500 });
+    expect(sumRewards(r.rewards)).toBeCloseTo(r.cycleVaultPool, 6);
+    expect(r.undistributed).toBe(0);
+  });
+
+  it('pool decomposes into closed-deterministic part + real yield', () => {
+    const cycle: SyntheticVaultCycle = { syntheticParimutuelPool: 1000, cleaned: cleaned3 };
+    const real: RealYieldInputs = { casinoHouseEdge: 300, modeCRake: 100, modeBPnl: 250, lossBudget: 1000 };
+    const r = mapRewards(cycle, real);
+    const deterministicPool = (1000 + 300 + 100) * (1 - DEFAULT_SKIM_RATE);
+    expect(r.cycleVaultPool - deterministicPool).toBeCloseTo(r.realYield, 6);
+  });
+
+  it('gross inflow is the exact memo-2 §5 sum of all four terms', () => {
+    const cycle: SyntheticVaultCycle = { syntheticParimutuelPool: 1000, cleaned: cleaned3 };
+    const r = mapRewards(cycle, { casinoHouseEdge: 300, modeBPnl: -100, modeCRake: 100, lossBudget: 500 });
+    expect(r.grossInflow).toBe(1000 + 300 + -100 + 100);
+  });
+});
+
+describe('mapRewards — zero / empty cleaned ledger', () => {
+  it('all-zero cleaned → no distribution, pool carried as undistributed', () => {
+    const cycle: SyntheticVaultCycle = {
+      syntheticParimutuelPool: 1000,
+      cleaned: [{ id: 'a', cleaned: 0 }, { id: 'b', cleaned: 0 }],
+    };
+    const r = mapRewards(cycle);
+    expect(r.totalCleaned).toBe(0);
+    expect(r.undistributed).toBeCloseTo(980, 9);
+    expect(sumRewards(r.rewards)).toBe(0);
+    expect(r.rewards.every((x) => x.reward === 0)).toBe(true);
+  });
+
+  it('empty cleaned array → no rewards, pool undistributed', () => {
+    const cycle: SyntheticVaultCycle = { syntheticParimutuelPool: 1000, cleaned: [] };
+    const r = mapRewards(cycle);
+    expect(r.rewards).toEqual([]);
+    expect(r.undistributed).toBeCloseTo(980, 9);
+  });
+});
+
+describe('mapRewards — configurable skim', () => {
+  it('honors a custom skim rate', () => {
+    const cycle: SyntheticVaultCycle = { syntheticParimutuelPool: 1000, cleaned: cleaned3 };
+    const r = mapRewards(cycle, {}, { skimRate: 0.05 });
+    expect(r.skim).toBeCloseTo(50, 9);
+    expect(r.cycleVaultPool).toBeCloseTo(950, 9);
+  });
+
+  it('skimRate of 0 takes no skim', () => {
+    const cycle: SyntheticVaultCycle = { syntheticParimutuelPool: 1000, cleaned: cleaned3 };
+    const r = mapRewards(cycle, {}, { skimRate: 0 });
+    expect(r.skim).toBe(0);
+    expect(r.cycleVaultPool).toBe(1000);
+  });
+});
+
+describe('mapRewards — purity', () => {
+  it('does not mutate its inputs', () => {
+    const cycle: SyntheticVaultCycle = { syntheticParimutuelPool: 1000, cleaned: cleaned3 };
+    const real: RealYieldInputs = { casinoHouseEdge: 100, modeBPnl: -50, lossBudget: 200 };
+    const cycleSnap = JSON.stringify(cycle);
+    const realSnap = JSON.stringify(real);
+    mapRewards(cycle, real);
+    expect(JSON.stringify(cycle)).toBe(cycleSnap);
+    expect(JSON.stringify(real)).toBe(realSnap);
+  });
+
+  it('is deterministic — identical inputs give identical outputs', () => {
+    const cycle: SyntheticVaultCycle = { syntheticParimutuelPool: 777, cleaned: cleaned3 };
+    const real: RealYieldInputs = { modeBPnl: 123, lossBudget: 500, casinoHouseEdge: 9 };
+    expect(mapRewards(cycle, real)).toEqual(mapRewards(cycle, real));
+  });
+});
+
+describe('mapRewards — input validation', () => {
+  it('rejects a negative synthetic pool', () => {
+    expect(() => mapRewards({ syntheticParimutuelPool: -1, cleaned: cleaned3 })).toThrow(/syntheticParimutuelPool/);
+  });
+
+  it('rejects a negative casino house edge', () => {
+    const cycle: SyntheticVaultCycle = { syntheticParimutuelPool: 100, cleaned: cleaned3 };
+    expect(() => mapRewards(cycle, { casinoHouseEdge: -5 })).toThrow(/casinoHouseEdge/);
+  });
+
+  it('rejects a negative loss budget', () => {
+    const cycle: SyntheticVaultCycle = { syntheticParimutuelPool: 100, cleaned: cleaned3 };
+    expect(() => mapRewards(cycle, { lossBudget: -1 })).toThrow(/lossBudget/);
+  });
+
+  it('rejects a negative cleaned value', () => {
+    const cycle: SyntheticVaultCycle = {
+      syntheticParimutuelPool: 100,
+      cleaned: [{ id: 'bad', cleaned: -10 }],
+    };
+    expect(() => mapRewards(cycle)).toThrow(/cleaned/);
+  });
+
+  it('rejects a non-finite Mode-B PnL', () => {
+    const cycle: SyntheticVaultCycle = { syntheticParimutuelPool: 100, cleaned: cleaned3 };
+    expect(() => mapRewards(cycle, { modeBPnl: Number.NaN })).toThrow(/modeBPnl/);
+  });
+
+  it('rejects a skim rate ≥ 1', () => {
+    const cycle: SyntheticVaultCycle = { syntheticParimutuelPool: 100, cleaned: cleaned3 };
+    expect(() => mapRewards(cycle, {}, { skimRate: 1 })).toThrow(/skimRate/);
+  });
+});

--- a/lib/outer-rim/rewardMapping.ts
+++ b/lib/outer-rim/rewardMapping.ts
@@ -1,0 +1,304 @@
+/**
+ * Star Vault reward-mapping reducer — folds real (Mode B/C) Perpl PnL into the
+ * synthetic parimutuel Star Vault pool, then distributes the cycle pool
+ * pro-rata across cleaned DUST.
+ *
+ * Spec: source memo `memory/evolution/swo_offshore_protocol_analysis_2026-05-23.md`
+ * **Memo 2 — Hybrid Execution §5** (real-yield fold into the synthetic pool),
+ * grounded by:
+ *   - `docs/SANCTUARY_ADR_003_OUTER_RIM.md` §4 — Star Vault 24-hour pro-rata
+ *     settlement, §4.2 reward formula, §4.3 cycle pool sources (lost Influence,
+ *     casino house-edge inflow, 2% protocol skim).
+ *   - `docs/SANCTUARY_OUTER_RIM_HYBRID_RFC.md` §3 — the three execution modes
+ *     (A synthetic / B treasury-netted / C premium) whose real PnL this reducer
+ *     folds in, and §"Open questions" OQ-H7 (gas-budget owner → Star Vault
+ *     inflow ledger).
+ *   - `docs/PERPL_INTEGRATION_REFERENCE.md` — the venue (Star Arena / Perpl)
+ *     operational parameters that produce the Mode B/C realized PnL fed in here.
+ *
+ * Core identity (memo 2 §5):
+ *
+ *   cycle_vault_pool = synthetic_parimutuel_pool
+ *                    + casino_house_edge
+ *                    + max(mode_B_pnl, -loss_budget)   // floored real hedge PnL
+ *                    + mode_C_rake
+ *                    - skim(2%)                         // 2% protocol skim on gross
+ *
+ *   reward_i = (cleaned_i / total_cleaned) × cycle_vault_pool
+ *
+ * Invariants (see `.test.ts`):
+ *   (a) Parimutuel sub-pool stays CLOSED. Excluding real PnL, every unit in
+ *       (lost Influence + casino edge + Mode-C rake) is fully accounted for as
+ *       payout + skim + seed — no value is created or destroyed internally.
+ *   (b) Real PnL is the ONLY term that breaks closure (the "real yield"). The
+ *       amount by which the cycle pool deviates from the closed deterministic
+ *       redistribution equals exactly the (post-skim) floored Mode-B PnL.
+ *   (c) Negative Mode-B PnL is floored at `-loss_budget`, so the vault never
+ *       goes negative (defended further by a non-negativity clamp on the pool).
+ *
+ * Composition: this reducer consumes a `SyntheticVaultCycle` — the per-cycle
+ * synthetic settlement produced by the pure Star Vault engine
+ * `lib/outer-rim/star-vault.ts` (`[SWO_OUTER_RIM_STAR_VAULT_ENGINE_PURE]`,
+ * ADR-003 §4.4). The synthetic engine owns the parimutuel pool and the cleaned
+ * ledger; this reducer is the additive real-yield layer on top, exactly mirroring
+ * how Hybrid-RFC §4 layers Modes B/C *behind* the mode-agnostic synthetic engine.
+ *
+ * Purity: no I/O, no clock, no randomness. Same inputs → same outputs.
+ */
+
+/** A single Skrumpey's cleaned-DUST contribution for the cycle. */
+export interface CleanedEntry {
+  /** Stable Skrumpey identifier (token id, wallet, etc.). */
+  id: string;
+  /** DUST cleaned by this Skrumpey this cycle. Must be ≥ 0. */
+  cleaned: number;
+}
+
+/**
+ * The synthetic-side cycle settlement produced by `star-vault.ts`. Only the
+ * fields this reducer needs are modeled; the Star Vault engine may carry more.
+ * This is the composition seam — `star-vault.ts` output → this reducer's input.
+ */
+export interface SyntheticVaultCycle {
+  /**
+   * The closed synthetic parimutuel pool for the cycle (lost Influence from
+   * failed voyages, ADR-003 §4.3 item 1), in DUST. Must be ≥ 0.
+   */
+  syntheticParimutuelPool: number;
+  /** Per-Skrumpey cleaned-DUST ledger for the cycle. */
+  cleaned: CleanedEntry[];
+  /**
+   * Optional seed retained inside the synthetic sub-pool (carried forward,
+   * not distributed this cycle). Part of closure accounting. Default 0.
+   */
+  seed?: number;
+}
+
+/** Real-execution (Mode B/C) inflows folded into the synthetic pool. */
+export interface RealYieldInputs {
+  /**
+   * Cosmic Casino house-edge inflow routed to the vault (ADR-003 §4.3 item 2),
+   * in DUST. Deterministic rake — part of the closed accounting. Must be ≥ 0.
+   */
+  casinoHouseEdge?: number;
+  /**
+   * Net realized PnL from the Mode-B treasury-netted hedge (Hybrid-RFC §3.2),
+   * in DUST-equivalent. May be NEGATIVE. This is the "real yield" — the only
+   * term that breaks parimutuel closure.
+   */
+  modeBPnl?: number;
+  /**
+   * Protocol rake skimmed from Mode-C premium per-user real positions
+   * (Hybrid-RFC §3.3). Deterministic cut — part of the closed accounting.
+   * Must be ≥ 0.
+   */
+  modeCRake?: number;
+  /**
+   * Maximum loss (in DUST) the vault will absorb from Mode-B in one cycle.
+   * `modeBPnl` is floored at `-lossBudget`. Must be ≥ 0. Default 0
+   * (i.e. no real loss is absorbed unless a budget is set).
+   */
+  lossBudget?: number;
+}
+
+/** Tunable reducer constants. */
+export interface RewardMappingConfig {
+  /** Protocol skim fraction on the gross pool. ADR-003 §4.3 item 3 → 0.02 (2%). */
+  skimRate?: number;
+}
+
+/** Default protocol skim — 2% (ADR-003 §4.3 item 3). */
+export const DEFAULT_SKIM_RATE = 0.02;
+
+/** Per-Skrumpey reward line. */
+export interface RewardEntry {
+  id: string;
+  /** Cleaned DUST that earned this reward (echoed from input). */
+  cleaned: number;
+  /** Pro-rata MON/DUST reward for this Skrumpey. */
+  reward: number;
+}
+
+/** Full result of folding real yield into the synthetic pool. */
+export interface RewardMappingResult {
+  /** Floored Mode-B PnL actually applied: `max(modeBPnl, -lossBudget)`. */
+  flooredModeBPnl: number;
+  /**
+   * Gross inflow before skim:
+   * synthetic + casinoHouseEdge + flooredModeBPnl + modeCRake.
+   */
+  grossInflow: number;
+  /** Protocol skim taken: `skimRate × max(grossInflow, 0)`. */
+  skim: number;
+  /** Distributable cycle pool after skim, clamped to ≥ 0 (invariant c). */
+  cycleVaultPool: number;
+  /**
+   * The "real yield" component of the pool (invariant b): the post-skim
+   * contribution of the floored Mode-B PnL — the only term that breaks
+   * parimutuel closure. Signed.
+   */
+  realYield: number;
+  /** Sum of all `cleaned` across entries. 0 ⇒ no distribution. */
+  totalCleaned: number;
+  /** Per-Skrumpey rewards (pro-rata). Empty/zero `totalCleaned` ⇒ all 0. */
+  rewards: RewardEntry[];
+  /**
+   * Pool left undistributed because `totalCleaned === 0` (no eligible cleaner).
+   * 0 whenever anyone cleaned DUST. Carried forward by the caller.
+   */
+  undistributed: number;
+}
+
+/** Closure decomposition of the synthetic parimutuel sub-pool (invariant a). */
+export interface ParimutuelClosure {
+  /** Σ synthetic in — the parimutuel pool funded by lost Influence. */
+  syntheticIn: number;
+  /** Σ synthetic out — the portion paid to cleaners (in − skim − seed). */
+  syntheticOut: number;
+  /** Skim taken on the synthetic sub-pool. */
+  skim: number;
+  /** Seed retained in the sub-pool (carried forward). */
+  seed: number;
+  /** `syntheticIn − (syntheticOut + skim + seed)`. Closure ⇔ ≈ 0. */
+  residual: number;
+}
+
+function requireFinite(value: number, name: string): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new TypeError(`${name} must be a finite number, got ${value}`);
+  }
+  return value;
+}
+
+function requireNonNegative(value: number, name: string): number {
+  requireFinite(value, name);
+  if (value < 0) {
+    throw new RangeError(`${name} must be ≥ 0, got ${value}`);
+  }
+  return value;
+}
+
+/**
+ * Decompose the synthetic parimutuel sub-pool into its closed accounting:
+ * `syntheticIn === syntheticOut + skim + seed`. Real PnL is intentionally
+ * absent here — that is what makes the sub-pool closed (invariant a/b).
+ */
+export function parimutuelClosure(
+  cycle: SyntheticVaultCycle,
+  config: RewardMappingConfig = {},
+): ParimutuelClosure {
+  const syntheticIn = requireNonNegative(
+    cycle.syntheticParimutuelPool,
+    'syntheticParimutuelPool',
+  );
+  const seed = requireNonNegative(cycle.seed ?? 0, 'seed');
+  const skimRate = resolveSkimRate(config);
+
+  if (seed > syntheticIn) {
+    throw new RangeError(
+      `seed (${seed}) cannot exceed syntheticParimutuelPool (${syntheticIn})`,
+    );
+  }
+
+  const skim = skimRate * syntheticIn;
+  const syntheticOut = syntheticIn - skim - seed;
+  const residual = syntheticIn - (syntheticOut + skim + seed);
+
+  return { syntheticIn, syntheticOut, skim, seed, residual };
+}
+
+function resolveSkimRate(config: RewardMappingConfig): number {
+  const skimRate = config.skimRate ?? DEFAULT_SKIM_RATE;
+  requireFinite(skimRate, 'skimRate');
+  if (skimRate < 0 || skimRate >= 1) {
+    throw new RangeError(`skimRate must be in [0, 1), got ${skimRate}`);
+  }
+  return skimRate;
+}
+
+/**
+ * Fold Mode B/C real yield into the synthetic Star Vault pool and distribute
+ * the resulting cycle pool pro-rata across cleaned DUST (memo 2 §5).
+ *
+ * Pure: deterministic in inputs, no side effects.
+ */
+export function mapRewards(
+  cycle: SyntheticVaultCycle,
+  real: RealYieldInputs = {},
+  config: RewardMappingConfig = {},
+): RewardMappingResult {
+  const synthetic = requireNonNegative(
+    cycle.syntheticParimutuelPool,
+    'syntheticParimutuelPool',
+  );
+  const casinoHouseEdge = requireNonNegative(
+    real.casinoHouseEdge ?? 0,
+    'casinoHouseEdge',
+  );
+  const modeCRake = requireNonNegative(real.modeCRake ?? 0, 'modeCRake');
+  const lossBudget = requireNonNegative(real.lossBudget ?? 0, 'lossBudget');
+  const modeBPnl = requireFinite(real.modeBPnl ?? 0, 'modeBPnl');
+  const skimRate = resolveSkimRate(config);
+
+  // (c) floor the real hedge loss at the loss budget so the vault can never be
+  // dragged negative by an adverse Mode-B outcome.
+  const flooredModeBPnl = Math.max(modeBPnl, -lossBudget);
+
+  const grossInflow = synthetic + casinoHouseEdge + flooredModeBPnl + modeCRake;
+
+  // Skim only ever taken on a positive gross (never "refund" the protocol).
+  const skim = skimRate * Math.max(grossInflow, 0);
+
+  // (c) defense-in-depth: clamp the distributable pool at 0. With a correctly
+  // sized loss budget (lossBudget ≤ synthetic + casinoHouseEdge + modeCRake)
+  // this clamp is never hit, but it guarantees the post-condition regardless.
+  const cycleVaultPool = Math.max(grossInflow - skim, 0);
+
+  // (b) the real-yield component: the floored Mode-B PnL after skim. This is
+  // the only term that moves the pool away from the closed deterministic value.
+  const realYield = flooredModeBPnl * (1 - skimRate);
+
+  const rewards: RewardEntry[] = [];
+  let totalCleaned = 0;
+  for (const entry of cycle.cleaned) {
+    const cleaned = requireNonNegative(entry.cleaned, `cleaned[${entry.id}]`);
+    totalCleaned += cleaned;
+  }
+
+  if (totalCleaned === 0) {
+    // No eligible cleaner — distribute nothing, carry the pool forward.
+    for (const entry of cycle.cleaned) {
+      rewards.push({ id: entry.id, cleaned: entry.cleaned, reward: 0 });
+    }
+    return {
+      flooredModeBPnl,
+      grossInflow,
+      skim,
+      cycleVaultPool,
+      realYield,
+      totalCleaned,
+      rewards,
+      undistributed: cycleVaultPool,
+    };
+  }
+
+  for (const entry of cycle.cleaned) {
+    const share = entry.cleaned / totalCleaned;
+    rewards.push({
+      id: entry.id,
+      cleaned: entry.cleaned,
+      reward: share * cycleVaultPool,
+    });
+  }
+
+  return {
+    flooredModeBPnl,
+    grossInflow,
+    skim,
+    cycleVaultPool,
+    realYield,
+    totalCleaned,
+    rewards,
+    undistributed: 0,
+  };
+}


### PR DESCRIPTION
## Summary

Pure reducer `lib/outer-rim/rewardMapping.ts` (+ `.test.ts`) folding Mode B/C real Perpl/Star-Arena PnL into the synthetic Star Vault pool, then distributing the cycle pool pro-rata across cleaned DUST.

Implements **memo 2 §5** (real-yield fold), grounded in in-repo docs:
- `docs/SANCTUARY_ADR_003_OUTER_RIM.md` §4 — Star Vault 24h pro-rata settlement, §4.2 reward formula, §4.3 cycle pool sources (lost Influence, casino house-edge, 2% protocol skim).
- `docs/SANCTUARY_OUTER_RIM_HYBRID_RFC.md` §3 — the three execution modes (A synthetic / B treasury-netted / C premium) whose real PnL is folded in; OQ-H7 (gas-budget → Star Vault inflow ledger).
- `docs/PERPL_INTEGRATION_REFERENCE.md` — venue params producing the Mode B/C realized PnL.

### Core identity

```
cycle_vault_pool = synthetic_parimutuel_pool
                 + casino_house_edge
                 + max(mode_B_pnl, -loss_budget)   // floored real hedge PnL
                 + mode_C_rake
                 - skim(2%)                         // 2% protocol skim on gross

reward_i = (cleaned_i / total_cleaned) × cycle_vault_pool
```

### Invariants tested
- **(a) Parimutuel sub-pool stays closed** — `parimutuelClosure()`: `synthetic_in == synthetic_out + skim + seed`, independent of real PnL.
- **(b) Real PnL is the only term that breaks closure** — the pool's deviation from the closed deterministic redistribution equals exactly the post-skim floored Mode-B PnL (`realYield`).
- **(c) Vault never goes negative** — negative Mode-B PnL floored at `-loss_budget`, with a defense-in-depth non-negativity clamp on the pool.

### Acceptance
- **(a) pure** — no I/O, clock, or randomness; determinism + no-mutation tested.
- **(b) ≥20 vitest cases** — 31 cases: all-synthetic, casino-edge, positive-Mode-B, loss-budget-clamp, Mode-C-rake-only, conservation, closure, zero/empty ledger, configurable skim, purity, validation.
- **(c) composes with `star-vault.ts`** — consumes a `SyntheticVaultCycle` (the synthetic engine's per-cycle output: parimutuel pool + cleaned ledger), mirroring Hybrid-RFC §4 (real modes layered *behind* the mode-agnostic synthetic engine). See PR class note below.
- **(d) cites memo 2 §5 + `docs/PERPL_INTEGRATION_REFERENCE.md`** — in the module header and test header.

## PR class: B (best safe progress)

The reducer is fully implemented, validated, and composition-ready. The dependency `[SWO_OUTER_RIM_STAR_VAULT_ENGINE_PURE]` (`lib/outer-rim/star-vault.ts`, P1) **has not yet merged**, so composition is established by an explicit interface seam (`SyntheticVaultCycle`) rather than a live cross-module import/integration test.

- **Blocker:** `lib/outer-rim/star-vault.ts` does not exist in the repo yet (separate P1 task).
- **Next step:** once `star-vault.ts` lands, add a thin integration test feeding its cycle output into `mapRewards()`; align field names if the synthetic engine's output type differs from the modeled `SyntheticVaultCycle`.

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS (no new errors introduced by these files)
- **vitest run** (`lib/outer-rim/rewardMapping.test.ts`): PASS — 31/31
- Files copied into `/opt/star_world_order/PROD`, validated, then removed (mirror left byte-identical).

Overall: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)