### PR TITLE
feat(outer-rim): real-execution risk guardrails (doc + pure guard module) [SWO_OUTER_RIM_RISK_GUARDRAILS]

### DIFF
--- a/docs/SANCTUARY_OUTER_RIM_RISK.md
+++ b/docs/SANCTUARY_OUTER_RIM_RISK.md
@@ -1,0 +1,260 @@
+# SWO Outer Rim — Real-Execution Risk Guardrails
+
+**Status:** Proposed (engineering rationale; pending operator review)
+**Date:** 2026-05-25
+**Deciders:** Operator (InverseAltruism), Clarvis (executive function)
+**Resolves:** `[SWO_OUTER_RIM_RISK_GUARDRAILS]` (PROJECT:SWO, P2)
+**Depends on:** [Hybrid Execution Model RFC](./SANCTUARY_OUTER_RIM_HYBRID_RFC.md) (§2 synthetic-vs-real, §2.1 fee-breakeven, §3 the three modes, §4 composition, OQ-H2/H3/H4/H5/H6/H8)
+**Extends:** [ADR-003 Outer Rim](./SANCTUARY_ADR_003_OUTER_RIM.md) (§2 Voyages, §"Risks" → Oracle dependency)
+**Knowledge ports:**
+[`docs/PERPL_INTEGRATION_REFERENCE.md`](./PERPL_INTEGRATION_REFERENCE.md) (connector facts: taker fee, 50× cap, 6-block TTL, IOC, 2 bps slippage floor, Perpl mainnet zero-address) ·
+Star Arena circuit-breaker `/home/agent/agents/star-arena/workspace/src/core/safety.py` (`SafetyManager` / `CircuitBreakerConfig`) and validation gates `…/src/core/validation_gates.py`
+**Implements:** `lib/outer-rim/riskGuards.ts` (+ `riskGuards.test.ts`, 25 vitest cases)
+**Source memo:** `memory/evolution/swo_offshore_protocol_analysis_2026-05-23.md` Memo 2 §3 (Mode B/C constraints)
+
+---
+
+## 1. Context
+
+The [Hybrid Execution RFC](./SANCTUARY_OUTER_RIM_HYBRID_RFC.md) fixed *when* a
+voyage runs synthetically (Mode A) versus against a real Star Arena perp
+position (Mode B treasury hedge, Mode C per-user). It deliberately deferred the
+**risk envelope** of that real tier to this document. The RFC's load-bearing
+principle is that **real execution is additive, never load-bearing** (RFC §7):
+the pure voyage engine owns the user-facing result in every mode, so if the
+venue degrades the product degrades *to Mode A* — the launch product — not to
+broken. This doc specifies the guards that enforce exactly that degradation.
+
+These are the same concerns the Star Arena trading agent already solved in
+production. `src/core/safety.py` runs a `SafetyManager` with a
+`CircuitBreakerConfig` (15% drawdown trigger, $1,000/hour loss limit, 300s
+cooldown, 10-consecutive-loss pause) and a `RUNNING / PAUSED / EMERGENCY_STOP`
+state machine that gates every trade via `is_trading_allowed()`. We port that
+shape — daily-loss trigger, cooldown re-arm, halt-but-don't-break — into the
+Outer Rim's economics, where "halt real backing" means "fall back to synthetic"
+rather than "stop trading," because synthetic is a fully functional product.
+
+**Scope.** Six guards covering memo 2 §3's Mode B/C constraints. Each is a
+**pure function** in `lib/outer-rim/riskGuards.ts` — no clock reads (callers
+pass `nowMs`), no network, no venue — so the entire risk envelope is
+unit-testable before any connector touches Monad, mirroring the discipline
+ADR-003 §"Constrains" requires of the voyage engine and Star Vault reducer.
+
+This is a **design RFC + pure module**, not a connector. No order is placed
+from this code; it returns verdicts that the future
+`[SWO_OUTER_RIM_PERP_CONNECTOR]` and settlement endpoint must honor.
+
+---
+
+## 2. The guard verdict contract
+
+Every guard returns a `GuardVerdict`:
+
+```ts
+interface GuardVerdict {
+  ok: boolean;          // real leg may proceed unchanged
+  tripped: boolean;     // a threshold was breached
+  action: GuardAction;  // what the caller must do
+  reason: string;       // human-readable (mirrors SafetyState.reason)
+}
+```
+
+`GuardAction` is the four-valued degradation ladder:
+
+| Action | Meaning | Who is affected |
+|---|---|---|
+| `allow` | real leg proceeds | — |
+| `degrade-to-synthetic` | skip the real leg; settle this voyage as Mode A | this voyage only |
+| `refund-and-degrade` | refund staked Influence **and** settle synthetically | this voyage's user |
+| `halt-real` | circuit breaker open: stop **all** real backing; synthetic continues | whole real tier |
+
+The ladder is the formalization of RFC §7's "degrade to Mode A, not to broken."
+`degrade-to-synthetic` is the default failure response because Mode A is the
+launch product (RFC §6.1) — a guard trip costs the protocol a hedge, never a
+user's voyage.
+
+---
+
+## 3. Thresholds (`DEFAULT_RISK_CONFIG`)
+
+All thresholds are explicit and operator-tunable. Launch defaults:
+
+| Threshold | Default | Source / rationale |
+|---|---|---|
+| `epochNotionalCapPct` | **0.10** (10% of treasury) | Conservative cap on real notional per epoch; bounds correlated-loss blast radius. |
+| `maxLeverageModeC` | **5×** | Task floor. Far under the venue cap — Mode C is per-*user* real capital, kept tight. |
+| `maxLeverageModeB` | **10×** | Configurable. Treasury hedge sizes to net delta (RFC OQ-H4), so modest leverage suffices. |
+| `venueMaxLeverage` | **50×** | Hard venue cap — `PerplMarket.max_leverage = 50` (PERPL_INTEGRATION_REFERENCE §4–5). No guard may exceed it. |
+| `dailyLossLimitMon` | **250 MON** | Circuit-breaker trigger. Ports `CircuitBreakerConfig.max_loss_per_hour` shape to a daily MON budget. |
+| `breakerCooldownMs` | **300_000** (300s) | Verbatim from Star Arena `CircuitBreakerConfig.cooldown_seconds = 300`. |
+| `oracleDivergenceToleranceBps` | **50 bps** | Headroom above the 2 bps slippage floor; the RFC OQ-H8 reconciliation tolerance. |
+| `maxRealPositionsPerEpoch` | **50** | Hard ceiling on venue surface area, independent of notional. |
+| `minFillFraction` | **0.95** | A fill below 95% of requested size is treated as a failed open. |
+
+Re-running with the operator's chosen regime is a one-struct change; the
+*shape* of the guards is invariant to the numbers.
+
+---
+
+## 4. The six guards
+
+### 4.1 Per-epoch notional cap — `notionalCapGuard`
+
+Caps cumulative real notional opened in an epoch at
+`treasury × epochNotionalCapPct`. Protects against a Mode-B aggregate hedge (or
+a burst of Mode-C positions) putting an outsized slice of treasury on-venue in
+one epoch — the correlated-loss event ADR-003 §"Risks" and RFC §3.2 name as the
+reason Mode B exists. **Trips** when `used + requested > cap` →
+`degrade-to-synthetic`.
+
+### 4.2 Max leverage cap — `leverageCapGuard`
+
+The synthetic book quotes fantasy leverage (2,500× / 750× / 250×, ADR-003 §2);
+the *real* leg is sized to **net delta notional, not the fantasy number**
+(RFC OQ-H4) and capped here: **Mode C ≤ 5×**, **Mode B ≤ 10×** (configurable),
+both clamped to the **50× venue hard cap**. Mode A has no real leverage to
+bound. **Trips** on `leverage > leverageCapFor(mode)` or invalid leverage →
+`degrade-to-synthetic`.
+
+### 4.3 Daily loss → circuit breaker — `stepCircuitBreaker` / `circuitBreakerGuard`
+
+A two-state breaker (`closed` ↔ `open`) directly modeled on Star Arena's
+`RUNNING ↔ PAUSED` transition. A pure reducer advances it on `loss` and `tick`
+events:
+
+- A `loss` whose **cumulative daily total** reaches `dailyLossLimitMon` opens
+  the breaker → `halt-real`. **The synthetic tier (Mode A) is unaffected** —
+  this is the whole point: the protocol stops putting capital on-venue while
+  voyages keep settling synthetically.
+- A `tick` after `breakerCooldownMs` has elapsed re-arms (closes) the breaker,
+  exactly as `SafetyManager.is_trading_allowed()` auto-resumes from `PAUSED`
+  after `cooldown_seconds`.
+- The cumulative loss tally is **UTC-day-scoped** and resets on day rollover.
+- `resetCircuitBreaker` is the manual operator override (mirrors
+  `resume_trading(force=True)`).
+
+This is the single guard that is system-wide rather than per-voyage, and the
+only one whose action is `halt-real`.
+
+### 4.4 Oracle ↔ Perpl divergence — `oracleDivergenceGuard`
+
+Mode C reconciles the venue fill against the synthetic oracle guard rail
+(RFC §4, OQ-H8). When the venue mark and the oracle diverge beyond
+`oracleDivergenceToleranceBps`, the fill is untrustworthy — a thin-book fill on
+a 6-block TTL, a stale oracle, or manipulation — so the stake is refunded and
+the voyage settles synthetically rather than minting DUST on a bad mark.
+**Trips** on `|oracle − venueMark| / oracle > tolerance`, or a non-positive
+price, → `refund-and-degrade`.
+
+### 4.5 Failed-open handling — `failedOpenGuard`
+
+Handles every way opening the real leg can fail without binding the user to a
+position they didn't get: an **IOC order that does not fill** (the connector
+sends market orders as IMMEDIATE_OR_CANCEL — PERPL_INTEGRATION_REFERENCE §6), a
+**6-block TTL expiry**, an **RPC timeout**, a **rejection**, or a **partial fill
+below `minFillFraction`**. Every such case → **refund stake + degrade to
+synthetic**. A clean fill (or a partial at/above the min fraction) → `allow`.
+
+### 4.6 Per-epoch real-position budget — `budgetExhaustionGuard`
+
+A hard ceiling on how many real positions the protocol opens per epoch,
+independent of notional. Once `epochRealPositionsUsed >=
+maxRealPositionsPerEpoch`, further voyages run synthetically for the rest of the
+epoch → `degrade-to-synthetic`. Resets implicitly at the epoch boundary (the
+caller passes `used = 0` for a new epoch).
+
+### 4.7 Composition — `assessRealLeg`
+
+Pre-trade, the stateless guards run in precedence order and the first trip wins:
+
+```
+circuit breaker (halt-real)  →  budget  →  notional  →  leverage
+```
+
+Breaker first because it is the system-wide kill; Mode A short-circuits to
+`allow` (no real leg to guard). The two **post-fill** guards — oracle divergence
+and failed-open — are evaluated at settlement, not in `assessRealLeg`, because
+they need the venue's response.
+
+---
+
+## 5. Failure modes
+
+The real tier must degrade gracefully under each of the following. In every
+case the user's voyage still settles (synthetically), because the pure engine
+owns the result (RFC §4). The ≥6 modes below are the concrete events the guards
+above are designed against:
+
+1. **Partial fill** — the venue fills less than `minFillFraction` of requested
+   size (thin book on a 6-block TTL). → `failedOpenGuard` → `refund-and-degrade`.
+2. **IOC no-fill** — the IMMEDIATE_OR_CANCEL market order finds no liquidity at
+   the slippage-bounded limit price and cancels unfilled
+   (PERPL_INTEGRATION_REFERENCE §6). → `failedOpenGuard` → `refund-and-degrade`.
+3. **RPC timeout** — the order/settle RPC to Monad times out; the connector
+   cannot confirm state. → `failedOpenGuard` (`timeout`) → `refund-and-degrade`;
+   the connector's idempotent `request_id` (`rq`) keying prevents double-open
+   (PERPL_INTEGRATION_REFERENCE §9).
+4. **WS drop mid-voyage** — the trading WebSocket disconnects while a position
+   is live. The connector re-auths with the cached nonce and re-subscribes
+   (PERPL_INTEGRATION_REFERENCE §11); cancel-on-disconnect orders are cancelled.
+   If reconciliation on reconnect shows the oracle and venue have drifted →
+   `oracleDivergenceGuard` → `refund-and-degrade`.
+5. **Liquidation** — the venue liquidates the real position before voyage end
+   (the move exceeded the venue's own maintenance margin). The realized loss
+   flows into the daily tally; if it pushes cumulative daily loss past
+   `dailyLossLimitMon`, `stepCircuitBreaker` opens → `halt-real` for the rest of
+   the cooldown. Synthetic voyages continue throughout.
+6. **Budget exhaustion** — the per-epoch real-position budget is spent;
+   `budgetExhaustionGuard` trips and all further voyages run Mode A until the
+   epoch rolls over.
+7. **Oracle/venue divergence at settlement** — venue mark and oracle path
+   disagree beyond tolerance (stale feed or manipulated fill); the oracle is the
+   guard rail (RFC OQ-H8) → `refund-and-degrade`.
+8. **Premature Perpl routing on mainnet** — Perpl's mainnet exchange is the
+   **zero address** (PERPL_INTEGRATION_REFERENCE §1; RFC §1.2). Any code that
+   would route there must hard-revert, not silently no-op. This is a connector
+   assertion (`venue != address(0)`), upstream of these guards, noted here for
+   completeness.
+
+---
+
+## 6. Why this is the right call
+
+- **Synthetic is the floor, not a fallback hack.** Every guard's default action
+  is to settle the voyage synthetically. Because Mode A is the full launch
+  product (RFC §6.1), a guard trip is never a user-visible failure — it is the
+  protocol declining a hedge. This is what makes "additive, never load-bearing"
+  (RFC §7) concrete.
+- **Ported, not invented.** The circuit-breaker shape (daily-loss trigger,
+  cooldown re-arm, halt-without-break) is Star Arena `safety.py` adapted to
+  DUST economics, and the connector failure modes (§5) are the documented
+  behaviors in PERPL_INTEGRATION_REFERENCE, not speculation.
+- **Pure and testable before mainnet.** No clock, no network, no venue — the
+  whole risk envelope is exercised by 25 vitest cases (trip + reset for each
+  guard) with zero infrastructure, satisfying ADR-003 §"Constrains."
+
+---
+
+## 7. Open questions
+
+These align with the RFC's Memo 2 §8 open questions and bound the constants
+above.
+
+| # | Question | Relates to |
+|---|---|---|
+| **OQ-R1** | Final `dailyLossLimitMon` — absolute MON, or a % of treasury recomputed each cycle? | RFC OQ-H3 (net-OI cap), §4.3 |
+| **OQ-R2** | Should the breaker also carry a **drawdown** trigger (Star Arena's 15%) in addition to daily loss? | safety.py `max_drawdown_trigger` |
+| **OQ-R3** | `oracleDivergenceToleranceBps` = 50 — confirm against realized Pyth↔venue spread on testnet (RFC §6.2). | RFC OQ-H8, OQ-H5 |
+| **OQ-R4** | On `refund-and-degrade`, does the user keep the synthetic *outcome* (could be a win) or just the refunded stake? | Settlement reducer |
+| **OQ-R5** | Per-epoch budget = 50 positions — tune against Mode-B rehedge frequency once OQ-H3 hysteresis is set. | RFC OQ-H3 |
+
+---
+
+## 8. References
+
+- [Hybrid Execution Model RFC](./SANCTUARY_OUTER_RIM_HYBRID_RFC.md) — §2–§4, OQ-H2/H3/H4/H5/H6/H8.
+- [ADR-003 Outer Rim](./SANCTUARY_ADR_003_OUTER_RIM.md) — §2 Voyages, §"Constrains", §"Risks".
+- [Perpl Integration Reference](./PERPL_INTEGRATION_REFERENCE.md) — §1 (mainnet zero-address), §4–5 (50× cap, taker fee), §6 (IOC/TTL), §7 (2 bps slippage floor), §9 (fill tracking), §11 (WS reconnect).
+- Star Arena circuit breaker: `src/core/safety.py` (`SafetyManager`, `CircuitBreakerConfig`, `SystemState`); validation gates: `src/core/validation_gates.py`.
+- Module: `lib/outer-rim/riskGuards.ts` + `riskGuards.test.ts`.
+- Source memo: `memory/evolution/swo_offshore_protocol_analysis_2026-05-23.md` Memo 2 §3.

--- a/lib/outer-rim/riskGuards.test.ts
+++ b/lib/outer-rim/riskGuards.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Unit tests for the Outer Rim real-execution risk guards.
+ *
+ * Each guard has at least a trip case and a reset/clear case, per the
+ * [SWO_OUTER_RIM_RISK_GUARDRAILS] acceptance criteria. Everything is pure:
+ * no clock, no network, no venue.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_RISK_CONFIG,
+  notionalCapGuard,
+  leverageCapGuard,
+  leverageCapFor,
+  initCircuitBreaker,
+  stepCircuitBreaker,
+  resetCircuitBreaker,
+  circuitBreakerGuard,
+  oracleDivergenceGuard,
+  failedOpenGuard,
+  budgetExhaustionGuard,
+  assessRealLeg,
+  type CircuitBreakerState,
+} from './riskGuards';
+
+const DAY = 86_400_000;
+
+describe('Guard 1 — per-epoch notional cap', () => {
+  it('trips when projected notional exceeds % of treasury', () => {
+    // cap = 1000 * 0.10 = 100 MON
+    const v = notionalCapGuard(90, 20, 1000);
+    expect(v.tripped).toBe(true);
+    expect(v.action).toBe('degrade-to-synthetic');
+  });
+
+  it('clears when projected notional stays within the cap', () => {
+    const v = notionalCapGuard(50, 40, 1000);
+    expect(v.tripped).toBe(false);
+    expect(v.ok).toBe(true);
+  });
+});
+
+describe('Guard 2 — leverage cap', () => {
+  it('Mode C caps at 5× (well under the 50× venue cap)', () => {
+    expect(leverageCapFor('C')).toBe(5);
+    expect(leverageCapFor('B')).toBe(10);
+    expect(leverageCapGuard(6, 'C').tripped).toBe(true);
+  });
+
+  it('clears when leverage is within the mode cap', () => {
+    expect(leverageCapGuard(5, 'C').ok).toBe(true);
+    expect(leverageCapGuard(10, 'B').ok).toBe(true);
+  });
+
+  it('rejects invalid (non-positive / NaN) leverage on a real mode', () => {
+    expect(leverageCapGuard(0, 'C').tripped).toBe(true);
+    expect(leverageCapGuard(NaN, 'B').tripped).toBe(true);
+  });
+
+  it('Mode A has no real leverage to bound', () => {
+    expect(leverageCapGuard(9999, 'A').ok).toBe(true);
+  });
+});
+
+describe('Guard 3 — daily loss circuit breaker', () => {
+  const t0 = 10 * DAY; // arbitrary day boundary
+
+  it('trips (opens) once cumulative daily loss reaches the limit', () => {
+    let s = initCircuitBreaker(t0);
+    s = stepCircuitBreaker(s, { type: 'loss', amountMon: 100, nowMs: t0 });
+    expect(s.status).toBe('closed');
+    s = stepCircuitBreaker(s, { type: 'loss', amountMon: 200, nowMs: t0 + 1000 }); // 300 >= 250
+    expect(s.status).toBe('open');
+    expect(circuitBreakerGuard(s)).toMatchObject({ tripped: true, action: 'halt-real' });
+  });
+
+  it('re-arms (resets) on a tick after the cooldown elapses', () => {
+    let s: CircuitBreakerState = {
+      status: 'open',
+      openedAtMs: t0,
+      reason: 'x',
+      dayIndex: Math.floor(t0 / DAY),
+      cumulativeLossMon: 300,
+    };
+    // before cooldown → still open
+    s = stepCircuitBreaker(s, { type: 'tick', nowMs: t0 + DEFAULT_RISK_CONFIG.breakerCooldownMs - 1 });
+    expect(s.status).toBe('open');
+    // after cooldown → closed
+    s = stepCircuitBreaker(s, { type: 'tick', nowMs: t0 + DEFAULT_RISK_CONFIG.breakerCooldownMs });
+    expect(s.status).toBe('closed');
+    expect(circuitBreakerGuard(s).ok).toBe(true);
+  });
+
+  it('resets the cumulative loss tally on a UTC day rollover', () => {
+    let s = initCircuitBreaker(t0);
+    s = stepCircuitBreaker(s, { type: 'loss', amountMon: 200, nowMs: t0 });
+    s = stepCircuitBreaker(s, { type: 'tick', nowMs: t0 + DAY }); // next day
+    expect(s.cumulativeLossMon).toBe(0);
+  });
+
+  it('manual reset re-arms immediately', () => {
+    const open: CircuitBreakerState = {
+      status: 'open',
+      openedAtMs: t0,
+      reason: 'x',
+      dayIndex: Math.floor(t0 / DAY),
+      cumulativeLossMon: 999,
+    };
+    const s = resetCircuitBreaker(open, t0 + 5);
+    expect(s.status).toBe('closed');
+    expect(s.cumulativeLossMon).toBe(0);
+  });
+});
+
+describe('Guard 4 — oracle ↔ venue divergence', () => {
+  it('trips when divergence exceeds tolerance (default 50 bps)', () => {
+    // 100 vs 100.6 → 60 bps > 50
+    const v = oracleDivergenceGuard(100, 100.6);
+    expect(v.tripped).toBe(true);
+    expect(v.action).toBe('refund-and-degrade');
+  });
+
+  it('clears when within tolerance', () => {
+    // 100 vs 100.3 → 30 bps < 50
+    expect(oracleDivergenceGuard(100, 100.3).ok).toBe(true);
+  });
+
+  it('treats a non-positive price as a failed reconciliation', () => {
+    expect(oracleDivergenceGuard(0, 100).tripped).toBe(true);
+  });
+});
+
+describe('Guard 5 — failed-open handling', () => {
+  it('clears on a clean fill at/above min fraction', () => {
+    expect(failedOpenGuard({ status: 'filled', filledFraction: 1 }).ok).toBe(true);
+  });
+
+  it.each(['no-fill', 'timeout', 'rejected'] as const)(
+    'trips on %s → refund-and-degrade',
+    (status) => {
+      const v = failedOpenGuard({ status, filledFraction: 0 });
+      expect(v.tripped).toBe(true);
+      expect(v.action).toBe('refund-and-degrade');
+    },
+  );
+
+  it('trips on a partial fill below the minimum fraction', () => {
+    expect(failedOpenGuard({ status: 'partial', filledFraction: 0.5 }).tripped).toBe(true);
+  });
+
+  it('clears on a partial fill at/above the minimum fraction', () => {
+    expect(failedOpenGuard({ status: 'partial', filledFraction: 0.97 }).ok).toBe(true);
+  });
+});
+
+describe('Guard 6 — per-epoch real-position budget', () => {
+  it('trips when the per-epoch budget is exhausted', () => {
+    const v = budgetExhaustionGuard(DEFAULT_RISK_CONFIG.maxRealPositionsPerEpoch);
+    expect(v.tripped).toBe(true);
+    expect(v.action).toBe('degrade-to-synthetic');
+  });
+
+  it('clears at the start of a fresh epoch (used = 0)', () => {
+    expect(budgetExhaustionGuard(0).ok).toBe(true);
+  });
+});
+
+describe('assessRealLeg — composition & precedence', () => {
+  const base = {
+    mode: 'C' as const,
+    leverage: 5,
+    requestedNotionalMon: 10,
+    epochNotionalUsedMon: 0,
+    epochRealPositionsUsed: 0,
+    treasuryMon: 1000,
+    breaker: initCircuitBreaker(0),
+  };
+
+  it('allows a clean Mode C request', () => {
+    expect(assessRealLeg(base).ok).toBe(true);
+  });
+
+  it('Mode A short-circuits to allow', () => {
+    expect(assessRealLeg({ ...base, mode: 'A', leverage: 9999 }).ok).toBe(true);
+  });
+
+  it('open breaker halts before any other check', () => {
+    const breaker: CircuitBreakerState = {
+      status: 'open',
+      openedAtMs: 0,
+      reason: 'daily loss',
+      dayIndex: 0,
+      cumulativeLossMon: 300,
+    };
+    const v = assessRealLeg({ ...base, breaker, leverage: 9999 });
+    expect(v.action).toBe('halt-real');
+  });
+
+  it('flags leverage breach when system is otherwise healthy', () => {
+    const v = assessRealLeg({ ...base, leverage: 6 });
+    expect(v.tripped).toBe(true);
+    expect(v.action).toBe('degrade-to-synthetic');
+  });
+});

--- a/lib/outer-rim/riskGuards.ts
+++ b/lib/outer-rim/riskGuards.ts
@@ -1,0 +1,453 @@
+/**
+ * Outer Rim — real-execution risk guards (Mode B / Mode C).
+ *
+ * Pure, deterministic guard functions for the real-Perpl execution tier of the
+ * Outer Rim hybrid voyage model. Mode A (synthetic) carries no venue exposure
+ * and needs none of these; these guards bound the *real* leg (Star Arena perp
+ * order behind a voyage) and define how it degrades back to synthetic when a
+ * limit trips.
+ *
+ * Design discipline (ADR-003 §"Constrains"): like `lib/outer-rim/voyage.ts` and
+ * `lib/sanctuary/expeditions.ts`, every guard here is a pure function — no clock
+ * reads (callers pass `nowMs`), no network, no venue. This keeps the real-tier
+ * risk math unit-testable before any connector goes near Monad.
+ *
+ * Knowledge ported from the Star Arena trading agent's circuit-breaker
+ * (`src/core/safety.py` `SafetyManager` / `CircuitBreakerConfig`: drawdown +
+ * hourly-loss + cooldown triggers, RUNNING/PAUSED/EMERGENCY states) and
+ * profitability gates (`src/core/validation_gates.py`). Connector facts
+ * (taker fee, 50× venue cap, 6-block TTL, IOC semantics, 2 bps slippage floor,
+ * Perpl mainnet zero-address) come from `docs/PERPL_INTEGRATION_REFERENCE.md`.
+ * Execution-model context (synthetic-vs-real, the three modes, fee-breakeven)
+ * is `docs/SANCTUARY_OUTER_RIM_HYBRID_RFC.md` §2–§4 (memo 2 §3).
+ *
+ * See `docs/SANCTUARY_OUTER_RIM_RISK.md` for the full design and rationale.
+ */
+
+/** Execution mode for a voyage. A = synthetic, B = treasury hedge, C = per-user real. */
+export type VoyageMode = 'A' | 'B' | 'C';
+
+/**
+ * What a tripped guard tells the settlement path to do.
+ * - `allow`               — real execution may proceed.
+ * - `degrade-to-synthetic`— skip the real leg; settle the voyage synthetically (Mode A).
+ * - `refund-and-degrade`  — refund the staked Influence AND fall back to synthetic
+ *                            (the real leg could not be opened/closed cleanly — "failed open").
+ * - `halt-real`           — circuit breaker open: stop ALL real backing; synthetic continues.
+ */
+export type GuardAction =
+  | 'allow'
+  | 'degrade-to-synthetic'
+  | 'refund-and-degrade'
+  | 'halt-real';
+
+/** Verdict returned by every stateless guard. */
+export interface GuardVerdict {
+  /** True iff the real leg may proceed unchanged. */
+  ok: boolean;
+  /** True iff a guard threshold was breached. */
+  tripped: boolean;
+  /** What the caller should do. */
+  action: GuardAction;
+  /** Human-readable explanation (mirrors `SafetyState.reason`). */
+  reason: string;
+}
+
+/** Explicit, tunable thresholds. Defaults are conservative launch values. */
+export interface RiskConfig {
+  /** Per-epoch real notional cap as a fraction of treasury (e.g. 0.10 = 10%). */
+  epochNotionalCapPct: number;
+  /** Mode C hard leverage cap. Task floor: ≤ 5× (well under the 50× venue cap). */
+  maxLeverageModeC: number;
+  /** Mode B hedge leverage cap (configurable; still ≤ venue cap). */
+  maxLeverageModeB: number;
+  /** Venue hard cap — Star Arena / Perpl `max_leverage = 50` (PERPL_INTEGRATION_REFERENCE §4–5). */
+  venueMaxLeverage: number;
+  /** Daily realized-loss limit (MON) that opens the circuit breaker. */
+  dailyLossLimitMon: number;
+  /** Cooldown before an open breaker re-arms (ms). Star Arena `cooldown_seconds = 300`. */
+  breakerCooldownMs: number;
+  /** Max oracle↔venue-mark divergence tolerated before Mode C reconciliation fails (bps). */
+  oracleDivergenceToleranceBps: number;
+  /** Per-epoch budget of real positions; beyond it, voyages fall back to synthetic. */
+  maxRealPositionsPerEpoch: number;
+  /** Minimum acceptable fill fraction; a partial below this is treated as a failed open. */
+  minFillFraction: number;
+}
+
+/**
+ * Conservative launch defaults. The cooldown (300s) and the
+ * loss-trigger shape are lifted from Star Arena `CircuitBreakerConfig`;
+ * `venueMaxLeverage` (50×) is the Perpl/Star Arena market cap.
+ */
+export const DEFAULT_RISK_CONFIG: RiskConfig = {
+  epochNotionalCapPct: 0.1,
+  maxLeverageModeC: 5,
+  maxLeverageModeB: 10,
+  venueMaxLeverage: 50,
+  dailyLossLimitMon: 250,
+  breakerCooldownMs: 300_000,
+  oracleDivergenceToleranceBps: 50,
+  maxRealPositionsPerEpoch: 50,
+  minFillFraction: 0.95,
+};
+
+const ALLOW: GuardVerdict = { ok: true, tripped: false, action: 'allow', reason: '' };
+
+function bps(part: number, whole: number): number {
+  if (whole === 0) return Infinity;
+  return (Math.abs(part) / Math.abs(whole)) * 10_000;
+}
+
+// ---------------------------------------------------------------------------
+// Guard 1 — per-epoch notional cap (% of treasury)
+// ---------------------------------------------------------------------------
+
+/**
+ * Caps the cumulative real notional opened in an epoch at a fraction of
+ * treasury. Protects against the Mode-B aggregate hedge (or a burst of Mode-C
+ * positions) putting an outsized slice of treasury on-venue in one epoch.
+ *
+ * Trips when `used + requested > treasury × epochNotionalCapPct`.
+ */
+export function notionalCapGuard(
+  epochNotionalUsedMon: number,
+  requestedNotionalMon: number,
+  treasuryMon: number,
+  config: RiskConfig = DEFAULT_RISK_CONFIG,
+): GuardVerdict {
+  const cap = Math.max(0, treasuryMon) * config.epochNotionalCapPct;
+  const projected = Math.max(0, epochNotionalUsedMon) + Math.max(0, requestedNotionalMon);
+  if (projected > cap) {
+    return {
+      ok: false,
+      tripped: true,
+      action: 'degrade-to-synthetic',
+      reason: `epoch notional ${projected.toFixed(2)} MON exceeds cap ${cap.toFixed(2)} MON (${(
+        config.epochNotionalCapPct * 100
+      ).toFixed(0)}% of treasury)`,
+    };
+  }
+  return ALLOW;
+}
+
+// ---------------------------------------------------------------------------
+// Guard 2 — max leverage cap (Mode C ≤ 5×, Mode B configurable, venue ≤ 50×)
+// ---------------------------------------------------------------------------
+
+/** Effective leverage cap for a mode, never above the venue hard cap. */
+export function leverageCapFor(mode: VoyageMode, config: RiskConfig = DEFAULT_RISK_CONFIG): number {
+  switch (mode) {
+    case 'C':
+      return Math.min(config.maxLeverageModeC, config.venueMaxLeverage);
+    case 'B':
+      return Math.min(config.maxLeverageModeB, config.venueMaxLeverage);
+    case 'A':
+    default:
+      return 0; // Mode A has no real position → no real leverage.
+  }
+}
+
+/**
+ * Bounds the real position's leverage. The synthetic book may quote fantasy
+ * leverage (2,500×/750×/250×, ADR-003 §2); the *real* leg is sized to net
+ * delta notional, not to that fantasy number (RFC OQ-H4), and capped here.
+ *
+ * Trips when `leverage > leverageCapFor(mode)`.
+ */
+export function leverageCapGuard(
+  leverage: number,
+  mode: VoyageMode,
+  config: RiskConfig = DEFAULT_RISK_CONFIG,
+): GuardVerdict {
+  if (mode === 'A') {
+    // No real leverage to bound; nothing to do.
+    return ALLOW;
+  }
+  const cap = leverageCapFor(mode, config);
+  if (!Number.isFinite(leverage) || leverage <= 0) {
+    return {
+      ok: false,
+      tripped: true,
+      action: 'degrade-to-synthetic',
+      reason: `invalid leverage ${leverage} for Mode ${mode}`,
+    };
+  }
+  if (leverage > cap) {
+    return {
+      ok: false,
+      tripped: true,
+      action: 'degrade-to-synthetic',
+      reason: `leverage ${leverage}× exceeds Mode ${mode} cap ${cap}×`,
+    };
+  }
+  return ALLOW;
+}
+
+// ---------------------------------------------------------------------------
+// Guard 3 — daily loss limit → circuit breaker (halts real, synthetic continues)
+// ---------------------------------------------------------------------------
+
+/** Two-state breaker (mirrors Star Arena RUNNING ↔ PAUSED; emergency-stop is a separate manual path). */
+export type BreakerStatus = 'closed' | 'open';
+
+/** Pure, serializable circuit-breaker state. */
+export interface CircuitBreakerState {
+  status: BreakerStatus;
+  /** When the breaker opened (ms), or null while closed. */
+  openedAtMs: number | null;
+  /** Why it opened. */
+  reason: string;
+  /** UTC day the cumulative loss is scoped to (`floor(nowMs / 86_400_000)`). */
+  dayIndex: number;
+  /** Cumulative realized loss (MON, positive number) within `dayIndex`. */
+  cumulativeLossMon: number;
+}
+
+const MS_PER_DAY = 86_400_000;
+const utcDayIndex = (nowMs: number): number => Math.floor(nowMs / MS_PER_DAY);
+
+/** Fresh, closed breaker for the day containing `nowMs`. */
+export function initCircuitBreaker(nowMs: number): CircuitBreakerState {
+  return {
+    status: 'closed',
+    openedAtMs: null,
+    reason: '',
+    dayIndex: utcDayIndex(nowMs),
+    cumulativeLossMon: 0,
+  };
+}
+
+/** Event fed to the breaker reducer. */
+export type BreakerEvent =
+  | { type: 'loss'; amountMon: number; nowMs: number }
+  | { type: 'tick'; nowMs: number };
+
+/**
+ * Pure reducer: advance the breaker by one event.
+ *
+ * - On a UTC day rollover, the daily cumulative loss resets to 0.
+ * - A `loss` whose cumulative total reaches `dailyLossLimitMon` opens the breaker
+ *   → real backing halts; synthetic voyages (Mode A) are unaffected.
+ * - A `tick` after `breakerCooldownMs` has elapsed re-arms (closes) the breaker,
+ *   exactly as Star Arena auto-resumes from PAUSED after `cooldown_seconds`.
+ */
+export function stepCircuitBreaker(
+  prev: CircuitBreakerState,
+  event: BreakerEvent,
+  config: RiskConfig = DEFAULT_RISK_CONFIG,
+): CircuitBreakerState {
+  const s: CircuitBreakerState = { ...prev };
+
+  // UTC day rollover resets the daily loss tally.
+  const today = utcDayIndex(event.nowMs);
+  if (today !== s.dayIndex) {
+    s.dayIndex = today;
+    s.cumulativeLossMon = 0;
+  }
+
+  if (event.type === 'loss') {
+    s.cumulativeLossMon += Math.max(0, event.amountMon);
+    if (s.status === 'closed' && s.cumulativeLossMon >= config.dailyLossLimitMon) {
+      s.status = 'open';
+      s.openedAtMs = event.nowMs;
+      s.reason = `daily loss ${s.cumulativeLossMon.toFixed(2)} MON ≥ limit ${config.dailyLossLimitMon.toFixed(
+        2,
+      )} MON`;
+    }
+  } else {
+    // tick — re-arm once the cooldown has elapsed.
+    if (
+      s.status === 'open' &&
+      s.openedAtMs !== null &&
+      event.nowMs - s.openedAtMs >= config.breakerCooldownMs
+    ) {
+      s.status = 'closed';
+      s.openedAtMs = null;
+      s.reason = '';
+    }
+  }
+
+  return s;
+}
+
+/** Manual re-arm (operator override; mirrors `resume_trading(force=True)`). */
+export function resetCircuitBreaker(state: CircuitBreakerState, nowMs: number): CircuitBreakerState {
+  return {
+    status: 'closed',
+    openedAtMs: null,
+    reason: '',
+    dayIndex: utcDayIndex(nowMs),
+    cumulativeLossMon: 0,
+  };
+}
+
+/** Gate read at settlement time: may the real leg run given the breaker state? */
+export function circuitBreakerGuard(state: CircuitBreakerState): GuardVerdict {
+  if (state.status === 'open') {
+    return {
+      ok: false,
+      tripped: true,
+      action: 'halt-real',
+      reason: state.reason || 'circuit breaker open',
+    };
+  }
+  return ALLOW;
+}
+
+// ---------------------------------------------------------------------------
+// Guard 4 — oracle ↔ Perpl mark divergence
+// ---------------------------------------------------------------------------
+
+/**
+ * Mode C reconciles the venue fill against the synthetic oracle guard rail
+ * (RFC OQ-H8). When the venue mark and the oracle diverge beyond tolerance,
+ * the fill is untrustworthy (thin book, stale oracle, manipulation) — refund
+ * the stake and degrade to synthetic rather than settle DUST on a bad mark.
+ *
+ * Trips when `|oraclePrice − venueMarkPrice| / oraclePrice > toleranceBps`.
+ */
+export function oracleDivergenceGuard(
+  oraclePrice: number,
+  venueMarkPrice: number,
+  config: RiskConfig = DEFAULT_RISK_CONFIG,
+): GuardVerdict {
+  if (!Number.isFinite(oraclePrice) || oraclePrice <= 0 || !Number.isFinite(venueMarkPrice) || venueMarkPrice <= 0) {
+    return {
+      ok: false,
+      tripped: true,
+      action: 'refund-and-degrade',
+      reason: `non-positive price (oracle=${oraclePrice}, venue=${venueMarkPrice})`,
+    };
+  }
+  const divergence = bps(oraclePrice - venueMarkPrice, oraclePrice);
+  if (divergence > config.oracleDivergenceToleranceBps) {
+    return {
+      ok: false,
+      tripped: true,
+      action: 'refund-and-degrade',
+      reason: `oracle↔venue divergence ${divergence.toFixed(1)} bps exceeds tolerance ${config.oracleDivergenceToleranceBps} bps`,
+    };
+  }
+  return ALLOW;
+}
+
+// ---------------------------------------------------------------------------
+// Guard 5 — failed-open handling (refund stake + degrade-to-synthetic)
+// ---------------------------------------------------------------------------
+
+/** Outcome of attempting to open the real leg on the venue. */
+export type FillStatus = 'filled' | 'partial' | 'no-fill' | 'timeout' | 'rejected';
+
+/** Result of a fill attempt. `filledFraction` is the share of requested size that filled. */
+export interface FillOutcome {
+  status: FillStatus;
+  /** 0..1; only meaningful for `filled` / `partial`. */
+  filledFraction: number;
+}
+
+/**
+ * Handles the "failed open" cases from RFC §1.1 / memo 2 §3: an IOC order that
+ * does not fill, a 6-block TTL expiry, an RPC timeout, or a partial fill below
+ * the minimum acceptable fraction. In every such case the user's stake is
+ * refunded and the voyage settles synthetically — the real leg never partially
+ * binds the user to a venue position they didn't get.
+ *
+ * Trips on anything that is not a clean fill at/above `minFillFraction`.
+ */
+export function failedOpenGuard(
+  fill: FillOutcome,
+  config: RiskConfig = DEFAULT_RISK_CONFIG,
+): GuardVerdict {
+  if (fill.status === 'filled' && fill.filledFraction >= config.minFillFraction) {
+    return ALLOW;
+  }
+  if (fill.status === 'partial' && fill.filledFraction >= config.minFillFraction) {
+    // Effectively complete — treat as filled.
+    return ALLOW;
+  }
+  const detail =
+    fill.status === 'partial'
+      ? `partial fill ${(fill.filledFraction * 100).toFixed(1)}% < min ${(config.minFillFraction * 100).toFixed(0)}%`
+      : `order ${fill.status}`;
+  return {
+    ok: false,
+    tripped: true,
+    action: 'refund-and-degrade',
+    reason: `failed open: ${detail}`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Guard 6 — per-epoch real-position budget exhaustion → synthetic fallback
+// ---------------------------------------------------------------------------
+
+/**
+ * Bounds how many real positions the protocol opens per epoch. Once the budget
+ * is exhausted, further voyages run synthetically (Mode A) for the rest of the
+ * epoch — a hard ceiling on venue surface area independent of notional.
+ *
+ * Trips when `epochRealPositionsUsed >= maxRealPositionsPerEpoch`.
+ * Resets implicitly at epoch boundary (caller passes `used = 0` for a new epoch).
+ */
+export function budgetExhaustionGuard(
+  epochRealPositionsUsed: number,
+  config: RiskConfig = DEFAULT_RISK_CONFIG,
+): GuardVerdict {
+  if (epochRealPositionsUsed >= config.maxRealPositionsPerEpoch) {
+    return {
+      ok: false,
+      tripped: true,
+      action: 'degrade-to-synthetic',
+      reason: `real-position budget exhausted (${epochRealPositionsUsed}/${config.maxRealPositionsPerEpoch} this epoch)`,
+    };
+  }
+  return ALLOW;
+}
+
+// ---------------------------------------------------------------------------
+// Composition — assess a real-leg request against all stateless guards
+// ---------------------------------------------------------------------------
+
+/** Inputs for a pre-trade assessment of a Mode B/C real leg. */
+export interface RealLegRequest {
+  mode: VoyageMode;
+  leverage: number;
+  requestedNotionalMon: number;
+  epochNotionalUsedMon: number;
+  epochRealPositionsUsed: number;
+  treasuryMon: number;
+  breaker: CircuitBreakerState;
+}
+
+/**
+ * Run the pre-trade guards in precedence order and return the first that trips
+ * (or ALLOW). Order: breaker (system-wide halt) → budget → notional → leverage.
+ * Oracle-divergence and failed-open are *post-fill* guards and are evaluated
+ * separately at settlement, not here.
+ */
+export function assessRealLeg(
+  req: RealLegRequest,
+  config: RiskConfig = DEFAULT_RISK_CONFIG,
+): GuardVerdict {
+  if (req.mode === 'A') return ALLOW;
+
+  const breaker = circuitBreakerGuard(req.breaker);
+  if (breaker.tripped) return breaker;
+
+  const budget = budgetExhaustionGuard(req.epochRealPositionsUsed, config);
+  if (budget.tripped) return budget;
+
+  const notional = notionalCapGuard(
+    req.epochNotionalUsedMon,
+    req.requestedNotionalMon,
+    req.treasuryMon,
+    config,
+  );
+  if (notional.tripped) return notional;
+
+  const leverage = leverageCapGuard(req.leverage, req.mode, config);
+  if (leverage.tripped) return leverage;
+
+  return ALLOW;
+}


### PR DESCRIPTION
## What

Design doc `docs/SANCTUARY_OUTER_RIM_RISK.md` + pure guard module
`lib/outer-rim/riskGuards.ts` (+ `riskGuards.test.ts`, **25 vitest cases**) for
the Mode B/C **real-Perpl execution tier** of the Outer Rim hybrid voyage model.

Implements `[SWO_OUTER_RIM_RISK_GUARDRAILS]` (P2). Depends on
`[SWO_OUTER_RIM_HYBRID_RFC]` (PR #362).

## Six guards (each a pure function, explicit thresholds, trip + reset test)

1. **Per-epoch notional cap** — `notionalCapGuard`: caps real notional at a % of treasury.
2. **Max leverage cap** — `leverageCapGuard`: Mode C ≤ 5×, Mode B configurable (10×), both clamped to the 50× venue hard cap.
3. **Daily-loss circuit breaker** — `stepCircuitBreaker`/`circuitBreakerGuard`: `closed↔open` reducer; opening **halts real backing while synthetic (Mode A) continues**; 300s cooldown re-arm; UTC-day loss reset; manual `resetCircuitBreaker`.
4. **Oracle↔Perpl mark divergence** — `oracleDivergenceGuard`: refund-and-degrade when venue mark and oracle disagree > 50 bps (RFC OQ-H8).
5. **Failed-open handling** — `failedOpenGuard`: IOC no-fill / TTL timeout / rejection / sub-threshold partial → refund stake + degrade-to-synthetic.
6. **Per-epoch real-position budget exhaustion** — `budgetExhaustionGuard`: synthetic fallback once the budget is spent.

Plus `assessRealLeg` composing the stateless pre-trade guards in precedence order
(breaker → budget → notional → leverage).

## Design notes

- All guards are **pure** (no clock — callers pass `nowMs`; no network, no venue), matching ADR-003 §"Constrains" discipline. The whole risk envelope is unit-tested with zero infrastructure.
- The degradation ladder (`allow` / `degrade-to-synthetic` / `refund-and-degrade` / `halt-real`) formalizes RFC §7's "degrade to Mode A, not to broken."
- Circuit-breaker shape ported from Star Arena `src/core/safety.py` (`SafetyManager`, `CircuitBreakerConfig` — daily-loss trigger, 300s cooldown, halt-without-break).
- §"Failure modes" lists **8** (partial fill, IOC no-fill, RPC timeout, WS drop mid-voyage, liquidation, budget exhaustion, oracle/venue divergence, premature Perpl zero-address routing), each cited to `docs/PERPL_INTEGRATION_REFERENCE.md`.

## Validation

- `npx vitest run lib/outer-rim/riskGuards.test.ts` → **25 passed**
- `npx tsc --noEmit` → no errors from the new files
- `npx eslint` on both files → clean

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS (2.5s) — 18 pre-existing errors in untouched `game/scenes/*` excluded; **0 from `lib/outer-rim/riskGuards*`**
- **vitest run** (riskGuards): PASS (25/25)
- Mirror restored byte-identical (copied files removed; `lib/outer-rim/` back to `abi/` only).
Overall: PASS

## PR class
**Class A** — task fully implemented (doc + module + tests), validated, scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)