### PR TITLE
feat(outer-rim): pure voyage state-machine engine (Sprint/Run/Expedition) [SWO_OUTER_RIM_VOYAGE_ENGINE_PURE]

### DIFF
--- a/lib/outer-rim/voyage.test.ts
+++ b/lib/outer-rim/voyage.test.ts
@@ -1,0 +1,331 @@
+/**
+ * Unit tests for the Outer Rim pure voyage state-machine.
+ *
+ * Acceptance ([SWO_OUTER_RIM_VOYAGE_ENGINE_PURE]):
+ *   (a) pure — no IO, no clock, no RNG except seeded leverage jitter;
+ *   (b) ≥30 cases: happy path × 3 tiers, binary vs progressive, jitter range,
+ *       edge cases (price exactly at threshold, completion=0, completion=1);
+ *   (c) deterministic for `(seed, inputs)`;
+ *   (d) engine-only — exercises no DB / API.
+ *
+ * Math grounded in ADR-003 §2 / source memo §1.1 (tiers) and §4.1 (payout).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  VOYAGE_TYPES,
+  VOYAGE_CATALOG,
+  DEFAULT_VOYAGE_CONFIG,
+  paramsFor,
+  seededJitter,
+  effectiveSensitivity,
+  binaryDust,
+  progressiveDust,
+  evaluateVoyage,
+  type VoyageInput,
+  type VoyageType,
+} from './voyage';
+
+const CFG = DEFAULT_VOYAGE_CONFIG;
+
+/** Build a voyage input with sensible defaults; override per-test. */
+function input(overrides: Partial<VoyageInput> = {}): VoyageInput {
+  return {
+    voyageType: 'run',
+    startPrice: 100,
+    currentPrice: 100,
+    completionPct: 0.5,
+    leverageJitterSeed: 1,
+    voyageLevel: 1,
+    ...overrides,
+  };
+}
+
+/**
+ * A current price safely above any jittered liquidation threshold for `type`.
+ * Even Expedition (250×, ±20% jitter) liquidates at ≈0.48% below entry, so a
+ * price equal to entry is always "unliquidated".
+ */
+const SAFE_PRICE = 100;
+
+describe('catalog (ADR-003 §2 / memo §1.1)', () => {
+  it('models exactly the three voyage tiers', () => {
+    expect(VOYAGE_TYPES).toEqual(['sprint', 'run', 'expedition']);
+  });
+
+  it('Sprint: 5m / 2500× / binary', () => {
+    expect(VOYAGE_CATALOG.sprint).toMatchObject({
+      durationMinutes: 5,
+      leverage: 2_500,
+      payout: 'binary',
+    });
+  });
+
+  it('Run: 30m / 750× / progressive', () => {
+    expect(VOYAGE_CATALOG.run).toMatchObject({
+      durationMinutes: 30,
+      leverage: 750,
+      payout: 'progressive',
+    });
+  });
+
+  it('Expedition: 90m / 250× / progressive', () => {
+    expect(VOYAGE_CATALOG.expedition).toMatchObject({
+      durationMinutes: 90,
+      leverage: 250,
+      payout: 'progressive',
+    });
+  });
+
+  it('paramsFor throws on an unknown voyage type', () => {
+    expect(() => paramsFor('cruise' as VoyageType)).toThrow(/unknown voyage type/);
+  });
+});
+
+describe('happy path — success across all three tiers', () => {
+  it.each(VOYAGE_TYPES)('%s completes unliquidated at completion=1', (type) => {
+    const r = evaluateVoyage(input({ voyageType: type, currentPrice: SAFE_PRICE, completionPct: 1 }));
+    expect(r.status).toBe('success');
+    expect(r.influenceRefund).toBe(CFG.influenceCost);
+    expect(r.completionAtFailure).toBeNull();
+    expect(r.dustEarned).toBeGreaterThan(0);
+  });
+
+  it('Sprint success pays the level-scaled binary payout (not a completion curve)', () => {
+    const r = evaluateVoyage(input({ voyageType: 'sprint', completionPct: 1, voyageLevel: 1 }));
+    expect(r.dustEarned).toBe(CFG.binaryDustMin);
+  });
+
+  it('Run success pays the full dust_per_success coefficient at completion=1', () => {
+    const r = evaluateVoyage(input({ voyageType: 'run', completionPct: 1 }));
+    expect(r.dustEarned).toBeCloseTo(VOYAGE_CATALOG.run.dustPerSuccess, 9);
+  });
+
+  it('Expedition success pays the full dust_per_success coefficient at completion=1', () => {
+    const r = evaluateVoyage(input({ voyageType: 'expedition', completionPct: 1 }));
+    expect(r.dustEarned).toBeCloseTo(VOYAGE_CATALOG.expedition.dustPerSuccess, 9);
+  });
+});
+
+describe('live state', () => {
+  it('progressive voyage is live and accrues partial cargo before completion', () => {
+    const r = evaluateVoyage(input({ voyageType: 'run', completionPct: 0.5, currentPrice: SAFE_PRICE }));
+    expect(r.status).toBe('live');
+    expect(r.influenceRefund).toBe(0);
+    expect(r.completionAtFailure).toBeNull();
+    expect(r.dustEarned).toBeCloseTo(progressiveDust('run', 0.5), 9);
+    expect(r.dustEarned).toBeGreaterThan(0);
+  });
+
+  it('binary voyage earns nothing while live (no partial payout)', () => {
+    const r = evaluateVoyage(input({ voyageType: 'sprint', completionPct: 0.9, currentPrice: SAFE_PRICE }));
+    expect(r.status).toBe('live');
+    expect(r.dustEarned).toBe(0);
+    expect(r.influenceRefund).toBe(0);
+  });
+});
+
+describe('failure — liquidation loses the stake', () => {
+  it('failed when current price breaches the threshold', () => {
+    const r = evaluateVoyage(input({ voyageType: 'run', currentPrice: 50, completionPct: 0.3 }));
+    expect(r.status).toBe('failed');
+    expect(r.dustEarned).toBe(0);
+    expect(r.influenceRefund).toBe(0);
+  });
+
+  it('records completionAtFailure at the breach point', () => {
+    const r = evaluateVoyage(input({ voyageType: 'run', currentPrice: 1, completionPct: 0.42 }));
+    expect(r.status).toBe('failed');
+    expect(r.completionAtFailure).toBe(0.42);
+  });
+
+  it('a failed progressive voyage forfeits accrued cargo (dust 0 despite high completion)', () => {
+    const r = evaluateVoyage(input({ voyageType: 'expedition', currentPrice: 1, completionPct: 0.99 }));
+    expect(r.status).toBe('failed');
+    expect(r.dustEarned).toBe(0);
+  });
+
+  it('liquidation can occur at completion=1 (term reached but breached) → failed, not success', () => {
+    const r = evaluateVoyage(input({ voyageType: 'run', currentPrice: 1, completionPct: 1 }));
+    expect(r.status).toBe('failed');
+    expect(r.completionAtFailure).toBe(1);
+  });
+});
+
+describe('binary vs progressive payout shape', () => {
+  it('binary payout scales linearly across Voyage Levels 1..5', () => {
+    const dusts = [1, 2, 3, 4, 5].map((lvl) => binaryDust(lvl));
+    expect(dusts).toEqual([50, 62.5, 75, 87.5, 100]);
+  });
+
+  it('binary payout clamps below level 1 and above max level', () => {
+    expect(binaryDust(0)).toBe(CFG.binaryDustMin);
+    expect(binaryDust(99)).toBe(CFG.binaryDustMax);
+  });
+
+  it('progressive uses completion^1.2 verbatim (50% completion ≈ 44% payout)', () => {
+    const full = VOYAGE_CATALOG.run.dustPerSuccess;
+    const half = progressiveDust('run', 0.5);
+    expect(half / full).toBeCloseTo(Math.pow(0.5, 1.2), 9);
+    expect(half / full).toBeCloseTo(0.4353, 3);
+  });
+
+  it('progressive curve is monotonic increasing in completion', () => {
+    const samples = [0, 0.1, 0.25, 0.5, 0.75, 0.9, 1].map((c) => progressiveDust('expedition', c));
+    for (let i = 1; i < samples.length; i++) {
+      expect(samples[i]).toBeGreaterThanOrEqual(samples[i - 1]);
+    }
+  });
+
+  it('progressive payout is exactly 0 at completion=0', () => {
+    expect(progressiveDust('run', 0)).toBe(0);
+    expect(progressiveDust('expedition', 0)).toBe(0);
+  });
+
+  it('progressive payout equals the coefficient at completion=1', () => {
+    expect(progressiveDust('run', 1)).toBeCloseTo(VOYAGE_CATALOG.run.dustPerSuccess, 9);
+  });
+
+  it('progressive clamps completion outside [0,1] before applying the curve', () => {
+    expect(progressiveDust('run', 2)).toBeCloseTo(VOYAGE_CATALOG.run.dustPerSuccess, 9);
+    expect(progressiveDust('run', -1)).toBe(0);
+  });
+});
+
+describe('leverage jitter — seeded, bounded, deterministic', () => {
+  it('seededJitter is in [-1, 1)', () => {
+    for (let seed = 0; seed < 200; seed++) {
+      const j = seededJitter(seed);
+      expect(j).toBeGreaterThanOrEqual(-1);
+      expect(j).toBeLessThan(1);
+    }
+  });
+
+  it('seededJitter is deterministic for a given seed', () => {
+    expect(seededJitter(12345)).toBe(seededJitter(12345));
+  });
+
+  it('different seeds generally produce different jitter', () => {
+    expect(seededJitter(1)).not.toBe(seededJitter(2));
+  });
+
+  it('seededJitter coerces non-integer / non-finite-adjacent seeds stably', () => {
+    expect(seededJitter(7.9)).toBe(seededJitter(7)); // truncated to 7
+    expect(() => seededJitter(NaN)).toThrow(TypeError);
+  });
+
+  it('effective sensitivity stays within base × [1 - maxJitter, 1 + maxJitter)', () => {
+    const base = 1 / VOYAGE_CATALOG.run.leverage;
+    const lo = base * (1 - CFG.maxJitterFraction);
+    const hi = base * (1 + CFG.maxJitterFraction);
+    for (let seed = 0; seed < 500; seed++) {
+      const s = effectiveSensitivity('run', seed);
+      expect(s).toBeGreaterThanOrEqual(lo);
+      expect(s).toBeLessThan(hi);
+    }
+  });
+
+  it('higher leverage tiers have a tighter (smaller) base sensitivity', () => {
+    // Hold jitter fixed via the same seed; Sprint (2500×) liquidates on a
+    // smaller move than Expedition (250×).
+    const sprint = effectiveSensitivity('sprint', 42);
+    const expedition = effectiveSensitivity('expedition', 42);
+    expect(sprint).toBeLessThan(expedition);
+  });
+
+  it('the jitter seed shifts the liquidation threshold deterministically', () => {
+    const a = evaluateVoyage(input({ leverageJitterSeed: 1 }));
+    const b = evaluateVoyage(input({ leverageJitterSeed: 2 }));
+    // Same inputs except the seed → thresholds differ but each is reproducible.
+    expect(a.liquidationThreshold).not.toBe(b.liquidationThreshold);
+    expect(evaluateVoyage(input({ leverageJitterSeed: 1 })).liquidationThreshold).toBe(
+      a.liquidationThreshold,
+    );
+  });
+});
+
+describe('determinism (acceptance c)', () => {
+  it('identical (seed, inputs) yields a deep-equal result', () => {
+    const i = input({ voyageType: 'expedition', completionPct: 0.7, leverageJitterSeed: 99 });
+    expect(evaluateVoyage(i)).toEqual(evaluateVoyage(i));
+  });
+
+  it('repeated evaluation does not mutate the input', () => {
+    const i = input({ leverageJitterSeed: 7 });
+    const snapshot = JSON.stringify(i);
+    evaluateVoyage(i);
+    evaluateVoyage(i);
+    expect(JSON.stringify(i)).toBe(snapshot);
+  });
+});
+
+describe('edge case — price exactly at the threshold', () => {
+  it('current price exactly equal to the threshold is treated as a breach (failed)', () => {
+    const i = input({ voyageType: 'run', startPrice: 100, completionPct: 0.5 });
+    const sensitivity = effectiveSensitivity('run', i.leverageJitterSeed);
+    const threshold = 100 * (1 - sensitivity);
+    const r = evaluateVoyage({ ...i, currentPrice: threshold });
+    expect(r.status).toBe('failed');
+    expect(r.completionAtFailure).toBe(0.5);
+  });
+
+  it('a hair above the threshold is not a breach (live/success)', () => {
+    const i = input({ voyageType: 'run', startPrice: 100, completionPct: 0.5 });
+    const sensitivity = effectiveSensitivity('run', i.leverageJitterSeed);
+    const threshold = 100 * (1 - sensitivity);
+    const r = evaluateVoyage({ ...i, currentPrice: threshold * (1 + 1e-9) });
+    expect(r.status).toBe('live');
+  });
+});
+
+describe('edge case — completion boundaries', () => {
+  it('completion=0 with a safe price is live, earns nothing yet', () => {
+    const r = evaluateVoyage(input({ voyageType: 'run', completionPct: 0, currentPrice: SAFE_PRICE }));
+    expect(r.status).toBe('live');
+    expect(r.dustEarned).toBe(0);
+    expect(r.completionAtFailure).toBeNull();
+  });
+
+  it('completion=0 with a breached price is failed at completion 0', () => {
+    const r = evaluateVoyage(input({ voyageType: 'run', completionPct: 0, currentPrice: 1 }));
+    expect(r.status).toBe('failed');
+    expect(r.completionAtFailure).toBe(0);
+  });
+
+  it('completion=1 with a safe price is a success across all tiers', () => {
+    for (const type of VOYAGE_TYPES) {
+      const r = evaluateVoyage(input({ voyageType: type, completionPct: 1, currentPrice: SAFE_PRICE }));
+      expect(r.status).toBe('success');
+    }
+  });
+});
+
+describe('input validation (purity guards)', () => {
+  it('rejects a non-positive start price', () => {
+    expect(() => evaluateVoyage(input({ startPrice: 0 }))).toThrow(RangeError);
+  });
+
+  it('rejects a non-positive current price', () => {
+    expect(() => evaluateVoyage(input({ currentPrice: -5 }))).toThrow(RangeError);
+  });
+
+  it('rejects a NaN price', () => {
+    expect(() => evaluateVoyage(input({ currentPrice: NaN }))).toThrow(TypeError);
+  });
+
+  it('rejects completion outside [0, 1]', () => {
+    expect(() => evaluateVoyage(input({ completionPct: 1.5 }))).toThrow(RangeError);
+    expect(() => evaluateVoyage(input({ completionPct: -0.1 }))).toThrow(RangeError);
+  });
+
+  it('rejects a non-finite voyage level', () => {
+    expect(() => evaluateVoyage(input({ voyageLevel: Infinity }))).toThrow(TypeError);
+  });
+});
+
+describe('result surfaces audit fields', () => {
+  it('exposes the jittered liquidation threshold and sensitivity', () => {
+    const r = evaluateVoyage(input({ voyageType: 'run', startPrice: 100, leverageJitterSeed: 3 }));
+    expect(r.effectiveSensitivity).toBeCloseTo(effectiveSensitivity('run', 3), 12);
+    expect(r.liquidationThreshold).toBeCloseTo(100 * (1 - r.effectiveSensitivity), 9);
+  });
+});

--- a/lib/outer-rim/voyage.ts
+++ b/lib/outer-rim/voyage.ts
@@ -1,0 +1,325 @@
+/**
+ * Outer Rim — pure voyage state-machine (synthetic / Mode A core).
+ *
+ * A "voyage" is a leverage-on-price operation: the player stakes Influence and
+ * the Skrumpey takes a leveraged long on the MON/USD price feed for a fixed
+ * duration. The voyage *succeeds* if the feed never breaches the leverage-derived
+ * liquidation threshold over its run, and *fails* (loses the stake) if it does.
+ *
+ * Three tiers, lifted verbatim from the Offshore Protocol overview (source memo
+ * §1.1, cached) and ratified in `docs/SANCTUARY_ADR_003_OUTER_RIM.md` §2:
+ *
+ *   | Voyage     | Duration | Leverage | Reward shape | Lore name            |
+ *   |------------|----------|----------|--------------|----------------------|
+ *   | Sprint     | 5 min    | 2,500×   | binary       | Quick contraband run |
+ *   | Run        | 30 min   | 750×     | progressive  | Cargo haul           |
+ *   | Expedition | 90 min   | 250×     | progressive  | Long Haul            |
+ *
+ * Reward math (memo §4.1, ADR-003 §2):
+ *   - progressive: `dust = dust_per_success × completion^1.2` — the `^1.2`
+ *     curve is verbatim from Offshore; it gives early-failure proportionally
+ *     larger haircuts (50% completion → 0.5^1.2 ≈ 44% payout).
+ *   - binary: a flat 50–100 DUST payout that scales with Voyage Level; no
+ *     completion curve (you either clear the run or you don't).
+ *   On a clean success the 5-Influence stake is refunded; on failure it is lost
+ *   (routed to the Star Vault per ADR-003 §4.3 item 1).
+ *
+ * Design discipline (ADR-003 §"Constrains"): like `lib/outer-rim/riskGuards.ts`,
+ * `lib/outer-rim/rewardMapping.ts`, and `lib/sanctuary/expeditions.ts`, this is a
+ * pure function — no clock reads, no network, no oracle, and no unseeded RNG.
+ * The only stochastic element (per-trade liquidation jitter) is derived
+ * deterministically from `leverageJitterSeed`, so the engine is fully
+ * unit-testable before any oracle or contract goes near Monad. The caller owns
+ * time (passes `completionPct`) and price (passes `startPrice` / `currentPrice`).
+ *
+ * Scope: engine only. No DB, no API, no oracle wiring — those land in later PRs
+ * (`app/api/sanctuary/voyages/`, the DUST contract, the price-oracle research
+ * item OQ2). This file is the deterministic core they all build on.
+ */
+
+/** The three voyage tiers (ADR-003 §2). */
+export type VoyageType = 'sprint' | 'run' | 'expedition';
+
+export const VOYAGE_TYPES: readonly VoyageType[] = ['sprint', 'run', 'expedition'];
+
+/** Reward shape: `binary` = flat level-scaled payout; `progressive` = completion^1.2 curve. */
+export type PayoutShape = 'binary' | 'progressive';
+
+/** Live state of a voyage at the evaluated snapshot. */
+export type VoyageStatus = 'live' | 'success' | 'failed';
+
+/** Per-tier static parameters. */
+export interface VoyageParams {
+  type: VoyageType;
+  /** Voyage duration in minutes (ADR-003 §2). */
+  durationMinutes: number;
+  /** Synthetic leverage multiplier (ADR-003 §2). */
+  leverage: number;
+  /** Reward shape. */
+  payout: PayoutShape;
+  /** In-fiction name (ADR-003 §2). */
+  loreName: string;
+  /**
+   * DUST paid for a fully-completed progressive voyage (the `dust_per_success`
+   * coefficient in `dust = dust_per_success × completion^1.2`). Ignored for
+   * binary tiers, whose payout is level-scaled instead.
+   */
+  dustPerSuccess: number;
+}
+
+/**
+ * The canonical voyage catalog. Durations, leverages, and payout shapes are
+ * verbatim from ADR-003 §2 (memo §1.1). `dustPerSuccess` coefficients sit inside
+ * the ADR-002/§1 "50–100/op" DUST band for a full run and are operator-tunable.
+ */
+export const VOYAGE_CATALOG: Readonly<Record<VoyageType, VoyageParams>> = {
+  sprint: {
+    type: 'sprint',
+    durationMinutes: 5,
+    leverage: 2_500,
+    payout: 'binary',
+    loreName: 'Quick contraband run',
+    dustPerSuccess: 0, // binary tier: payout is level-scaled, see binaryDust().
+  },
+  run: {
+    type: 'run',
+    durationMinutes: 30,
+    leverage: 750,
+    payout: 'progressive',
+    loreName: 'Cargo haul',
+    dustPerSuccess: 75,
+  },
+  expedition: {
+    type: 'expedition',
+    durationMinutes: 90,
+    leverage: 250,
+    payout: 'progressive',
+    loreName: 'Long Haul',
+    dustPerSuccess: 120,
+  },
+};
+
+/** Tunable engine constants. Conservative launch values; operator-tunable. */
+export interface VoyageConfig {
+  /** Influence staked per voyage and refunded on success (ADR-003 §2). */
+  influenceCost: number;
+  /** Lowest binary payout (Voyage Level 1), in DUST (ADR-003 §2 "50–100"). */
+  binaryDustMin: number;
+  /** Highest binary payout (Voyage Level `maxVoyageLevel`), in DUST. */
+  binaryDustMax: number;
+  /** Voyage Level range; binary payout interpolates across [1, maxVoyageLevel]. */
+  maxVoyageLevel: number;
+  /**
+   * Progressive payout exponent. `1.2` verbatim from Offshore (memo §4.1):
+   * early-failure haircuts (0.5^1.2 ≈ 0.44).
+   */
+  progressiveExponent: number;
+  /**
+   * Maximum fraction by which per-trade jitter widens or tightens the base
+   * (1/leverage) liquidation sensitivity. `0.2` ⇒ effective sensitivity lands in
+   * `base × [0.8, 1.2]`. Keeps per-trade outcomes unpredictable while bounded.
+   */
+  maxJitterFraction: number;
+}
+
+/** Conservative launch defaults (ADR-003 §2). */
+export const DEFAULT_VOYAGE_CONFIG: VoyageConfig = {
+  influenceCost: 5,
+  binaryDustMin: 50,
+  binaryDustMax: 100,
+  maxVoyageLevel: 5,
+  progressiveExponent: 1.2,
+  maxJitterFraction: 0.2,
+};
+
+/** Inputs for a single voyage evaluation. All time/price is caller-supplied. */
+export interface VoyageInput {
+  voyageType: VoyageType;
+  /** Entry price (oracle mark at voyage open). Must be finite and > 0. */
+  startPrice: number;
+  /** Current oracle mark at the evaluated snapshot. Must be finite and > 0. */
+  currentPrice: number;
+  /** Fraction of the duration elapsed, in [0, 1]. 1 ⇒ the voyage has run its full term. */
+  completionPct: number;
+  /** Integer seed for the deterministic per-trade liquidation jitter. */
+  leverageJitterSeed: number;
+  /** Voyage Level in [1, maxVoyageLevel]; scales the binary payout. */
+  voyageLevel: number;
+}
+
+/** Result of evaluating a voyage at a snapshot. */
+export interface VoyageResult {
+  status: VoyageStatus;
+  /**
+   * DUST earned at this snapshot.
+   *   - progressive: `dust_per_success × completion^1.2` (accrued payout — the
+   *     amount banked if settled now; full coefficient at completion = 1).
+   *   - binary: 0 while live/failed, the level-scaled flat payout on success.
+   *   - failed: always 0 (liquidated — the stake and accrued cargo are lost).
+   */
+  dustEarned: number;
+  /** Influence refunded: `influenceCost` on a clean success, otherwise 0. */
+  influenceRefund: number;
+  /** Completion fraction at which the voyage was liquidated; null unless `failed`. */
+  completionAtFailure: number | null;
+  /**
+   * The leverage-derived liquidation threshold actually used (entry ×
+   * (1 − effective sensitivity)). Surfaced for HUD display / settlement audit.
+   */
+  liquidationThreshold: number;
+  /** Effective liquidation sensitivity after jitter (base/leverage × jitter). */
+  effectiveSensitivity: number;
+}
+
+function requireFinite(value: number, name: string): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new TypeError(`${name} must be a finite number, got ${value}`);
+  }
+  return value;
+}
+
+function requirePositive(value: number, name: string): number {
+  requireFinite(value, name);
+  if (value <= 0) {
+    throw new RangeError(`${name} must be > 0, got ${value}`);
+  }
+  return value;
+}
+
+/** Params for a voyage type. Throws on an unknown type. */
+export function paramsFor(type: VoyageType): VoyageParams {
+  const params = VOYAGE_CATALOG[type];
+  if (!params) {
+    throw new RangeError(`unknown voyage type: ${String(type)}`);
+  }
+  return params;
+}
+
+/**
+ * Deterministic per-trade jitter in `[-1, 1)` from an integer seed, via a
+ * mulberry32 step. Pure: identical seeds always yield identical jitter, so the
+ * whole engine is reproducible for `(seed, inputs)`. Non-integer / non-finite
+ * seeds are coerced to a stable integer first.
+ */
+export function seededJitter(seed: number): number {
+  // Coerce to a uint32 so the bit math below is well-defined for any input.
+  let t = (Math.trunc(requireFinite(seed, 'leverageJitterSeed')) >>> 0) + 0x6d2b79f5;
+  t = Math.imul(t ^ (t >>> 15), t | 1);
+  t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+  const unit = ((t ^ (t >>> 14)) >>> 0) / 4294967296; // [0, 1)
+  return unit * 2 - 1; // [-1, 1)
+}
+
+/**
+ * Effective liquidation sensitivity for a voyage: the base move (1/leverage)
+ * that liquidates the position, widened/tightened by bounded seeded jitter.
+ *
+ * `sensitivity = (1 / leverage) × (1 + jitterFraction)`, where
+ * `jitterFraction ∈ [-maxJitterFraction, +maxJitterFraction)`.
+ */
+export function effectiveSensitivity(
+  type: VoyageType,
+  leverageJitterSeed: number,
+  config: VoyageConfig = DEFAULT_VOYAGE_CONFIG,
+): number {
+  const { leverage } = paramsFor(type);
+  const base = 1 / leverage;
+  const jitterFraction = seededJitter(leverageJitterSeed) * config.maxJitterFraction;
+  return base * (1 + jitterFraction);
+}
+
+/** Flat binary payout for a Voyage Level, interpolated across [1, maxVoyageLevel]. */
+export function binaryDust(voyageLevel: number, config: VoyageConfig = DEFAULT_VOYAGE_CONFIG): number {
+  const { binaryDustMin, binaryDustMax, maxVoyageLevel } = config;
+  if (maxVoyageLevel <= 1) return binaryDustMax;
+  const clamped = Math.min(Math.max(voyageLevel, 1), maxVoyageLevel);
+  const frac = (clamped - 1) / (maxVoyageLevel - 1);
+  return binaryDustMin + frac * (binaryDustMax - binaryDustMin);
+}
+
+/** Progressive accrued payout at a completion fraction: `dust_per_success × completion^1.2`. */
+export function progressiveDust(
+  type: VoyageType,
+  completionPct: number,
+  config: VoyageConfig = DEFAULT_VOYAGE_CONFIG,
+): number {
+  const { dustPerSuccess } = paramsFor(type);
+  const completion = Math.min(Math.max(completionPct, 0), 1);
+  return dustPerSuccess * Math.pow(completion, config.progressiveExponent);
+}
+
+/**
+ * Evaluate a voyage at a single price/time snapshot. Pure and deterministic in
+ * `(input, config)`.
+ *
+ * Status resolution (ADR-003 §2):
+ *   1. Compute the leverage-derived liquidation threshold (with seeded jitter).
+ *   2. If `currentPrice <= threshold` → `failed` (long liquidated on the
+ *      downside). The Influence stake is lost; `completionAtFailure` records
+ *      where the breach was observed.
+ *   3. Else if `completionPct >= 1` → `success` (ran the full term unliquidated).
+ *   4. Else → `live` (still running).
+ *
+ * Payout:
+ *   - failed:      dust 0, no refund.
+ *   - progressive: dust = `dust_per_success × completion^1.2` (accrued; full
+ *                  coefficient at completion = 1). Refund only on `success`.
+ *   - binary:      dust 0 while `live`; level-scaled flat payout on `success`.
+ */
+export function evaluateVoyage(
+  input: VoyageInput,
+  config: VoyageConfig = DEFAULT_VOYAGE_CONFIG,
+): VoyageResult {
+  const params = paramsFor(input.voyageType);
+  const startPrice = requirePositive(input.startPrice, 'startPrice');
+  const currentPrice = requirePositive(input.currentPrice, 'currentPrice');
+  requireFinite(input.completionPct, 'completionPct');
+  if (input.completionPct < 0 || input.completionPct > 1) {
+    throw new RangeError(`completionPct must be in [0, 1], got ${input.completionPct}`);
+  }
+  requireFinite(input.voyageLevel, 'voyageLevel');
+
+  const sensitivity = effectiveSensitivity(input.voyageType, input.leverageJitterSeed, config);
+  const liquidationThreshold = startPrice * (1 - sensitivity);
+
+  // Long position: liquidated when the mark touches or breaches the threshold.
+  const breached = currentPrice <= liquidationThreshold;
+
+  let status: VoyageStatus;
+  if (breached) {
+    status = 'failed';
+  } else if (input.completionPct >= 1) {
+    status = 'success';
+  } else {
+    status = 'live';
+  }
+
+  let dustEarned = 0;
+  let influenceRefund = 0;
+  let completionAtFailure: number | null = null;
+
+  if (status === 'failed') {
+    completionAtFailure = input.completionPct;
+  } else if (params.payout === 'progressive') {
+    // Accrued cargo value; equals dust_per_success when completion = 1.
+    dustEarned = progressiveDust(input.voyageType, input.completionPct, config);
+    if (status === 'success') {
+      influenceRefund = config.influenceCost;
+    }
+  } else {
+    // binary: nothing until the run clears, then a flat level-scaled payout.
+    if (status === 'success') {
+      dustEarned = binaryDust(input.voyageLevel, config);
+      influenceRefund = config.influenceCost;
+    }
+  }
+
+  return {
+    status,
+    dustEarned,
+    influenceRefund,
+    completionAtFailure,
+    liquidationThreshold,
+    effectiveSensitivity: sensitivity,
+  };
+}


### PR DESCRIPTION
## What

Adds `lib/outer-rim/voyage.ts` + `lib/outer-rim/voyage.test.ts` — the pure, deterministic voyage state-machine for the Outer Rim. This is the engine that `docs/SANCTUARY_ADR_003_OUTER_RIM.md` §2 names (line 199) and that `lib/outer-rim/riskGuards.ts:10` already forward-references as the canonical core. **Class A — full completion** of `[SWO_OUTER_RIM_VOYAGE_ENGINE_PURE]` (P1).

## Design (source memo §1.1 and §4.1; ratified in ADR-003 §2)

Three voyage tiers, verbatim from the Offshore Protocol overview (memo §1.1):

| Voyage | Duration | Leverage | Payout | Lore |
|---|---|---|---|---|
| Sprint | 5 min | 2,500× | binary | Quick contraband run |
| Run | 30 min | 750× | progressive | Cargo haul |
| Expedition | 90 min | 250× | progressive | Long Haul |

- **Input:** `(voyageType, startPrice, currentPrice, completionPct, leverageJitterSeed, voyageLevel)`.
- **Output:** `{ status: 'live'|'success'|'failed', dustEarned, influenceRefund, completionAtFailure, liquidationThreshold, effectiveSensitivity }`.
- **Liquidation:** long position liquidated when `currentPrice <= startPrice × (1 − sensitivity)`, where `sensitivity = (1/leverage) × (1 + jitter)` and jitter is a bounded, **seeded** value derived from `leverageJitterSeed` (mulberry32 step).
- **Payout (memo §4.1):** progressive uses `dust = dust_per_success × completion^1.2` **verbatim from Offshore** — early-failure haircut (`0.5^1.2 ≈ 0.44`). Binary is a flat 50–100 DUST payout scaling with Voyage Level. Clean success refunds the 5 Influence stake; failure forfeits it (→ Star Vault per ADR-003 §4.3).

## Acceptance criteria

- **(a) Pure** — no IO, no clock, no network/oracle, no unseeded RNG. The only stochastic element (per-trade jitter) is deterministic in `leverageJitterSeed`. Inputs validated; never mutated.
- **(b) ≥30 cases** — **44 vitest cases**: happy path × 3 tiers, binary vs progressive, jitter range/bounds, and edge cases (price exactly at threshold, completion=0, completion=1, breach-at-completion=1).
- **(c) Deterministic** for `(seed, inputs)` — covered by dedicated deep-equal + no-mutation tests.
- **(d) Engine-only** — no DB/API/oracle/contract; those land in later PRs (`app/api/sanctuary/voyages/`, DUST contract, oracle research OQ2).
- **(e)** PR cites memo §1.1 (tiers) and §4.1 (payout curve). ✓

## Validation

- `npx vitest run lib/outer-rim/voyage.test.ts` → **44 passed**
- `npx tsc --noEmit` → no new errors (18 pre-existing in `game/scenes/*`, unrelated)
- `npx eslint lib/outer-rim/voyage.ts lib/outer-rim/voyage.test.ts` → clean

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS (5s) — 18 errors before AND after overlay (0 new; pre-existing `game/scenes/*` excluded)
- **vitest run lib/outer-rim/voyage.test.ts**: PASS (44 passed)
- Mirror restored byte-identical (new files removed after run).
Overall: **PASS**

## Notes / follow-ups
- The progressive "accrued cargo" (`dustEarned` while live) models the early-bank value; settlement-side wiring of that into the Star Vault reducer (`rewardMapping.ts`) is a later integration PR.
- Voyage Level here scales only the binary payout; its parallelism role (concurrent voyages, ADR-003 §2) is orchestration, out of scope for this single-voyage engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)