### PR TITLE
feat(outer-rim): pure Star Vault cycle-settlement reducer [SWO_OUTER_RIM_STAR_VAULT_ENGINE_PURE]

### DIFF
--- a/lib/outer-rim/starVault.test.ts
+++ b/lib/outer-rim/starVault.test.ts
@@ -1,0 +1,420 @@
+/**
+ * Tests for the pure Star Vault cycle-settlement reducer (ADR-003 §4).
+ *
+ * Covers the required scenarios — 1-player, 100-player, dust-of-0 (no reward),
+ * pool-empty, casino-inflow-only — plus split escalation, the conservation
+ * invariant (Σ rewards + skim + nextSeed === totalInflows), pro-rata
+ * correctness, purity, and input validation.
+ *
+ * Spec refs: docs/SANCTUARY_ADR_003_OUTER_RIM.md §4; memo
+ * swo_offshore_protocol_analysis_2026-05-23.md §1.3/§4.1; Offshore swiss-vault doc.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  settleStarVaultCycle,
+  DEFAULT_SPLIT,
+  ESCALATED_SPLIT,
+  DEFAULT_SKIM_RATE,
+  DEFAULT_DEPLETION_THRESHOLD,
+  type StarVaultCycleInput,
+  type StarVaultSettlement,
+} from './starVault';
+
+function sumRewards(s: StarVaultSettlement): number {
+  return s.rewards.reduce((acc, r) => acc + r.reward, 0);
+}
+
+/** The conservation invariant (c): inflows fully accounted for. */
+function expectConservation(s: StarVaultSettlement): void {
+  expect(sumRewards(s) + s.protocolSkim + s.nextCycleSeed).toBeCloseTo(s.totalInflows, 9);
+}
+
+const baseInfluence = { oldest: 1000, middle: 500, newest: 300 };
+
+describe('settleStarVaultCycle — pool composition (default split)', () => {
+  it('releases 40/30/30 of the reserve plus casino edge, less 2% skim', () => {
+    const input: StarVaultCycleInput = {
+      priorLostInfluence: baseInfluence,
+      casinoHouseEdge: 200,
+      cleaned: [{ id: 'a', dust: 100 }],
+    };
+    const s = settleStarVaultCycle(input);
+    // released = 0.4*1000 + 0.3*500 + 0.3*300 = 400 + 150 + 90 = 640
+    const released = 640;
+    expect(s.grossPool).toBeCloseTo(released + 200, 9);
+    expect(s.protocolSkim).toBeCloseTo(0.02 * (released + 200), 9);
+    expect(s.distributablePool).toBeCloseTo(0.98 * (released + 200), 9);
+    expect(s.escalated).toBe(false);
+    expect(s.splitApplied).toEqual(DEFAULT_SPLIT);
+  });
+
+  it('retains the un-released reserve (60/70/70) as the next-cycle seed', () => {
+    const input: StarVaultCycleInput = {
+      priorLostInfluence: baseInfluence,
+      casinoHouseEdge: 0,
+      cleaned: [{ id: 'a', dust: 50 }],
+    };
+    const s = settleStarVaultCycle(input);
+    // retained = 0.6*1000 + 0.7*500 + 0.7*300 = 600 + 350 + 210 = 1160
+    expect(s.nextCycleSeed).toBeCloseTo(1160, 9);
+  });
+
+  it('reports totalInflows as the full reserve plus casino edge', () => {
+    const s = settleStarVaultCycle({
+      priorLostInfluence: baseInfluence,
+      casinoHouseEdge: 200,
+      cleaned: [{ id: 'a', dust: 1 }],
+    });
+    expect(s.totalInflows).toBeCloseTo(1000 + 500 + 300 + 200, 9);
+  });
+});
+
+describe('settleStarVaultCycle — split escalation (memo §1.3)', () => {
+  it('does NOT escalate at exactly the 80% threshold (strict >)', () => {
+    const s = settleStarVaultCycle({
+      priorLostInfluence: baseInfluence,
+      casinoHouseEdge: 0,
+      cleaned: [{ id: 'a', dust: 1 }],
+      priorPoolDepletion: DEFAULT_DEPLETION_THRESHOLD,
+    });
+    expect(s.escalated).toBe(false);
+    expect(s.splitApplied).toEqual(DEFAULT_SPLIT);
+  });
+
+  it('escalates to 70/15/15 when prior pool depleted >80%', () => {
+    const s = settleStarVaultCycle({
+      priorLostInfluence: baseInfluence,
+      casinoHouseEdge: 0,
+      cleaned: [{ id: 'a', dust: 1 }],
+      priorPoolDepletion: 0.81,
+    });
+    expect(s.escalated).toBe(true);
+    expect(s.splitApplied).toEqual(ESCALATED_SPLIT);
+    // released = 0.7*1000 + 0.15*500 + 0.15*300 = 700 + 75 + 45 = 820
+    expect(s.grossPool).toBeCloseTo(820, 9);
+  });
+
+  it('escalated split front-loads more reward than the default split', () => {
+    const common: StarVaultCycleInput = {
+      priorLostInfluence: baseInfluence,
+      casinoHouseEdge: 0,
+      cleaned: [{ id: 'a', dust: 1 }],
+    };
+    const def = settleStarVaultCycle({ ...common, priorPoolDepletion: 0.5 });
+    const esc = settleStarVaultCycle({ ...common, priorPoolDepletion: 0.95 });
+    expect(esc.grossPool).toBeGreaterThan(def.grossPool);
+    expect(esc.nextCycleSeed).toBeLessThan(def.nextCycleSeed);
+  });
+});
+
+describe('settleStarVaultCycle — required scenarios', () => {
+  it('1-player: the sole cleaner takes the entire distributable pool', () => {
+    const s = settleStarVaultCycle({
+      priorLostInfluence: baseInfluence,
+      casinoHouseEdge: 200,
+      cleaned: [{ id: 'solo', dust: 42 }],
+    });
+    expect(s.rewards).toHaveLength(1);
+    expect(s.rewards[0].reward).toBeCloseTo(s.distributablePool, 9);
+    expect(s.undistributed).toBe(0);
+    expectConservation(s);
+  });
+
+  it('100-player: pro-rata, sums to the pool, conserves inflows', () => {
+    const cleaned = Array.from({ length: 100 }, (_, i) => ({
+      id: `s${i}`,
+      dust: i + 1, // 1..100
+    }));
+    const s = settleStarVaultCycle({
+      priorLostInfluence: baseInfluence,
+      casinoHouseEdge: 5000,
+      cleaned,
+    });
+    expect(s.rewards).toHaveLength(100);
+    expect(s.totalCleaned).toBe((100 * 101) / 2); // 5050
+    expect(sumRewards(s)).toBeCloseTo(s.distributablePool, 6);
+    // largest cleaner (dust=100) earns 100× the smallest (dust=1)
+    const smallest = s.rewards[0].reward;
+    const largest = s.rewards[99].reward;
+    expect(largest / smallest).toBeCloseTo(100, 6);
+    expectConservation(s);
+  });
+
+  it('dust-of-0: a zero-cleaning Skrumpey earns no reward; others split the pool', () => {
+    const s = settleStarVaultCycle({
+      priorLostInfluence: baseInfluence,
+      casinoHouseEdge: 0,
+      cleaned: [
+        { id: 'idle', dust: 0 },
+        { id: 'active', dust: 100 },
+      ],
+    });
+    const idle = s.rewards.find((r) => r.id === 'idle')!;
+    const active = s.rewards.find((r) => r.id === 'active')!;
+    expect(idle.reward).toBe(0);
+    expect(active.reward).toBeCloseTo(s.distributablePool, 9);
+    expectConservation(s);
+  });
+
+  it('pool-empty: zero inflows ⇒ zero pool, zero rewards, zero seed, zero skim', () => {
+    const s = settleStarVaultCycle({
+      priorLostInfluence: { oldest: 0, middle: 0, newest: 0 },
+      casinoHouseEdge: 0,
+      cleaned: [
+        { id: 'a', dust: 10 },
+        { id: 'b', dust: 20 },
+      ],
+    });
+    expect(s.grossPool).toBe(0);
+    expect(s.protocolSkim).toBe(0);
+    expect(s.distributablePool).toBe(0);
+    expect(s.nextCycleSeed).toBe(0);
+    expect(sumRewards(s)).toBe(0);
+    expect(s.totalInflows).toBe(0);
+    expectConservation(s);
+  });
+
+  it('casino-inflow-only: pool funded entirely by house edge', () => {
+    const s = settleStarVaultCycle({
+      priorLostInfluence: { oldest: 0, middle: 0, newest: 0 },
+      casinoHouseEdge: 1000,
+      cleaned: [{ id: 'a', dust: 100 }],
+    });
+    expect(s.grossPool).toBeCloseTo(1000, 9);
+    expect(s.protocolSkim).toBeCloseTo(20, 9);
+    expect(s.distributablePool).toBeCloseTo(980, 9);
+    expect(s.nextCycleSeed).toBe(0); // nothing retained — no influence reserve
+    expect(s.rewards[0].reward).toBeCloseTo(980, 9);
+    expectConservation(s);
+  });
+
+  it('nobody cleaned: distributable pool rolls into the next-cycle seed', () => {
+    const s = settleStarVaultCycle({
+      priorLostInfluence: baseInfluence,
+      casinoHouseEdge: 200,
+      cleaned: [
+        { id: 'a', dust: 0 },
+        { id: 'b', dust: 0 },
+      ],
+    });
+    expect(s.totalCleaned).toBe(0);
+    expect(sumRewards(s)).toBe(0);
+    expect(s.undistributed).toBeCloseTo(s.distributablePool, 9);
+    // retained influence (1160) + undistributed pool
+    expect(s.nextCycleSeed).toBeCloseTo(1160 + s.distributablePool, 9);
+    expectConservation(s);
+  });
+
+  it('empty cleaned ledger: no rewards, pool seeds forward', () => {
+    const s = settleStarVaultCycle({
+      priorLostInfluence: baseInfluence,
+      casinoHouseEdge: 0,
+      cleaned: [],
+    });
+    expect(s.rewards).toEqual([]);
+    expect(s.totalCleaned).toBe(0);
+    expect(s.undistributed).toBeCloseTo(s.distributablePool, 9);
+    expectConservation(s);
+  });
+});
+
+describe('settleStarVaultCycle — conservation invariant (c)', () => {
+  it('holds for the default split', () => {
+    expectConservation(
+      settleStarVaultCycle({
+        priorLostInfluence: baseInfluence,
+        casinoHouseEdge: 333,
+        cleaned: [
+          { id: 'a', dust: 100 },
+          { id: 'b', dust: 300 },
+          { id: 'c', dust: 600 },
+        ],
+      }),
+    );
+  });
+
+  it('holds for the escalated split', () => {
+    expectConservation(
+      settleStarVaultCycle({
+        priorLostInfluence: baseInfluence,
+        casinoHouseEdge: 333,
+        cleaned: [
+          { id: 'a', dust: 100 },
+          { id: 'b', dust: 300 },
+        ],
+        priorPoolDepletion: 0.9,
+      }),
+    );
+  });
+
+  it('holds for casino-only inflow', () => {
+    expectConservation(
+      settleStarVaultCycle({
+        priorLostInfluence: { oldest: 0, middle: 0, newest: 0 },
+        casinoHouseEdge: 777,
+        cleaned: [{ id: 'a', dust: 5 }],
+      }),
+    );
+  });
+
+  it('holds across randomized fuzz inputs', () => {
+    // deterministic LCG so the test stays pure/reproducible
+    let seed = 123456789;
+    const rand = () => {
+      seed = (1103515245 * seed + 12345) % 2 ** 31;
+      return seed / 2 ** 31;
+    };
+    for (let t = 0; t < 50; t++) {
+      const n = 1 + Math.floor(rand() * 12);
+      const cleaned = Array.from({ length: n }, (_, i) => ({
+        id: `s${i}`,
+        dust: Math.floor(rand() * 1000),
+      }));
+      const s = settleStarVaultCycle({
+        priorLostInfluence: {
+          oldest: rand() * 10000,
+          middle: rand() * 10000,
+          newest: rand() * 10000,
+        },
+        casinoHouseEdge: rand() * 5000,
+        cleaned,
+        priorPoolDepletion: rand(),
+      });
+      expectConservation(s);
+    }
+  });
+});
+
+describe('settleStarVaultCycle — pro-rata correctness (ADR-003 §4.2)', () => {
+  it('reward shares equal cleaned-DUST shares', () => {
+    const s = settleStarVaultCycle({
+      priorLostInfluence: baseInfluence,
+      casinoHouseEdge: 0,
+      cleaned: [
+        { id: 'a', dust: 100 }, // 1/6
+        { id: 'b', dust: 200 }, // 2/6
+        { id: 'c', dust: 300 }, // 3/6
+      ],
+    });
+    const pool = s.distributablePool;
+    expect(s.rewards[0].reward).toBeCloseTo(pool * (100 / 600), 9);
+    expect(s.rewards[1].reward).toBeCloseTo(pool * (200 / 600), 9);
+    expect(s.rewards[2].reward).toBeCloseTo(pool * (300 / 600), 9);
+  });
+
+  it('echoes each entry id and dust onto its reward line', () => {
+    const s = settleStarVaultCycle({
+      priorLostInfluence: baseInfluence,
+      casinoHouseEdge: 0,
+      cleaned: [{ id: 'x', dust: 7 }],
+    });
+    expect(s.rewards[0].id).toBe('x');
+    expect(s.rewards[0].dust).toBe(7);
+  });
+});
+
+describe('settleStarVaultCycle — configuration', () => {
+  it('honors a custom skim rate', () => {
+    const s = settleStarVaultCycle(
+      {
+        priorLostInfluence: { oldest: 0, middle: 0, newest: 0 },
+        casinoHouseEdge: 1000,
+        cleaned: [{ id: 'a', dust: 1 }],
+      },
+      { skimRate: 0.05 },
+    );
+    expect(s.protocolSkim).toBeCloseTo(50, 9);
+    expect(s.distributablePool).toBeCloseTo(950, 9);
+  });
+
+  it('honors a custom split and depletion threshold', () => {
+    const s = settleStarVaultCycle(
+      {
+        priorLostInfluence: { oldest: 1000, middle: 0, newest: 0 },
+        casinoHouseEdge: 0,
+        cleaned: [{ id: 'a', dust: 1 }],
+        priorPoolDepletion: 0.6,
+      },
+      {
+        defaultSplit: [0.5, 0.5, 0.5],
+        escalatedSplit: [0.9, 0.9, 0.9],
+        depletionThreshold: 0.5,
+      },
+    );
+    // 0.6 > 0.5 → escalated; released = 0.9*1000 = 900
+    expect(s.escalated).toBe(true);
+    expect(s.grossPool).toBeCloseTo(900, 9);
+  });
+
+  it('exposes the ratified default constants', () => {
+    expect(DEFAULT_SPLIT).toEqual([0.4, 0.3, 0.3]);
+    expect(ESCALATED_SPLIT).toEqual([0.7, 0.15, 0.15]);
+    expect(DEFAULT_SKIM_RATE).toBe(0.02);
+    expect(DEFAULT_DEPLETION_THRESHOLD).toBe(0.8);
+  });
+});
+
+describe('settleStarVaultCycle — purity', () => {
+  it('is deterministic: same input → deep-equal output', () => {
+    const input: StarVaultCycleInput = {
+      priorLostInfluence: baseInfluence,
+      casinoHouseEdge: 200,
+      cleaned: [
+        { id: 'a', dust: 100 },
+        { id: 'b', dust: 300 },
+      ],
+    };
+    expect(settleStarVaultCycle(input)).toEqual(settleStarVaultCycle(input));
+  });
+
+  it('does not mutate its inputs', () => {
+    const input: StarVaultCycleInput = {
+      priorLostInfluence: { oldest: 1000, middle: 500, newest: 300 },
+      casinoHouseEdge: 200,
+      cleaned: [{ id: 'a', dust: 100 }],
+    };
+    const snapshot = JSON.stringify(input);
+    settleStarVaultCycle(input);
+    expect(JSON.stringify(input)).toBe(snapshot);
+  });
+});
+
+describe('settleStarVaultCycle — input validation', () => {
+  const ok: StarVaultCycleInput = {
+    priorLostInfluence: baseInfluence,
+    casinoHouseEdge: 0,
+    cleaned: [{ id: 'a', dust: 1 }],
+  };
+
+  it('rejects negative lost Influence', () => {
+    expect(() =>
+      settleStarVaultCycle({ ...ok, priorLostInfluence: { oldest: -1, middle: 0, newest: 0 } }),
+    ).toThrow(RangeError);
+  });
+
+  it('rejects negative casino house edge', () => {
+    expect(() => settleStarVaultCycle({ ...ok, casinoHouseEdge: -1 })).toThrow(RangeError);
+  });
+
+  it('rejects negative cleaned dust', () => {
+    expect(() => settleStarVaultCycle({ ...ok, cleaned: [{ id: 'a', dust: -5 }] })).toThrow(
+      RangeError,
+    );
+  });
+
+  it('rejects a non-finite inflow', () => {
+    expect(() => settleStarVaultCycle({ ...ok, casinoHouseEdge: NaN })).toThrow(TypeError);
+  });
+
+  it('rejects priorPoolDepletion outside [0, 1]', () => {
+    expect(() => settleStarVaultCycle({ ...ok, priorPoolDepletion: 1.5 })).toThrow(RangeError);
+  });
+
+  it('rejects a skim rate ≥ 1', () => {
+    expect(() => settleStarVaultCycle(ok, { skimRate: 1 })).toThrow(RangeError);
+  });
+
+  it('rejects a split weight outside [0, 1]', () => {
+    expect(() => settleStarVaultCycle(ok, { defaultSplit: [1.2, 0.3, 0.3] })).toThrow(RangeError);
+  });
+});

--- a/lib/outer-rim/starVault.ts
+++ b/lib/outer-rim/starVault.ts
@@ -1,0 +1,264 @@
+/**
+ * Star Vault — pure 24-hour cycle-settlement reducer.
+ *
+ * Models the Outer Rim "Star Vault" yield pool: each cycle a slice of the
+ * lost-Influence reserve (accumulated over the prior 3 cycles) plus the
+ * Cosmic Casino house-edge inflow is released, the 2% protocol skim is removed,
+ * and the remainder is distributed pro-rata across the DUST each Skrumpey
+ * cleaned this cycle. The un-released remainder of the reserve rolls forward as
+ * the next-cycle seed.
+ *
+ * Spec / sources:
+ *   - `docs/SANCTUARY_ADR_003_OUTER_RIM.md` §4 — Star Vault settlement.
+ *       §4.1 cycle (24h, engagement-gated), §4.2 reward formula
+ *       (reward_i = cleaned_i / total_cleaned × cycle pool), §4.3 pool sources
+ *       (1: lost Influence over prior 3 cycles, default split 40/30/30
+ *        escalating to 70/15/15; 2: casino house-edge inflow; 3: 2% protocol
+ *        skim), §4.4 this engine (`[SWO_OUTER_RIM_STAR_VAULT_ENGINE_PURE]`).
+ *   - Upstream memo `swo_offshore_protocol_analysis_2026-05-23.md` §1.3
+ *     (split escalation on >80% prior-pool depletion) and §4.1 (cycle
+ *     settlement), ratified verbatim into ADR-003 §4.
+ *   - Offshore Protocol swiss-vault doc:
+ *     `https://www.offshoreprotocol.fun/docs/swiss-vault` — the parent
+ *     mechanic this reducer ports (front-loading split + protocol skim).
+ *
+ * Conservation invariant (see `.test.ts`):
+ *
+ *   Σ rewards + protocolSkim + nextCycleSeed === totalInflows
+ *
+ * where `totalInflows = Σ prior-3-cycle lost Influence + casinoHouseEdge`.
+ * Nothing is created or destroyed: the released-and-distributed value, the
+ * skim, and the retained-plus-undistributed seed exactly re-sum to the inflows.
+ *
+ * Purity: no I/O, no clock, no randomness. Same inputs → same outputs, and
+ * inputs are never mutated.
+ */
+
+/**
+ * Lost Influence pooled in each of the prior 3 cycles, in DUST. Ordered by age:
+ * `oldest` is the cycle that pays out the largest split weight (ADR-003 §4.3
+ * item 1, "oldest cycle pays out 40%"). Each value must be ≥ 0.
+ */
+export interface PriorCycleInfluence {
+  oldest: number;
+  middle: number;
+  newest: number;
+}
+
+/** A single Skrumpey's cleaned-DUST contribution for the cycle. */
+export interface CleanedEntry {
+  /** Stable Skrumpey identifier (token id, wallet, etc.). */
+  id: string;
+  /** DUST cleaned by this Skrumpey this cycle. Must be ≥ 0. */
+  dust: number;
+}
+
+/** All inputs for one cycle settlement. */
+export interface StarVaultCycleInput {
+  /** Lost-Influence reserve for the prior 3 cycles (ADR-003 §4.3 item 1). */
+  priorLostInfluence: PriorCycleInfluence;
+  /** Casino house-edge inflow this cycle, in DUST (ADR-003 §4.3 item 2). Must be ≥ 0. */
+  casinoHouseEdge: number;
+  /** Per-Skrumpey DUST cleaned this cycle. */
+  cleaned: CleanedEntry[];
+  /**
+   * Fraction of the prior cycle's distributable pool that was paid out
+   * ("depleted"), ∈ [0, 1]. When this exceeds `depletionThreshold` the split
+   * escalates to front-load reward (memo §1.3 / ADR-003 §4.3). Default 0.
+   */
+  priorPoolDepletion?: number;
+}
+
+/** Split weights applied per prior cycle, ordered `[oldest, middle, newest]`. */
+export type SplitWeights = readonly [number, number, number];
+
+/** Tunable reducer constants. All ratified in ADR-003 §4.3. */
+export interface StarVaultConfig {
+  /** Default release split (ADR-003 §4.3). Default `[0.4, 0.3, 0.3]`. */
+  defaultSplit?: SplitWeights;
+  /** Escalated release split when prior pool depleted past threshold. Default `[0.7, 0.15, 0.15]`. */
+  escalatedSplit?: SplitWeights;
+  /** Depletion fraction above which the escalated split applies. Default 0.8 (>80%). */
+  depletionThreshold?: number;
+  /** Protocol skim fraction on the released pool. Default 0.02 (2%). */
+  skimRate?: number;
+}
+
+/** Default release split — 40/30/30 (ADR-003 §4.3 item 1). */
+export const DEFAULT_SPLIT: SplitWeights = [0.4, 0.3, 0.3];
+/** Escalated release split — 70/15/15 (ADR-003 §4.3 item 1). */
+export const ESCALATED_SPLIT: SplitWeights = [0.7, 0.15, 0.15];
+/** Default depletion threshold — escalate when prior pool > 80% depleted. */
+export const DEFAULT_DEPLETION_THRESHOLD = 0.8;
+/** Default protocol skim — 2% (ADR-003 §4.3 item 3). */
+export const DEFAULT_SKIM_RATE = 0.02;
+
+/** Per-Skrumpey reward line. */
+export interface StarVaultReward {
+  id: string;
+  /** Cleaned DUST that earned this reward (echoed from input). */
+  dust: number;
+  /** Pro-rata MON reward for this Skrumpey. */
+  reward: number;
+}
+
+/** Full result of settling one Star Vault cycle. */
+export interface StarVaultSettlement {
+  /** Whether the escalated split was triggered this cycle. */
+  escalated: boolean;
+  /** The split weights actually applied. */
+  splitApplied: SplitWeights;
+  /**
+   * Gross pool released this cycle, pre-skim:
+   * `Σ weight_i × priorLostInfluence_i + casinoHouseEdge`.
+   */
+  grossPool: number;
+  /** Protocol skim removed: `skimRate × grossPool`. */
+  protocolSkim: number;
+  /** Distributable pool after skim — the "cycle pool size" of ADR-003 §4.2. */
+  distributablePool: number;
+  /** Σ cleaned DUST across all entries. 0 ⇒ no distribution. */
+  totalCleaned: number;
+  /** Per-Skrumpey rewards (pro-rata on cleaned DUST). All 0 if `totalCleaned === 0`. */
+  rewards: StarVaultReward[];
+  /**
+   * Next-cycle pool seed: the un-released portion of the lost-Influence reserve
+   * (`Σ (1 − weight_i) × priorLostInfluence_i`) plus any distributable pool that
+   * went unclaimed because nobody cleaned DUST.
+   */
+  nextCycleSeed: number;
+  /**
+   * Distributable pool that went unclaimed (`totalCleaned === 0`). Folded into
+   * `nextCycleSeed`; 0 whenever at least one Skrumpey cleaned DUST.
+   */
+  undistributed: number;
+  /** Total inflows = `Σ priorLostInfluence + casinoHouseEdge` (conservation basis). */
+  totalInflows: number;
+}
+
+function requireFinite(value: number, name: string): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new TypeError(`${name} must be a finite number, got ${value}`);
+  }
+  return value;
+}
+
+function requireNonNegative(value: number, name: string): number {
+  requireFinite(value, name);
+  if (value < 0) {
+    throw new RangeError(`${name} must be ≥ 0, got ${value}`);
+  }
+  return value;
+}
+
+function resolveSplit(split: SplitWeights, name: string): SplitWeights {
+  if (!Array.isArray(split) || split.length !== 3) {
+    throw new TypeError(`${name} must be a 3-tuple of weights`);
+  }
+  split.forEach((w, i) => {
+    requireFinite(w, `${name}[${i}]`);
+    if (w < 0 || w > 1) {
+      throw new RangeError(`${name}[${i}] must be in [0, 1], got ${w}`);
+    }
+  });
+  return split;
+}
+
+function resolveSkimRate(config: StarVaultConfig): number {
+  const skimRate = config.skimRate ?? DEFAULT_SKIM_RATE;
+  requireFinite(skimRate, 'skimRate');
+  if (skimRate < 0 || skimRate >= 1) {
+    throw new RangeError(`skimRate must be in [0, 1), got ${skimRate}`);
+  }
+  return skimRate;
+}
+
+function resolveThreshold(config: StarVaultConfig): number {
+  const threshold = config.depletionThreshold ?? DEFAULT_DEPLETION_THRESHOLD;
+  requireFinite(threshold, 'depletionThreshold');
+  if (threshold < 0 || threshold > 1) {
+    throw new RangeError(`depletionThreshold must be in [0, 1], got ${threshold}`);
+  }
+  return threshold;
+}
+
+/**
+ * Settle one Star Vault cycle (ADR-003 §4). Pure: deterministic in its inputs
+ * with no side effects, and the inputs are never mutated.
+ */
+export function settleStarVaultCycle(
+  input: StarVaultCycleInput,
+  config: StarVaultConfig = {},
+): StarVaultSettlement {
+  const oldest = requireNonNegative(input.priorLostInfluence.oldest, 'priorLostInfluence.oldest');
+  const middle = requireNonNegative(input.priorLostInfluence.middle, 'priorLostInfluence.middle');
+  const newest = requireNonNegative(input.priorLostInfluence.newest, 'priorLostInfluence.newest');
+  const casinoHouseEdge = requireNonNegative(input.casinoHouseEdge, 'casinoHouseEdge');
+  const priorPoolDepletion = requireNonNegative(
+    input.priorPoolDepletion ?? 0,
+    'priorPoolDepletion',
+  );
+  if (priorPoolDepletion > 1) {
+    throw new RangeError(`priorPoolDepletion must be in [0, 1], got ${priorPoolDepletion}`);
+  }
+
+  const defaultSplit = resolveSplit(config.defaultSplit ?? DEFAULT_SPLIT, 'defaultSplit');
+  const escalatedSplit = resolveSplit(config.escalatedSplit ?? ESCALATED_SPLIT, 'escalatedSplit');
+  const skimRate = resolveSkimRate(config);
+  const threshold = resolveThreshold(config);
+
+  // Escalate the split to front-load reward when the prior pool was drained
+  // past the threshold (memo §1.3: ">80% depleted" → 70/15/15).
+  const escalated = priorPoolDepletion > threshold;
+  const splitApplied = escalated ? escalatedSplit : defaultSplit;
+
+  const reserve: SplitWeights = [oldest, middle, newest];
+  let releasedInfluence = 0;
+  let retainedInfluence = 0;
+  for (let i = 0; i < 3; i++) {
+    releasedInfluence += splitApplied[i] * reserve[i];
+    retainedInfluence += (1 - splitApplied[i]) * reserve[i];
+  }
+
+  const grossPool = releasedInfluence + casinoHouseEdge;
+  const protocolSkim = skimRate * grossPool;
+  const distributablePool = grossPool - protocolSkim;
+
+  let totalCleaned = 0;
+  for (const entry of input.cleaned) {
+    totalCleaned += requireNonNegative(entry.dust, `cleaned[${entry.id}].dust`);
+  }
+
+  const totalInflows = oldest + middle + newest + casinoHouseEdge;
+
+  let rewards: StarVaultReward[];
+  let undistributed: number;
+  if (totalCleaned === 0) {
+    // No eligible cleaner — distribute nothing, roll the pool into the seed.
+    rewards = input.cleaned.map((entry) => ({ id: entry.id, dust: entry.dust, reward: 0 }));
+    undistributed = distributablePool;
+  } else {
+    rewards = input.cleaned.map((entry) => ({
+      id: entry.id,
+      dust: entry.dust,
+      // ADR-003 §4.2: reward_i = (cleaned_i / total_cleaned) × cycle pool size.
+      reward: (entry.dust / totalCleaned) * distributablePool,
+    }));
+    undistributed = 0;
+  }
+
+  const nextCycleSeed = retainedInfluence + undistributed;
+
+  return {
+    escalated,
+    splitApplied,
+    grossPool,
+    protocolSkim,
+    distributablePool,
+    totalCleaned,
+    rewards,
+    nextCycleSeed,
+    undistributed,
+    totalInflows,
+  };
+}


### PR DESCRIPTION
## Summary
Pure, deterministic **Star Vault** cycle-settlement reducer at `lib/outer-rim/starVault.ts`, modeling the Outer Rim 24-hour yield pool per **`docs/SANCTUARY_ADR_003_OUTER_RIM.md` §4** (which ratifies upstream memo §1.3 / §4.1 and the Offshore swiss-vault doc).

`settleStarVaultCycle(input, config)`:
- **Releases** a slice of the lost-Influence reserve accumulated over the prior 3 cycles — default split **40/30/30** (oldest cycle pays 40%), escalating to **70/15/15** when the prior cycle's pool was **>80% depleted** (memo §1.3) — plus the **casino house-edge inflow** this cycle (§4.3 items 1–2).
- Removes the **2% protocol skim** (§4.3 item 3).
- **Distributes** the post-skim pool **pro-rata across cleaned DUST**: `reward_i = (cleaned_i / total_cleaned) × pool_size` (§4.2).
- Rolls the **un-released reserve** (`Σ (1−weight_i)·influence_i`) plus any **unclaimed pool** (when nobody cleaned) forward as the **next-cycle seed**.

## Acceptance criteria
- **(a) Pure** — no I/O, no clock, no RNG; inputs never mutated (purity tests assert deep-equal output + unchanged input snapshot).
- **(b) ≥20 vitest cases** — 31 total, including the five required scenarios: **1-player**, **100-player**, **dust-of-0 (no reward)**, **pool-empty**, **casino-inflow-only**.
- **(c) Conservation invariant** — `Σ rewards + protocolSkim + nextCycleSeed === totalInflows` asserted directly and across a 50-iteration deterministic fuzz.
- **(d) Cites** ADR-003 §4 (ratifying memo §1.3/§4.1) and the Offshore swiss-vault doc in the module header.

## Validations
- `npx vitest run lib/outer-rim/starVault.test.ts` → **31 passed**
- `npx tsc --noEmit` → no new errors
- `npx eslint` (both files) → clean

## Mirror Validation (PROD)
Copied both files into `/opt/star_world_order/PROD`, ran checks, then restored the mirror byte-identical (both files are NEW, removed after).
- **tsc --noEmit**: PASS (no starVault errors introduced)
- **vitest run** (`lib/outer-rim/starVault.test.ts`): PASS (31/31)
- Overall: **PASS**

## Notes / follow-ups
- ADR-003 §4.4 and the existing `lib/outer-rim/rewardMapping.ts` header reference this engine as `star-vault.ts` (kebab-case); the task specifies `starVault.ts` (camel-case), which this PR follows. A future small PR could reconcile the cross-reference / wire `rewardMapping`'s `SyntheticVaultCycle` seam to this engine's output.

PR class: **A** (full completion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)