### PR TITLE
feat(queue): reconcile held closures — reopen false-done QUEUE rows

### DIFF
--- a/scripts/queue/reconcile_held_closures.py
+++ b/scripts/queue/reconcile_held_closures.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""Reverse false queue closures whose post-flight artifact never landed.
+
+The spawn post-flight hook *detects* when a task is marked done in ``QUEUE.md``
+but its promised artifact is missing, emitting a
+``SPAWN_POSTFLIGHT_HELD: ARTIFACT_MISSING`` (or ``NO_CONCRETE_ARTIFACT_PATH``)
+row to ``monitoring/spawn_artifact_holds.log``. Detection alone does not undo
+the closure: the row stays ``[x]`` in ``QUEUE.md``, so it is counted as done
+while being silently incomplete — invisible to the scheduler yet unfinished.
+That silent-incomplete state is the dominant queue failure mode this month.
+
+This script closes the loop. It parses the hold log, dedupes by ``tag``, and
+for every held tag still marked ``[x]`` in ``QUEUE.md`` whose ``missing_path``
+is *still absent on disk* it reopens the row:
+
+* flips ``[x]`` -> ``[ ]``
+* strips the leading ``[UNVERIFIED]`` closure marker
+* appends ``_(reopened <date>: held artifact never landed — <missing_path>)_``
+
+Tags whose ``missing_path`` now EXISTS on disk are treated as
+``FALSE_HOLD_RESOLVED`` (a stale hold from the verifier/workspace mismatch,
+see MEMORY.md) and are *skipped*, never reopened.
+
+Default mode is ``--dry-run`` (prints the unified intent, mutates nothing).
+``--apply`` rewrites ``QUEUE.md`` and appends one audit row per reopen to
+``monitoring/held_closure_reopens.log``.
+
+Hold-log format (JSON lines, one event per line)::
+
+    {"ts": "2026-05-23T11:08:00Z", "event": "SPAWN_POSTFLIGHT_HELD",
+     "tag": "BRAIN_AVG_ONNX_WARMUP_2026-05-23", "reason": "ARTIFACT_MISSING",
+     "missing_path": "docs/brain/avg_onnx_warmup.md"}
+
+Lines that are not JSON, lack a ``tag``, or carry a non-held reason are
+ignored, so the parser tolerates interleaved free-form log noise.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+
+# Reasons that mean "the closure was held because the artifact never landed".
+HELD_REASONS = frozenset({"ARTIFACT_MISSING", "NO_CONCRETE_ARTIFACT_PATH"})
+
+DEFAULT_HOLD_LOG = "monitoring/spawn_artifact_holds.log"
+DEFAULT_QUEUE = "memory/evolution/QUEUE.md"
+DEFAULT_REOPEN_LOG = "monitoring/held_closure_reopens.log"
+
+# A markdown checklist row that is currently CLOSED: ``- [x] ...`` / ``* [x] ...``.
+# Group 1 = list prefix incl. the bracket, group 2 = the trailing content.
+_CHECKED_ROW = re.compile(r"^(\s*[-*]\s*)\[[xX]\](\s+)(.*)$")
+# A leading ``[UNVERIFIED]`` closure marker (optionally followed by whitespace).
+_UNVERIFIED = re.compile(r"^\[UNVERIFIED\]\s*")
+
+
+@dataclass(frozen=True)
+class HoldEntry:
+    """A single deduped post-flight hold for one tag."""
+
+    tag: str
+    reason: str
+    missing_path: str
+    ts: str = ""
+
+
+@dataclass(frozen=True)
+class Action:
+    """The decision taken for one held tag."""
+
+    tag: str
+    kind: str  # REOPENED | FALSE_HOLD_RESOLVED | NO_OPEN_ROW
+    missing_path: str
+    old_line: str = ""
+    new_line: str = ""
+
+
+def parse_hold_log(text: str) -> "dict[str, HoldEntry]":
+    """Parse hold-log text into ``{tag: HoldEntry}``, deduped by tag.
+
+    Dedupe keeps the *last* held event for a tag (most recent state wins).
+    Only events whose ``reason`` is in :data:`HELD_REASONS` are retained.
+    Malformed / unrelated lines are silently skipped.
+    """
+    holds: dict[str, HoldEntry] = {}
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            rec = json.loads(line)
+        except (ValueError, TypeError):
+            continue
+        if not isinstance(rec, dict):
+            continue
+        reason = rec.get("reason")
+        tag = rec.get("tag")
+        if reason not in HELD_REASONS or not tag:
+            continue
+        holds[tag] = HoldEntry(
+            tag=tag,
+            reason=reason,
+            missing_path=rec.get("missing_path", "") or "",
+            ts=rec.get("ts", "") or "",
+        )
+    return holds
+
+
+def artifact_exists(missing_path: str, repo_root: str) -> bool:
+    """True if ``missing_path`` resolves to something on disk under ``repo_root``."""
+    if not missing_path:
+        return False
+    path = missing_path
+    if not os.path.isabs(path):
+        path = os.path.join(repo_root, missing_path)
+    return os.path.exists(path)
+
+
+def _row_matches_tag(content: str, tag: str) -> bool:
+    """True if a checklist row's content references ``[<tag>]`` as a token."""
+    return f"[{tag}]" in content
+
+
+def reconcile(
+    queue_text: str,
+    holds: "dict[str, HoldEntry]",
+    repo_root: str,
+    date: str,
+) -> "tuple[str, list[Action]]":
+    """Compute reopened ``QUEUE.md`` text and the list of actions taken.
+
+    For each held tag (deduped) we locate the *checked* row that references it:
+
+    * artifact still absent -> reopen the row (``[x]`` -> ``[ ]``, strip
+      ``[UNVERIFIED]``, append the reopened annotation) and record ``REOPENED``.
+    * artifact now present -> record ``FALSE_HOLD_RESOLVED`` and leave it closed.
+    * no open ``[x]`` row found -> record ``NO_OPEN_ROW`` (nothing to reverse).
+    """
+    lines = queue_text.split("\n")
+    actions: list[Action] = []
+
+    for tag in sorted(holds):
+        entry = holds[tag]
+        if artifact_exists(entry.missing_path, repo_root):
+            actions.append(
+                Action(tag, "FALSE_HOLD_RESOLVED", entry.missing_path)
+            )
+            continue
+
+        idx = _find_checked_row(lines, tag)
+        if idx is None:
+            actions.append(Action(tag, "NO_OPEN_ROW", entry.missing_path))
+            continue
+
+        old_line = lines[idx]
+        new_line = _reopen_line(old_line, entry.missing_path, date)
+        lines[idx] = new_line
+        actions.append(
+            Action(tag, "REOPENED", entry.missing_path, old_line, new_line)
+        )
+
+    return "\n".join(lines), actions
+
+
+def _find_checked_row(lines: "list[str]", tag: str) -> "int | None":
+    """Index of the first ``[x]`` checklist row referencing ``tag``, or None."""
+    for i, line in enumerate(lines):
+        m = _CHECKED_ROW.match(line)
+        if m and _row_matches_tag(m.group(3), tag):
+            return i
+    return None
+
+
+def _reopen_line(line: str, missing_path: str, date: str) -> str:
+    """Flip a checked row to open, drop ``[UNVERIFIED]``, append the note."""
+    m = _CHECKED_ROW.match(line)
+    assert m is not None, "caller must pass a checked row"
+    prefix, _gap, content = m.group(1), m.group(2), m.group(3)
+    content = _UNVERIFIED.sub("", content, count=1)
+    note = f" _(reopened {date}: held artifact never landed — {missing_path})_"
+    return f"{prefix}[ ] {content}{note}"
+
+
+def render_report(actions: "list[Action]", apply: bool) -> str:
+    """Human-readable closure report: reopened vs false-hold-skipped counts."""
+    reopened = [a for a in actions if a.kind == "REOPENED"]
+    false_holds = [a for a in actions if a.kind == "FALSE_HOLD_RESOLVED"]
+    no_row = [a for a in actions if a.kind == "NO_OPEN_ROW"]
+
+    mode = "APPLY" if apply else "DRY-RUN"
+    out = [f"=== held-closure reconcile ({mode}) ==="]
+
+    if reopened:
+        out.append(f"\nReopened ({len(reopened)}):")
+        for a in reopened:
+            out.append(f"  [x] -> [ ]  {a.tag}")
+            out.append(f"      missing: {a.missing_path}")
+    if false_holds:
+        out.append(f"\nFalse holds resolved — skipped ({len(false_holds)}):")
+        for a in false_holds:
+            out.append(f"  KEEP [x]  {a.tag}  (artifact now present: {a.missing_path})")
+    if no_row:
+        out.append(f"\nHeld tags with no open [x] row — nothing to reverse ({len(no_row)}):")
+        for a in no_row:
+            out.append(f"  --  {a.tag}")
+
+    out.append(
+        f"\nSummary: reopened={len(reopened)} "
+        f"false_hold_skipped={len(false_holds)} no_open_row={len(no_row)}"
+    )
+    if not apply and reopened:
+        out.append("(dry-run: no files modified — re-run with --apply to reopen)")
+    return "\n".join(out)
+
+
+def _audit_rows(actions: "list[Action]", now_iso: str) -> "list[str]":
+    """One audit line per reopen for ``held_closure_reopens.log``."""
+    return [
+        f"{now_iso} | REOPENED | {a.tag} | {a.missing_path}"
+        for a in actions
+        if a.kind == "REOPENED"
+    ]
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Reopen falsely-closed QUEUE.md rows whose held artifact never landed.",
+    )
+    parser.add_argument("--repo-root", default=".", help="repo root for path resolution (default: .)")
+    parser.add_argument("--hold-log", default=None, help=f"hold log path (default: <repo>/{DEFAULT_HOLD_LOG})")
+    parser.add_argument("--queue", default=None, help=f"QUEUE.md path (default: <repo>/{DEFAULT_QUEUE})")
+    parser.add_argument("--reopen-log", default=None, help=f"audit log path (default: <repo>/{DEFAULT_REOPEN_LOG})")
+    parser.add_argument("--date", default=_dt.date.today().isoformat(), help="reopened-on date (default: today)")
+    parser.add_argument("--apply", action="store_true", help="mutate QUEUE.md (default: dry-run)")
+    args = parser.parse_args(argv)
+
+    repo_root = os.path.abspath(args.repo_root)
+    hold_log = args.hold_log or os.path.join(repo_root, DEFAULT_HOLD_LOG)
+    queue = args.queue or os.path.join(repo_root, DEFAULT_QUEUE)
+    reopen_log = args.reopen_log or os.path.join(repo_root, DEFAULT_REOPEN_LOG)
+
+    if not os.path.exists(hold_log):
+        print(f"hold log not found: {hold_log}", file=sys.stderr)
+        return 2
+    if not os.path.exists(queue):
+        print(f"QUEUE.md not found: {queue}", file=sys.stderr)
+        return 2
+
+    with open(hold_log, encoding="utf-8") as fh:
+        holds = parse_hold_log(fh.read())
+    with open(queue, encoding="utf-8") as fh:
+        queue_text = fh.read()
+
+    new_text, actions = reconcile(queue_text, holds, repo_root, args.date)
+    print(render_report(actions, args.apply))
+
+    if args.apply:
+        reopened = [a for a in actions if a.kind == "REOPENED"]
+        if reopened:
+            with open(queue, "w", encoding="utf-8") as fh:
+                fh.write(new_text)
+            now_iso = _dt.datetime.now(_dt.timezone.utc).isoformat()
+            os.makedirs(os.path.dirname(reopen_log) or ".", exist_ok=True)
+            with open(reopen_log, "a", encoding="utf-8") as fh:
+                fh.write("\n".join(_audit_rows(actions, now_iso)) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_reconcile_held_closures.py
+++ b/tests/test_reconcile_held_closures.py
@@ -1,0 +1,161 @@
+"""Tests for scripts/queue/reconcile_held_closures.py.
+
+Covers the acceptance cases:
+* a held tag whose missing_path is absent is reopened ([x] -> [ ], note appended)
+* a held tag whose missing_path EXISTS is skipped as a false hold (stays [x])
+* repeated log lines for the same tag dedupe to a single action
+* --dry-run mutates nothing on disk
+* --apply flips rows and writes the audit log
+"""
+import importlib.util
+import json
+import os
+import sys
+
+import pytest
+
+_HERE = os.path.dirname(__file__)
+_SCRIPT = os.path.normpath(
+    os.path.join(_HERE, "..", "scripts", "queue", "reconcile_held_closures.py")
+)
+_spec = importlib.util.spec_from_file_location("reconcile_held_closures", _SCRIPT)
+rhc = importlib.util.module_from_spec(_spec)
+sys.modules["reconcile_held_closures"] = rhc  # needed for dataclass annotation resolution
+_spec.loader.exec_module(rhc)
+
+DATE = "2026-05-26"
+
+
+def _hold(tag, missing_path, reason="ARTIFACT_MISSING", ts="2026-05-26T11:08:00Z"):
+    return json.dumps(
+        {"ts": ts, "event": "SPAWN_POSTFLIGHT_HELD", "tag": tag,
+         "reason": reason, "missing_path": missing_path}
+    )
+
+
+# --------------------------------------------------------------------------- #
+# parse_hold_log
+# --------------------------------------------------------------------------- #
+def test_parse_only_held_reasons():
+    log = "\n".join([
+        _hold("TAG_A", "docs/a.md", reason="ARTIFACT_MISSING"),
+        _hold("TAG_B", "docs/b.md", reason="NO_CONCRETE_ARTIFACT_PATH"),
+        _hold("TAG_C", "docs/c.md", reason="SOME_OTHER_REASON"),
+        "not json at all",
+        json.dumps({"reason": "ARTIFACT_MISSING"}),  # no tag -> skipped
+    ])
+    holds = rhc.parse_hold_log(log)
+    assert set(holds) == {"TAG_A", "TAG_B"}
+    assert holds["TAG_B"].reason == "NO_CONCRETE_ARTIFACT_PATH"
+
+
+def test_dedupe_repeated_lines_last_wins():
+    log = "\n".join([
+        _hold("TAG_A", "docs/old.md", ts="2026-05-20T00:00:00Z"),
+        _hold("TAG_A", "docs/new.md", ts="2026-05-26T00:00:00Z"),
+        _hold("TAG_A", "docs/new.md", ts="2026-05-26T00:00:00Z"),
+    ])
+    holds = rhc.parse_hold_log(log)
+    assert list(holds) == ["TAG_A"]  # single deduped entry
+    assert holds["TAG_A"].missing_path == "docs/new.md"
+
+
+# --------------------------------------------------------------------------- #
+# reconcile (in-memory)
+# --------------------------------------------------------------------------- #
+def test_missing_path_tag_is_reopened(tmp_path):
+    queue = (
+        "# Queue\n"
+        "- [x] [UNVERIFIED] [TAG_MISSING] ship the thing\n"
+        "- [ ] [TAG_PENDING] not yet\n"
+    )
+    holds = {"TAG_MISSING": rhc.HoldEntry("TAG_MISSING", "ARTIFACT_MISSING", "docs/missing.md")}
+    new_text, actions = rhc.reconcile(queue, holds, str(tmp_path), DATE)
+
+    assert [a.kind for a in actions] == ["REOPENED"]
+    assert "- [ ] [TAG_MISSING] ship the thing" in new_text
+    assert "[UNVERIFIED]" not in new_text  # marker stripped
+    assert "_(reopened 2026-05-26: held artifact never landed — docs/missing.md)_" in new_text
+    assert "[x]" not in new_text.split("\n")[1]  # the row is no longer checked
+
+
+def test_present_path_tag_skipped_as_false_hold(tmp_path):
+    # Create the artifact so it "exists" on disk.
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "present.md").write_text("landed")
+    queue = "- [x] [UNVERIFIED] [TAG_PRESENT] done for real\n"
+    holds = {"TAG_PRESENT": rhc.HoldEntry("TAG_PRESENT", "ARTIFACT_MISSING", "docs/present.md")}
+
+    new_text, actions = rhc.reconcile(queue, holds, str(tmp_path), DATE)
+    assert [a.kind for a in actions] == ["FALSE_HOLD_RESOLVED"]
+    assert new_text == queue  # untouched, stays [x]
+
+
+def test_no_open_row_for_tag(tmp_path):
+    queue = "- [ ] [TAG_X] already open\n"
+    holds = {"TAG_X": rhc.HoldEntry("TAG_X", "ARTIFACT_MISSING", "docs/x.md")}
+    new_text, actions = rhc.reconcile(queue, holds, str(tmp_path), DATE)
+    assert [a.kind for a in actions] == ["NO_OPEN_ROW"]
+    assert new_text == queue
+
+
+def test_reopen_without_unverified_marker(tmp_path):
+    queue = "- [x] [TAG_PLAIN] no unverified marker here\n"
+    holds = {"TAG_PLAIN": rhc.HoldEntry("TAG_PLAIN", "ARTIFACT_MISSING", "docs/p.md")}
+    new_text, actions = rhc.reconcile(queue, holds, str(tmp_path), DATE)
+    assert actions[0].kind == "REOPENED"
+    assert "- [ ] [TAG_PLAIN] no unverified marker here _(reopened" in new_text
+
+
+# --------------------------------------------------------------------------- #
+# CLI: dry-run vs apply
+# --------------------------------------------------------------------------- #
+def _write_case(tmp_path):
+    (tmp_path / "monitoring").mkdir()
+    (tmp_path / "memory" / "evolution").mkdir(parents=True)
+    hold_log = tmp_path / "monitoring" / "spawn_artifact_holds.log"
+    hold_log.write_text("\n".join([
+        _hold("TAG_MISSING", "docs/missing.md"),
+        _hold("TAG_MISSING", "docs/missing.md"),  # dup
+    ]) + "\n")
+    queue = tmp_path / "memory" / "evolution" / "QUEUE.md"
+    queue.write_text("- [x] [UNVERIFIED] [TAG_MISSING] ship it\n")
+    return hold_log, queue
+
+
+def test_dry_run_mutates_nothing(tmp_path, capsys):
+    hold_log, queue = _write_case(tmp_path)
+    before = queue.read_text()
+    rc = rhc.main(["--repo-root", str(tmp_path), "--date", DATE])
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert queue.read_text() == before  # unchanged
+    assert "reopened=1" in out
+    assert "TAG_MISSING" in out
+    assert "docs/missing.md" in out
+    assert not (tmp_path / "monitoring" / "held_closure_reopens.log").exists()
+
+
+def test_apply_flips_row_and_writes_audit(tmp_path):
+    hold_log, queue = _write_case(tmp_path)
+    rc = rhc.main(["--repo-root", str(tmp_path), "--date", DATE, "--apply"])
+    assert rc == 0
+
+    text = queue.read_text()
+    assert "- [ ] [TAG_MISSING] ship it" in text
+    assert "[UNVERIFIED]" not in text
+    assert "_(reopened 2026-05-26:" in text
+
+    audit = (tmp_path / "monitoring" / "held_closure_reopens.log").read_text()
+    assert audit.count("REOPENED | TAG_MISSING") == 1  # deduped -> one row
+
+
+def test_missing_inputs_return_error(tmp_path, capsys):
+    rc = rhc.main(["--repo-root", str(tmp_path), "--date", DATE])
+    assert rc == 2
+    assert "not found" in capsys.readouterr().err
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## What

Authors `scripts/queue/reconcile_held_closures.py` + `tests/test_reconcile_held_closures.py` to **reverse silent false closures** — the dominant queue failure mode this month. The spawn post-flight hook already *detects* when a row is marked `[x]` but its artifact never landed (`SPAWN_POSTFLIGHT_HELD: ARTIFACT_MISSING`); nothing previously *reversed* the closure, so the row stayed counted-as-done yet incomplete and invisible to the scheduler.

## Behavior (matches task spec)

1. Parses `monitoring/spawn_artifact_holds.log` (JSON-lines) for `reason ∈ {ARTIFACT_MISSING, NO_CONCRETE_ARTIFACT_PATH}`, **deduped by tag** (last event wins).
2. For each held tag still `[x]` in `QUEUE.md` whose `missing_path` is **still absent on disk**: flips `[x] → [ ]`, strips the leading `[UNVERIFIED]` closure marker, and appends ` _(reopened 2026-05-26: held artifact never landed — <missing_path>)_`.
3. Writes one audit row per reopen to `monitoring/held_closure_reopens.log`.
4. `--dry-run` is the **default** (prints the diff, mutates nothing); `--apply` mutates.
5. Tags whose `missing_path` now **EXISTS** on disk are **skipped** and logged as `FALSE_HOLD_RESOLVED` (stale hold from the verifier/workspace mismatch — see MEMORY.md), never reopened.
6. Closure report counts **reopened vs false-hold-skipped** (+ a `no_open_row` bucket for held tags with no matching `[x]` row).

Paths are configurable (`--repo-root`, `--hold-log`, `--queue`, `--reopen-log`, `--date`) and default to the conventional locations.

## Acceptance

- (a) Tests pass — 9 cases, all green:
```
9 passed in 0.22s
```
  Covers: missing-path tag reopened; present-path tag skipped as false-hold; dedupe across repeated log lines; dry-run mutates nothing; `--apply` flips row + writes audit; held-reasons-only parse; no-open-row bucket; missing-input error.
- (b) `--dry-run` lists each genuinely-held tag with its missing path (verified end-to-end against a synthetic fixture).
- (c) `--apply` flips them so the next evolution scan sees them pending; audit log written.
- (d) Closure report prints `reopened=N false_hold_skipped=M no_open_row=K`.

## Scope note

`(PROJECT:CLARVIS, P1)`. The production `monitoring/spawn_artifact_holds.log` and `memory/evolution/QUEUE.md` are external Clarvis queue infra (not committed to this app repo — only a gitignored keeper-health log convention lives under `monitoring/`). The deliverable is a **self-contained, path-parameterized tool** that the queue infra can point at the real files; tests run entirely against synthetic temp fixtures, so they need no external infra and don't touch the Clarvis brain/memory.

## Mirror Validation (PROD)
- **tsc --noEmit**: PASS (N/A by construction — Python-only change; `.py` files are not compiled or imported by the TS toolchain, so no new tsc errors are possible under the baseline-diff gate)
- **vitest run**: PASS (N/A by construction — vitest globs only `**/*.{test,spec}.{ts,tsx}`; the new `.py` test is not collected)
Overall: PASS

## Test plan
```
python3 -m pytest tests/test_reconcile_held_closures.py -q   # 9 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)