### PR TITLE
feat(outer-rim): canonical Equipment catalog + schema + tests [SWO_OUTER_RIM_EQUIPMENT_DATA_SCHEMA]

### DIFF
--- a/data/outer-rim/equipment_items.json
+++ b/data/outer-rim/equipment_items.json
@@ -1,0 +1,389 @@
+{
+  "$schema_version": "1.0.0",
+  "spec_id": "SWO_OUTER_RIM_EQUIPMENT_DATA_SCHEMA",
+  "description": "Canonical Outer Rim Equipment catalog: 6 slots x 7 assets = 42 items, each carrying a 6-stat Common-base block. Rarity multipliers (x1 / x1.5 / x2.5 / x4.5 / x8) are lifted verbatim from Offshore (ADR-003 SS3.4) and applied at runtime over these base blocks. Each base_stats block is a normalized 100-point budget: every output point (haul_rate, speed, bonus_chance, bonus_multiplier) is paid for with a survival point (detection_tolerance, stealth), encoding the non-negotiable output<->survival tradeoff. Because all base blocks sum to the same budget, no distinct item can Pareto-dominate another. Schema: equipment_items.schema.json. Tests: lib/outer-rim/equipment.test.ts.",
+  "slots": ["Vessel", "Crew", "Cloaking", "Cargo", "Quartermaster", "CommsBlackout"],
+  "stats": ["haul_rate", "detection_tolerance", "speed", "stealth", "bonus_chance", "bonus_multiplier"],
+  "rarity_multipliers": { "Common": 1, "Rare": 1.5, "Epic": 2.5, "Legendary": 4.5, "Mythic": 8 },
+  "stat_sum_budget": 100,
+  "items": [
+    {
+      "item_key": "vessel_rustbucket_skiff",
+      "name": "Rustbucket Skiff",
+      "slot": "Vessel",
+      "rarity": "Common",
+      "asset_key": "vessel_rustbucket_skiff",
+      "lore": "Held together with prayer-tape and a stubborn refusal to sink.",
+      "base_stats": { "haul_rate": 30, "detection_tolerance": 20, "speed": 25, "stealth": 10, "bonus_chance": 8, "bonus_multiplier": 7 }
+    },
+    {
+      "item_key": "vessel_ion_runner",
+      "name": "Ion Runner",
+      "slot": "Vessel",
+      "rarity": "Common",
+      "asset_key": "vessel_ion_runner",
+      "lore": "Fast enough to outrun a patrol, loud enough to wake one.",
+      "base_stats": { "haul_rate": 28, "detection_tolerance": 15, "speed": 32, "stealth": 8, "bonus_chance": 9, "bonus_multiplier": 8 }
+    },
+    {
+      "item_key": "vessel_void_clipper",
+      "name": "Void Clipper",
+      "slot": "Vessel",
+      "rarity": "Common",
+      "asset_key": "vessel_void_clipper",
+      "lore": "A smuggler's classic: deep holds, shallow conscience.",
+      "base_stats": { "haul_rate": 35, "detection_tolerance": 18, "speed": 22, "stealth": 9, "bonus_chance": 8, "bonus_multiplier": 8 }
+    },
+    {
+      "item_key": "vessel_nebula_barge",
+      "name": "Nebula Barge",
+      "slot": "Vessel",
+      "rarity": "Common",
+      "asset_key": "vessel_nebula_barge",
+      "lore": "Slow, fat, and gloriously full of someone else's cargo.",
+      "base_stats": { "haul_rate": 40, "detection_tolerance": 22, "speed": 14, "stealth": 12, "bonus_chance": 6, "bonus_multiplier": 6 }
+    },
+    {
+      "item_key": "vessel_phantom_yacht",
+      "name": "Phantom Yacht",
+      "slot": "Vessel",
+      "rarity": "Common",
+      "asset_key": "vessel_phantom_yacht",
+      "lore": "Looks like a pleasure cruiser; runs like a ghost.",
+      "base_stats": { "haul_rate": 22, "detection_tolerance": 20, "speed": 20, "stealth": 25, "bonus_chance": 7, "bonus_multiplier": 6 }
+    },
+    {
+      "item_key": "vessel_dreadnaught_hull",
+      "name": "Dreadnaught Hull",
+      "slot": "Vessel",
+      "rarity": "Common",
+      "asset_key": "vessel_dreadnaught_hull",
+      "lore": "Armored to shrug off patrols, too proud to hide from them.",
+      "base_stats": { "haul_rate": 38, "detection_tolerance": 30, "speed": 12, "stealth": 10, "bonus_chance": 5, "bonus_multiplier": 5 }
+    },
+    {
+      "item_key": "vessel_starlight_cutter",
+      "name": "Starlight Cutter",
+      "slot": "Vessel",
+      "rarity": "Common",
+      "asset_key": "vessel_starlight_cutter",
+      "lore": "Trim, quick, and built for the long dark between checkpoints.",
+      "base_stats": { "haul_rate": 26, "detection_tolerance": 16, "speed": 30, "stealth": 12, "bonus_chance": 8, "bonus_multiplier": 8 }
+    },
+    {
+      "item_key": "crew_greenhorn_deckhands",
+      "name": "Greenhorn Deckhands",
+      "slot": "Crew",
+      "rarity": "Common",
+      "asset_key": "crew_greenhorn_deckhands",
+      "lore": "Eager, cheap, and only occasionally a liability.",
+      "base_stats": { "haul_rate": 18, "detection_tolerance": 22, "speed": 15, "stealth": 13, "bonus_chance": 18, "bonus_multiplier": 14 }
+    },
+    {
+      "item_key": "crew_void_pirates",
+      "name": "Void Pirates",
+      "slot": "Crew",
+      "rarity": "Common",
+      "asset_key": "crew_void_pirates",
+      "lore": "They take a cut, but the score is always bigger when they swing.",
+      "base_stats": { "haul_rate": 22, "detection_tolerance": 16, "speed": 18, "stealth": 9, "bonus_chance": 20, "bonus_multiplier": 15 }
+    },
+    {
+      "item_key": "crew_exiled_navigators",
+      "name": "Exiled Navigators",
+      "slot": "Crew",
+      "rarity": "Common",
+      "asset_key": "crew_exiled_navigators",
+      "lore": "Banished for charting routes that were never meant to exist.",
+      "base_stats": { "haul_rate": 16, "detection_tolerance": 20, "speed": 24, "stealth": 12, "bonus_chance": 16, "bonus_multiplier": 12 }
+    },
+    {
+      "item_key": "crew_rogue_ai_cluster",
+      "name": "Rogue AI Cluster",
+      "slot": "Crew",
+      "rarity": "Common",
+      "asset_key": "crew_rogue_ai_cluster",
+      "lore": "It calls the crits. It does not explain how.",
+      "base_stats": { "haul_rate": 20, "detection_tolerance": 14, "speed": 20, "stealth": 8, "bonus_chance": 22, "bonus_multiplier": 16 }
+    },
+    {
+      "item_key": "crew_mercenary_gunners",
+      "name": "Mercenary Gunners",
+      "slot": "Crew",
+      "rarity": "Common",
+      "asset_key": "crew_mercenary_gunners",
+      "lore": "Loyal to the manifest, devoted to the bonus payout.",
+      "base_stats": { "haul_rate": 24, "detection_tolerance": 18, "speed": 14, "stealth": 8, "bonus_chance": 19, "bonus_multiplier": 17 }
+    },
+    {
+      "item_key": "crew_smuggler_guild",
+      "name": "Smuggler's Guild",
+      "slot": "Crew",
+      "rarity": "Common",
+      "asset_key": "crew_smuggler_guild",
+      "lore": "Old hands who know which patrols can be bought and which must be ghosted.",
+      "base_stats": { "haul_rate": 17, "detection_tolerance": 19, "speed": 16, "stealth": 18, "bonus_chance": 16, "bonus_multiplier": 14 }
+    },
+    {
+      "item_key": "crew_ghost_crew",
+      "name": "Ghost Crew",
+      "slot": "Crew",
+      "rarity": "Common",
+      "asset_key": "crew_ghost_crew",
+      "lore": "Nobody signed them on. Nobody saw them leave.",
+      "base_stats": { "haul_rate": 14, "detection_tolerance": 16, "speed": 14, "stealth": 28, "bonus_chance": 15, "bonus_multiplier": 13 }
+    },
+    {
+      "item_key": "cloaking_patchwork_tarp",
+      "name": "Patchwork Tarp",
+      "slot": "Cloaking",
+      "rarity": "Common",
+      "asset_key": "cloaking_patchwork_tarp",
+      "lore": "It hides the cargo as long as nobody looks too hard.",
+      "base_stats": { "haul_rate": 18, "detection_tolerance": 25, "speed": 12, "stealth": 30, "bonus_chance": 8, "bonus_multiplier": 7 }
+    },
+    {
+      "item_key": "cloaking_mirror_field",
+      "name": "Mirror Field",
+      "slot": "Cloaking",
+      "rarity": "Common",
+      "asset_key": "cloaking_mirror_field",
+      "lore": "Patrols see only their own reflection and wave you through.",
+      "base_stats": { "haul_rate": 14, "detection_tolerance": 20, "speed": 12, "stealth": 40, "bonus_chance": 7, "bonus_multiplier": 7 }
+    },
+    {
+      "item_key": "cloaking_phase_shroud",
+      "name": "Phase Shroud",
+      "slot": "Cloaking",
+      "rarity": "Common",
+      "asset_key": "cloaking_phase_shroud",
+      "lore": "Half in this dimension, half somewhere the patrols can't subpoena.",
+      "base_stats": { "haul_rate": 10, "detection_tolerance": 18, "speed": 12, "stealth": 50, "bonus_chance": 5, "bonus_multiplier": 5 }
+    },
+    {
+      "item_key": "cloaking_null_signature",
+      "name": "Null Signature",
+      "slot": "Cloaking",
+      "rarity": "Common",
+      "asset_key": "cloaking_null_signature",
+      "lore": "On every sensor you read as empty space and bad luck.",
+      "base_stats": { "haul_rate": 8, "detection_tolerance": 16, "speed": 11, "stealth": 60, "bonus_chance": 3, "bonus_multiplier": 2 }
+    },
+    {
+      "item_key": "cloaking_event_horizon_veil",
+      "name": "Event Horizon Veil",
+      "slot": "Cloaking",
+      "rarity": "Common",
+      "asset_key": "cloaking_event_horizon_veil",
+      "lore": "The darkest cloak ever woven; light goes in, suspicion never comes out.",
+      "base_stats": { "haul_rate": 6, "detection_tolerance": 16, "speed": 8, "stealth": 70, "bonus_chance": 0, "bonus_multiplier": 0 }
+    },
+    {
+      "item_key": "cloaking_chameleon_plating",
+      "name": "Chameleon Plating",
+      "slot": "Cloaking",
+      "rarity": "Common",
+      "asset_key": "cloaking_chameleon_plating",
+      "lore": "Reads as a harmless freighter right up until it doesn't.",
+      "base_stats": { "haul_rate": 20, "detection_tolerance": 28, "speed": 12, "stealth": 28, "bonus_chance": 7, "bonus_multiplier": 5 }
+    },
+    {
+      "item_key": "cloaking_decoy_array",
+      "name": "Decoy Array",
+      "slot": "Cloaking",
+      "rarity": "Common",
+      "asset_key": "cloaking_decoy_array",
+      "lore": "Spawns a dozen phantom ships; patrols chase the wrong nine.",
+      "base_stats": { "haul_rate": 16, "detection_tolerance": 35, "speed": 14, "stealth": 22, "bonus_chance": 7, "bonus_multiplier": 6 }
+    },
+    {
+      "item_key": "cargo_scrap_ore",
+      "name": "Scrap Ore",
+      "slot": "Cargo",
+      "rarity": "Common",
+      "asset_key": "cargo_scrap_ore",
+      "lore": "Heavy, dull, and legal enough to bore a patrol into waving you on.",
+      "base_stats": { "haul_rate": 42, "detection_tolerance": 24, "speed": 12, "stealth": 10, "bonus_chance": 6, "bonus_multiplier": 6 }
+    },
+    {
+      "item_key": "cargo_contraband_spice",
+      "name": "Contraband Spice",
+      "slot": "Cargo",
+      "rarity": "Common",
+      "asset_key": "cargo_contraband_spice",
+      "lore": "Worth a fortune per gram and a death sentence per crate.",
+      "base_stats": { "haul_rate": 45, "detection_tolerance": 20, "speed": 12, "stealth": 8, "bonus_chance": 8, "bonus_multiplier": 7 }
+    },
+    {
+      "item_key": "cargo_stolen_relics",
+      "name": "Stolen Relics",
+      "slot": "Cargo",
+      "rarity": "Common",
+      "asset_key": "cargo_stolen_relics",
+      "lore": "Pried from a museum nobody admits owning.",
+      "base_stats": { "haul_rate": 38, "detection_tolerance": 18, "speed": 14, "stealth": 12, "bonus_chance": 10, "bonus_multiplier": 8 }
+    },
+    {
+      "item_key": "cargo_dark_matter_vials",
+      "name": "Dark Matter Vials",
+      "slot": "Cargo",
+      "rarity": "Common",
+      "asset_key": "cargo_dark_matter_vials",
+      "lore": "Pays like nothing else and screams across every sensor in the sector.",
+      "base_stats": { "haul_rate": 48, "detection_tolerance": 26, "speed": 10, "stealth": 6, "bonus_chance": 6, "bonus_multiplier": 4 }
+    },
+    {
+      "item_key": "cargo_forged_star_charts",
+      "name": "Forged Star Charts",
+      "slot": "Cargo",
+      "rarity": "Common",
+      "asset_key": "cargo_forged_star_charts",
+      "lore": "Maps to places that pay, drawn by people who lie.",
+      "base_stats": { "haul_rate": 36, "detection_tolerance": 16, "speed": 16, "stealth": 14, "bonus_chance": 9, "bonus_multiplier": 9 }
+    },
+    {
+      "item_key": "cargo_living_cargo",
+      "name": "Living Cargo",
+      "slot": "Cargo",
+      "rarity": "Common",
+      "asset_key": "cargo_living_cargo",
+      "lore": "Don't ask what's in the crates. Don't let it ask either.",
+      "base_stats": { "haul_rate": 40, "detection_tolerance": 22, "speed": 12, "stealth": 10, "bonus_chance": 9, "bonus_multiplier": 7 }
+    },
+    {
+      "item_key": "cargo_unmarked_bullion",
+      "name": "Unmarked Bullion",
+      "slot": "Cargo",
+      "rarity": "Common",
+      "asset_key": "cargo_unmarked_bullion",
+      "lore": "Cold, dense, and untraceable to anyone still breathing.",
+      "base_stats": { "haul_rate": 44, "detection_tolerance": 19, "speed": 11, "stealth": 9, "bonus_chance": 9, "bonus_multiplier": 8 }
+    },
+    {
+      "item_key": "quartermaster_dusty_ledger",
+      "name": "Dusty Ledger",
+      "slot": "Quartermaster",
+      "rarity": "Common",
+      "asset_key": "quartermaster_dusty_ledger",
+      "lore": "Every favor owed and every patrol bribed, in one cursed book.",
+      "base_stats": { "haul_rate": 24, "detection_tolerance": 20, "speed": 28, "stealth": 12, "bonus_chance": 9, "bonus_multiplier": 7 }
+    },
+    {
+      "item_key": "quartermaster_blackmarket_broker",
+      "name": "Black Market Broker",
+      "slot": "Quartermaster",
+      "rarity": "Common",
+      "asset_key": "quartermaster_blackmarket_broker",
+      "lore": "Turns your haul over faster and skims a little luck off the top.",
+      "base_stats": { "haul_rate": 22, "detection_tolerance": 16, "speed": 26, "stealth": 10, "bonus_chance": 14, "bonus_multiplier": 12 }
+    },
+    {
+      "item_key": "quartermaster_efficiency_droid",
+      "name": "Efficiency Droid",
+      "slot": "Quartermaster",
+      "rarity": "Common",
+      "asset_key": "quartermaster_efficiency_droid",
+      "lore": "Optimizes every tick; complains about your life choices in binary.",
+      "base_stats": { "haul_rate": 20, "detection_tolerance": 18, "speed": 34, "stealth": 10, "bonus_chance": 10, "bonus_multiplier": 8 }
+    },
+    {
+      "item_key": "quartermaster_supply_cache",
+      "name": "Supply Cache",
+      "slot": "Quartermaster",
+      "rarity": "Common",
+      "asset_key": "quartermaster_supply_cache",
+      "lore": "Stocked for a long haul and a longer getaway.",
+      "base_stats": { "haul_rate": 26, "detection_tolerance": 22, "speed": 24, "stealth": 14, "bonus_chance": 8, "bonus_multiplier": 6 }
+    },
+    {
+      "item_key": "quartermaster_fuel_skimmer",
+      "name": "Fuel Skimmer",
+      "slot": "Quartermaster",
+      "rarity": "Common",
+      "asset_key": "quartermaster_fuel_skimmer",
+      "lore": "Squeezes one more burn out of fuel that was already someone else's.",
+      "base_stats": { "haul_rate": 18, "detection_tolerance": 17, "speed": 38, "stealth": 9, "bonus_chance": 10, "bonus_multiplier": 8 }
+    },
+    {
+      "item_key": "quartermaster_route_optimizer",
+      "name": "Route Optimizer",
+      "slot": "Quartermaster",
+      "rarity": "Common",
+      "asset_key": "quartermaster_route_optimizer",
+      "lore": "Finds the gap between two patrols and threads the whole run through it.",
+      "base_stats": { "haul_rate": 21, "detection_tolerance": 19, "speed": 30, "stealth": 13, "bonus_chance": 9, "bonus_multiplier": 8 }
+    },
+    {
+      "item_key": "quartermaster_bribe_fund",
+      "name": "Bribe Fund",
+      "slot": "Quartermaster",
+      "rarity": "Common",
+      "asset_key": "quartermaster_bribe_fund",
+      "lore": "A slush of DUST that makes inconvenient sensors malfunction.",
+      "base_stats": { "haul_rate": 19, "detection_tolerance": 30, "speed": 22, "stealth": 15, "bonus_chance": 8, "bonus_multiplier": 6 }
+    },
+    {
+      "item_key": "commsblackout_static_jammer",
+      "name": "Static Jammer",
+      "slot": "CommsBlackout",
+      "rarity": "Common",
+      "asset_key": "commsblackout_static_jammer",
+      "lore": "Fills the patrol's channel with noise and the void with silence.",
+      "base_stats": { "haul_rate": 14, "detection_tolerance": 32, "speed": 14, "stealth": 28, "bonus_chance": 7, "bonus_multiplier": 5 }
+    },
+    {
+      "item_key": "commsblackout_silent_running",
+      "name": "Silent Running",
+      "slot": "CommsBlackout",
+      "rarity": "Common",
+      "asset_key": "commsblackout_silent_running",
+      "lore": "Power down to a whisper and let the patrol drift right past.",
+      "base_stats": { "haul_rate": 12, "detection_tolerance": 24, "speed": 16, "stealth": 38, "bonus_chance": 5, "bonus_multiplier": 5 }
+    },
+    {
+      "item_key": "commsblackout_signal_scrambler",
+      "name": "Signal Scrambler",
+      "slot": "CommsBlackout",
+      "rarity": "Common",
+      "asset_key": "commsblackout_signal_scrambler",
+      "lore": "Rewrites your transponder to read as someone with better paperwork.",
+      "base_stats": { "haul_rate": 16, "detection_tolerance": 38, "speed": 14, "stealth": 22, "bonus_chance": 6, "bonus_multiplier": 4 }
+    },
+    {
+      "item_key": "commsblackout_dead_channel",
+      "name": "Dead Channel",
+      "slot": "CommsBlackout",
+      "rarity": "Common",
+      "asset_key": "commsblackout_dead_channel",
+      "lore": "There is no hail to answer because there is no hail at all.",
+      "base_stats": { "haul_rate": 10, "detection_tolerance": 26, "speed": 12, "stealth": 45, "bonus_chance": 4, "bonus_multiplier": 3 }
+    },
+    {
+      "item_key": "commsblackout_ghost_protocol",
+      "name": "Ghost Protocol",
+      "slot": "CommsBlackout",
+      "rarity": "Common",
+      "asset_key": "commsblackout_ghost_protocol",
+      "lore": "Your ship stops existing on the network the instant it matters.",
+      "base_stats": { "haul_rate": 8, "detection_tolerance": 22, "speed": 12, "stealth": 52, "bonus_chance": 3, "bonus_multiplier": 3 }
+    },
+    {
+      "item_key": "commsblackout_encrypted_relay",
+      "name": "Encrypted Relay",
+      "slot": "CommsBlackout",
+      "rarity": "Common",
+      "asset_key": "commsblackout_encrypted_relay",
+      "lore": "Talks to the Vault and nobody else, no matter who's listening.",
+      "base_stats": { "haul_rate": 18, "detection_tolerance": 40, "speed": 16, "stealth": 18, "bonus_chance": 5, "bonus_multiplier": 3 }
+    },
+    {
+      "item_key": "commsblackout_void_whisper",
+      "name": "Void Whisper",
+      "slot": "CommsBlackout",
+      "rarity": "Common",
+      "asset_key": "commsblackout_void_whisper",
+      "lore": "The last word the sensors hear before they forget you were ever there.",
+      "base_stats": { "haul_rate": 11, "detection_tolerance": 20, "speed": 13, "stealth": 48, "bonus_chance": 4, "bonus_multiplier": 4 }
+    }
+  ]
+}

--- a/data/outer-rim/equipment_items.schema.json
+++ b/data/outer-rim/equipment_items.schema.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://starworldorder.xyz/schemas/outer-rim/equipment_items.schema.json",
+  "title": "Outer Rim Equipment Catalog",
+  "description": "Canonical schema for the Outer Rim Equipment loadout catalog (SWO_OUTER_RIM_EQUIPMENT_DATA_SCHEMA). 6 slots x 7 assets x 6 stats. Rarity multipliers (Common x1 / Rare x1.5 / Epic x2.5 / Legendary x4.5 / Mythic x8) are lifted verbatim from Offshore per ADR-003 SS3.4; catalog rows carry the Common base block and runtime applies the multiplier. base_stats values are a normalized 100-point Common-base budget so that the output<->survival tradeoff is enforced by construction (no two distinct items can Pareto-dominate when sums are equal).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["$schema_version", "spec_id", "slots", "stats", "rarity_multipliers", "stat_sum_budget", "items"],
+  "properties": {
+    "$schema_version": { "type": "string" },
+    "spec_id": { "type": "string", "const": "SWO_OUTER_RIM_EQUIPMENT_DATA_SCHEMA" },
+    "description": { "type": "string" },
+    "slots": {
+      "type": "array",
+      "minItems": 6,
+      "maxItems": 6,
+      "uniqueItems": true,
+      "items": { "enum": ["Vessel", "Crew", "Cloaking", "Cargo", "Quartermaster", "CommsBlackout"] }
+    },
+    "stats": {
+      "type": "array",
+      "minItems": 6,
+      "maxItems": 6,
+      "uniqueItems": true,
+      "items": { "enum": ["haul_rate", "detection_tolerance", "speed", "stealth", "bonus_chance", "bonus_multiplier"] }
+    },
+    "rarity_multipliers": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["Common", "Rare", "Epic", "Legendary", "Mythic"],
+      "properties": {
+        "Common": { "const": 1 },
+        "Rare": { "const": 1.5 },
+        "Epic": { "const": 2.5 },
+        "Legendary": { "const": 4.5 },
+        "Mythic": { "const": 8 }
+      }
+    },
+    "stat_sum_budget": { "type": "integer", "const": 100 },
+    "items": {
+      "type": "array",
+      "minItems": 42,
+      "maxItems": 42,
+      "items": { "$ref": "#/definitions/equipmentItem" }
+    }
+  },
+  "definitions": {
+    "equipmentItem": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["item_key", "name", "slot", "rarity", "asset_key", "base_stats", "lore"],
+      "properties": {
+        "item_key": { "type": "string", "pattern": "^[a-z]+_[a-z0-9_]+$" },
+        "name": { "type": "string", "minLength": 1 },
+        "slot": { "enum": ["Vessel", "Crew", "Cloaking", "Cargo", "Quartermaster", "CommsBlackout"] },
+        "rarity": { "enum": ["Common", "Rare", "Epic", "Legendary", "Mythic"] },
+        "asset_key": { "type": "string", "minLength": 1 },
+        "lore": { "type": "string", "minLength": 1 },
+        "base_stats": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["haul_rate", "detection_tolerance", "speed", "stealth", "bonus_chance", "bonus_multiplier"],
+          "properties": {
+            "haul_rate": { "type": "integer", "minimum": 0, "maximum": 100 },
+            "detection_tolerance": { "type": "integer", "minimum": 0, "maximum": 100 },
+            "speed": { "type": "integer", "minimum": 0, "maximum": 100 },
+            "stealth": { "type": "integer", "minimum": 0, "maximum": 70 },
+            "bonus_chance": { "type": "integer", "minimum": 0, "maximum": 100 },
+            "bonus_multiplier": { "type": "integer", "minimum": 0, "maximum": 100 }
+          }
+        }
+      }
+    }
+  }
+}

--- a/lib/outer-rim/equipment.test.ts
+++ b/lib/outer-rim/equipment.test.ts
@@ -1,0 +1,323 @@
+/**
+ * Tests for the canonical Outer Rim Equipment catalog
+ * [SWO_OUTER_RIM_EQUIPMENT_DATA_SCHEMA].
+ *
+ * Acceptance criteria asserted here:
+ *  (a) 42 entries — 7 assets per slot x 6 slots.
+ *  (b) every entry validates against equipment_items.schema.json.
+ *  (c) the output<->survival tradeoff is visible in the stat distribution
+ *      (no item maxes both Haul Rate and Stealth).
+ *  (d) no item is dominant — no item Pareto-dominates another across all
+ *      six stats.
+ *
+ * The validator is a self-contained Draft-07 subset (only the keywords the
+ * schema uses) so the suite carries no dependency the package.json doesn't
+ * already declare.
+ */
+import { describe, it, expect } from 'vitest';
+import catalog from '@/data/outer-rim/equipment_items.json';
+import schema from '@/data/outer-rim/equipment_items.schema.json';
+
+type StatKey =
+  | 'haul_rate'
+  | 'detection_tolerance'
+  | 'speed'
+  | 'stealth'
+  | 'bonus_chance'
+  | 'bonus_multiplier';
+
+const STAT_KEYS: StatKey[] = [
+  'haul_rate',
+  'detection_tolerance',
+  'speed',
+  'stealth',
+  'bonus_chance',
+  'bonus_multiplier',
+];
+
+const OUTPUT_STATS: StatKey[] = [
+  'haul_rate',
+  'speed',
+  'bonus_chance',
+  'bonus_multiplier',
+];
+
+const SLOTS = ['Vessel', 'Crew', 'Cloaking', 'Cargo', 'Quartermaster', 'CommsBlackout'];
+
+interface EquipmentItem {
+  item_key: string;
+  name: string;
+  slot: string;
+  rarity: string;
+  asset_key: string;
+  lore: string;
+  base_stats: Record<StatKey, number>;
+}
+
+const items = catalog.items as EquipmentItem[];
+
+/** Draft-07 subset node — only the keywords the schema actually uses. */
+interface SchemaNode {
+  $ref?: string;
+  type?: string;
+  const?: unknown;
+  enum?: unknown[];
+  required?: string[];
+  properties?: Record<string, SchemaNode>;
+  additionalProperties?: boolean;
+  items?: SchemaNode;
+  minimum?: number;
+  maximum?: number;
+  minLength?: number;
+  minItems?: number;
+  maxItems?: number;
+  uniqueItems?: boolean;
+  pattern?: string;
+  definitions?: Record<string, SchemaNode>;
+}
+
+/**
+ * Minimal recursive JSON-Schema (Draft-07 subset) validator. Returns a list
+ * of human-readable error strings; empty list means the value is valid.
+ * Supports: $ref (local), type, required, properties, additionalProperties:false,
+ * items, enum, const, minimum, maximum, minLength, minItems, maxItems,
+ * uniqueItems, pattern.
+ */
+function validate(value: unknown, node: SchemaNode, root: SchemaNode, path = '$'): string[] {
+  const errors: string[] = [];
+
+  if (node.$ref) {
+    const ref = node.$ref.replace(/^#\//, '').split('/');
+    let resolved: unknown = root;
+    for (const seg of ref) resolved = (resolved as Record<string, unknown>)?.[seg];
+    return validate(value, resolved as SchemaNode, root, path);
+  }
+
+  if (node.const !== undefined && value !== node.const) {
+    errors.push(`${path}: expected const ${JSON.stringify(node.const)}, got ${JSON.stringify(value)}`);
+  }
+
+  if (node.enum && !node.enum.includes(value)) {
+    errors.push(`${path}: ${JSON.stringify(value)} not in enum ${JSON.stringify(node.enum)}`);
+  }
+
+  if (node.type) {
+    const t = node.type;
+    const ok =
+      (t === 'object' && value !== null && typeof value === 'object' && !Array.isArray(value)) ||
+      (t === 'array' && Array.isArray(value)) ||
+      (t === 'string' && typeof value === 'string') ||
+      (t === 'integer' && typeof value === 'number' && Number.isInteger(value)) ||
+      (t === 'number' && typeof value === 'number');
+    if (!ok) {
+      errors.push(`${path}: expected type ${t}, got ${Array.isArray(value) ? 'array' : typeof value}`);
+      return errors; // further checks assume the type holds
+    }
+  }
+
+  if (typeof value === 'string') {
+    if (node.minLength !== undefined && value.length < node.minLength) {
+      errors.push(`${path}: shorter than minLength ${node.minLength}`);
+    }
+    if (node.pattern && !new RegExp(node.pattern).test(value)) {
+      errors.push(`${path}: "${value}" fails pattern ${node.pattern}`);
+    }
+  }
+
+  if (typeof value === 'number') {
+    if (node.minimum !== undefined && value < node.minimum) {
+      errors.push(`${path}: ${value} < minimum ${node.minimum}`);
+    }
+    if (node.maximum !== undefined && value > node.maximum) {
+      errors.push(`${path}: ${value} > maximum ${node.maximum}`);
+    }
+  }
+
+  if (Array.isArray(value)) {
+    if (node.minItems !== undefined && value.length < node.minItems) {
+      errors.push(`${path}: ${value.length} items < minItems ${node.minItems}`);
+    }
+    if (node.maxItems !== undefined && value.length > node.maxItems) {
+      errors.push(`${path}: ${value.length} items > maxItems ${node.maxItems}`);
+    }
+    if (node.uniqueItems) {
+      const seen = new Set(value.map((v) => JSON.stringify(v)));
+      if (seen.size !== value.length) errors.push(`${path}: items not unique`);
+    }
+    if (node.items) {
+      const itemSchema = node.items;
+      value.forEach((entry, i) => {
+        errors.push(...validate(entry, itemSchema, root, `${path}[${i}]`));
+      });
+    }
+  }
+
+  if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+    const obj = value as Record<string, unknown>;
+    for (const req of node.required ?? []) {
+      if (!(req in obj)) errors.push(`${path}: missing required property "${req}"`);
+    }
+    const props = node.properties ?? {};
+    if (node.additionalProperties === false) {
+      for (const key of Object.keys(obj)) {
+        if (!(key in props)) errors.push(`${path}: unexpected property "${key}"`);
+      }
+    }
+    for (const [key, subSchema] of Object.entries(props)) {
+      if (key in obj) {
+        errors.push(...validate(obj[key], subSchema, root, `${path}.${key}`));
+      }
+    }
+  }
+
+  return errors;
+}
+
+describe('Outer Rim equipment catalog — structure', () => {
+  it('declares the canonical spec id and rarity multipliers', () => {
+    expect(catalog.spec_id).toBe('SWO_OUTER_RIM_EQUIPMENT_DATA_SCHEMA');
+    // Multipliers lifted verbatim from Offshore (ADR-003 SS3.4).
+    expect(catalog.rarity_multipliers).toEqual({
+      Common: 1,
+      Rare: 1.5,
+      Epic: 2.5,
+      Legendary: 4.5,
+      Mythic: 8,
+    });
+  });
+
+  it('(a) has exactly 42 entries: 7 per slot x 6 slots', () => {
+    expect(items).toHaveLength(42);
+    for (const slot of SLOTS) {
+      expect(items.filter((i) => i.slot === slot)).toHaveLength(7);
+    }
+  });
+
+  it('uses unique item_keys', () => {
+    const keys = items.map((i) => i.item_key);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it('every item carries an SWO-themed name + lore one-liner', () => {
+    for (const item of items) {
+      expect(item.name.length).toBeGreaterThan(0);
+      expect(item.lore.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('Outer Rim equipment catalog — schema', () => {
+  const rootSchema = schema as unknown as SchemaNode;
+
+  it('(b) the whole document validates against the schema', () => {
+    expect(validate(catalog, rootSchema, rootSchema)).toEqual([]);
+  });
+
+  it('(b) every catalog row validates against the item schema', () => {
+    const itemSchema = rootSchema.definitions!.equipmentItem;
+    for (const item of items) {
+      expect(validate(item, itemSchema, rootSchema)).toEqual([]);
+    }
+  });
+
+  it('self-check: the validator rejects a malformed row', () => {
+    const itemSchema = rootSchema.definitions!.equipmentItem;
+    const bad = {
+      ...items[0],
+      base_stats: { ...items[0].base_stats, stealth: 95 }, // > 70 cap
+    };
+    expect(validate(bad, itemSchema, rootSchema).length).toBeGreaterThan(0);
+  });
+});
+
+describe('Outer Rim equipment catalog — economy invariants', () => {
+  const budget = catalog.stat_sum_budget as number;
+  const sumOf = (item: EquipmentItem) =>
+    STAT_KEYS.reduce((acc, k) => acc + item.base_stats[k], 0);
+
+  it('every base block sits in the same band as the Common base budget', () => {
+    // The Common base is a normalized 100-point budget; rarity multipliers
+    // scale it at runtime. A tight band keeps every starter item on the
+    // same power curve (acceptance (c) "same band as Offshore Common base").
+    const BAND = { min: budget - 5, max: budget + 5 };
+    for (const item of items) {
+      const total = sumOf(item);
+      expect(total).toBeGreaterThanOrEqual(BAND.min);
+      expect(total).toBeLessThanOrEqual(BAND.max);
+    }
+  });
+
+  it('respects the 70% Stealth cap', () => {
+    for (const item of items) {
+      expect(item.base_stats.stealth).toBeLessThanOrEqual(70);
+    }
+  });
+
+  it('(c) no item maxes both Haul Rate and Stealth', () => {
+    const maxHaul = Math.max(...items.map((i) => i.base_stats.haul_rate));
+    const maxStealth = Math.max(...items.map((i) => i.base_stats.stealth));
+    const topHaul = items.find((i) => i.base_stats.haul_rate === maxHaul)!;
+    const topStealth = items.find((i) => i.base_stats.stealth === maxStealth)!;
+    expect(topHaul.item_key).not.toBe(topStealth.item_key);
+    // No item is simultaneously top-tier output AND top-tier survival.
+    for (const item of items) {
+      const bothMaxed =
+        item.base_stats.haul_rate === maxHaul &&
+        item.base_stats.stealth === maxStealth;
+      expect(bothMaxed).toBe(false);
+    }
+  });
+
+  it('(c) output and survival are negatively correlated across the catalog', () => {
+    // Each item's output footprint should trade against its survival footprint.
+    const output = items.map((i) =>
+      OUTPUT_STATS.reduce((a, k) => a + i.base_stats[k], 0),
+    );
+    const survival = items.map(
+      (i) => i.base_stats.detection_tolerance + i.base_stats.stealth,
+    );
+    const n = items.length;
+    const mean = (xs: number[]) => xs.reduce((a, b) => a + b, 0) / xs.length;
+    const mo = mean(output);
+    const ms = mean(survival);
+    let cov = 0;
+    for (let i = 0; i < n; i++) cov += (output[i] - mo) * (survival[i] - ms);
+    expect(cov).toBeLessThan(0);
+  });
+
+  it('(d) no item Pareto-dominates another across all six stats', () => {
+    const dominates = (a: EquipmentItem, b: EquipmentItem) => {
+      let strictlyBetter = false;
+      for (const k of STAT_KEYS) {
+        if (a.base_stats[k] < b.base_stats[k]) return false;
+        if (a.base_stats[k] > b.base_stats[k]) strictlyBetter = true;
+      }
+      return strictlyBetter;
+    };
+    for (const a of items) {
+      for (const b of items) {
+        if (a.item_key === b.item_key) continue;
+        expect(
+          dominates(a, b),
+          `${a.item_key} dominates ${b.item_key}`,
+        ).toBe(false);
+      }
+    }
+  });
+
+  it('(d) every item is therefore Pareto-optimal (on the frontier)', () => {
+    const dominatedBy = (a: EquipmentItem) =>
+      items.some((b) => {
+        if (b.item_key === a.item_key) return false;
+        let strictlyBetter = false;
+        for (const k of STAT_KEYS) {
+          if (b.base_stats[k] < a.base_stats[k]) return false;
+          if (b.base_stats[k] > a.base_stats[k]) strictlyBetter = true;
+        }
+        return strictlyBetter;
+      });
+    for (const item of items) {
+      expect(dominatedBy(item), `${item.item_key} is dominated`).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Ships the canonical **Outer Rim Equipment** catalog per `[SWO_OUTER_RIM_EQUIPMENT_DATA_SCHEMA]` (P1), implementing the 6-slot × 7-asset × 6-stat loadout system ratified in ADR-003 §3.

- **`data/outer-rim/equipment_items.json`** — 42-item starter catalog (7 assets per slot × 6 slots: Vessel / Crew / Cloaking / Cargo / Quartermaster / CommsBlackout). Each item has an SWO-themed name, slot, Common-base stat block, lore one-liner, and asset key.
- **`data/outer-rim/equipment_items.schema.json`** — Draft-07 JSON Schema for the document and per-item rows (enums for slots/rarities/stats, 70% stealth cap, `additionalProperties:false`).
- **`lib/outer-rim/equipment.test.ts`** — vitest (13 cases) asserting all acceptance criteria.

## Design
- **Stats (6):** `haul_rate`, `detection_tolerance`, `speed`, `stealth` (cap 70), `bonus_chance`, `bonus_multiplier`.
- **Rarity multipliers** lifted verbatim from Offshore (ADR-003 §3.4): Common ×1 / Rare ×1.5 / Epic ×2.5 / Legendary ×4.5 / Mythic ×8. Catalog rows carry the **Common base**; runtime applies the multiplier.
- **Output↔survival tradeoff (non-negotiable per ADR-003 §3.3):** each `base_stats` block is a normalized **100-point budget**. Every output point (haul/speed/bonus) is paid for with a survival point (detection/stealth). Because all blocks sum to the same budget, **no distinct item can Pareto-dominate another** — the catalog is one big Pareto frontier by construction.
- Slot leans: Vessel→haul/speed, Crew→bonus, Cloaking & CommsBlackout→stealth/detection, Cargo→haul, Quartermaster→speed/efficiency.

## Acceptance criteria (all asserted by tests)
- (a) **42 entries** — 7 per slot × 6 slots ✓
- (b) **every entry validates** against the schema (self-contained Draft-07 subset validator — zero new deps; includes a negative self-check) ✓
- (c) **output-vs-survival tradeoff visible** — no item maxes both Haul Rate and Stealth; output and survival footprints are negatively correlated across the catalog ✓
- (d) **no item is dominant** — pairwise Pareto-domination check + every-item-on-frontier check ✓

## Validation
- `npx vitest run lib/outer-rim/equipment.test.ts` — **13 passed**
- `npx tsc --noEmit` — no new errors from these files
- `npx eslint lib/outer-rim/equipment.test.ts` — clean

## Mirror Validation (PROD)
Overlaid the 3 files into `/opt/star_world_order/PROD`, ran checks, then restored the mirror byte-identical (removed files + the new `data/outer-rim/` dir).
- **tsc --noEmit**: PASS (no new equipment errors; pre-existing PROD errors excluded)
- **vitest run** (`lib/outer-rim/equipment.test.ts`): PASS — 13 passed

## Notes
- ADR-003 §3.2 references `data/sanctuary/outer_rim_equipment.json`, but the task specifies `data/outer-rim/equipment_items.json`; followed the task path. Follow-up: reconcile the ADR path reference if desired.
- The rarity ladder uses the task's labels (Common/Rare/Epic/Legendary/Mythic) rather than ADR-003 §3.4's (Common/Uncommon/Rare/Legendary/Mythic); multiplier values are identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Depends on: [SWO_OUTER_RIM_ADR_003]