### PR TITLE
Promote dev → main: hide WIP sanctuary/casino on prod + casino-e2e CI fixes

### DIFF
--- a/.github/workflows/casino-e2e.yml
+++ b/.github/workflows/casino-e2e.yml
@@ -163,6 +163,18 @@ jobs:
           # flows execute against the deterministic snapshot rather than
           # the upstream Monad RPC.
           NEXT_PUBLIC_CHAIN_ID: ${{ env.MONAD_CHAIN_ID }}
+          # The dapp reads NEXT_PUBLIC_MONAD_CHAIN_ID (lib/wagmi.ts) — without
+          # it the wagmi config defaults to mainnet 143, whose casino registry
+          # entry is gated behind NEXT_PUBLIC_CASINO_MAINNET_LIVE, so every
+          # game renders "not deployed yet" and the connected specs fail.
+          NEXT_PUBLIC_MONAD_CHAIN_ID: ${{ env.MONAD_CHAIN_ID }}
+          # Server-commit hashes for the provably-fair flows. The connected
+          # specs mock the tx/event layer, so any well-formed 32-byte hex
+          # passes resolveCommitFromEnv(); without them the bet CTAs render
+          # "Server commit not configured" and stay disabled.
+          NEXT_PUBLIC_COSMIC_FLIP_COMMIT: '0x1111111111111111111111111111111111111111111111111111111111111111'
+          NEXT_PUBLIC_GRAVITY_DICE_COMMIT: '0x1111111111111111111111111111111111111111111111111111111111111111'
+          NEXT_PUBLIC_CONSTELLATION_CLIMB_COMMIT: '0x1111111111111111111111111111111111111111111111111111111111111111'
           NEXT_PUBLIC_MONAD_TESTNET_RPC: http://127.0.0.1:8545
           ANVIL_RPC: http://127.0.0.1:8545
         run: |

--- a/.github/workflows/casino-e2e.yml
+++ b/.github/workflows/casino-e2e.yml
@@ -39,7 +39,11 @@ env:
   # Pinned for reproducibility. Bumping this is deliberate: the anvil RPC
   # cache below is keyed on this number, so changing it forces exactly one
   # round-trip to the public RPC before subsequent runs replay from cache.
-  FORK_BLOCK: '5000000'
+  # NOTE: the public Monad RPC is NOT an archive node — it prunes historical
+  # state, and a too-old pin fails anvil genesis with "Block requested not
+  # found". If that error reappears, bump this to a recent block (head was
+  # ~36.62M when this was last set, 2026-06-07).
+  FORK_BLOCK: '36604992'
   MONAD_CHAIN_ID: '10143'
   CASINO_PROJECT: 'casino-connected'
   ANVIL_PORT: '8545'

--- a/.github/workflows/casino-e2e.yml
+++ b/.github/workflows/casino-e2e.yml
@@ -163,6 +163,9 @@ jobs:
           # flows execute against the deterministic snapshot rather than
           # the upstream Monad RPC.
           NEXT_PUBLIC_CHAIN_ID: ${{ env.MONAD_CHAIN_ID }}
+          # The middleware WIP gate [SWO_WIP_PROD_GATE] 404s /casino outside
+          # dev mode — CI must run the app in dev mode like DEV does.
+          NEXT_PUBLIC_ENV_MODE: dev
           # The dapp reads NEXT_PUBLIC_MONAD_CHAIN_ID (lib/wagmi.ts) — without
           # it the wagmi config defaults to mainnet 143, whose casino registry
           # entry is gated behind NEXT_PUBLIC_CASINO_MAINNET_LIVE, so every

--- a/components/Features.tsx
+++ b/components/Features.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import WalletConnect from './WalletConnect';
 import { Panel } from './ui';
+import { isProdMode } from '@/lib/config';
 
 type Feature = {
   icon: string;
@@ -13,15 +14,16 @@ type Feature = {
   color: string;
   href: string;
   external?: boolean;
+  dev?: boolean; // DEV-only (hidden in prod, mirrors SiteNav's flag)
 };
 
 const FEATURES: Feature[] = [
   { icon: 'skr_str_mon2', title: 'THE ORDER', description: 'Exclusive access & governance for Star holders', color: '#ffd700', href: '/dao' },
   { icon: 'monad_logo', title: 'MONAD REALM', description: 'Blazing-fast cosmic infrastructure', color: '#00ffff', href: 'https://monad.xyz', external: true },
-  { icon: '🪐', title: 'SANCTUARY', description: 'Adopt & raise your Skrumpey companion', color: '#9966ff', href: '/sanctuary' },
+  { icon: '🪐', title: 'SANCTUARY', description: 'Adopt & raise your Skrumpey companion', color: '#9966ff', href: '/sanctuary', dev: true },
   { icon: '💎', title: 'TREASURY', description: 'Collective DAO resources, on-chain', color: '#44ff88', href: '/treasury' },
   { icon: '💬', title: 'STAR COUNCIL', description: 'Hang with the gang in the lobby', color: '#ff7b00', href: '/hangout' },
-  { icon: '🎰', title: 'COSMIC CASINO', description: 'Provably-fair games among the stars', color: '#ff00ff', href: '/casino' },
+  { icon: '🎰', title: 'COSMIC CASINO', description: 'Provably-fair games among the stars', color: '#ff00ff', href: '/casino', dev: true },
 ];
 
 export default function Features() {
@@ -81,7 +83,7 @@ export default function Features() {
 
         {/* Feature launchpad — each card links to a real destination */}
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-          {FEATURES.map((f, i) => {
+          {FEATURES.filter((f) => !f.dev || !isProdMode()).map((f, i) => {
             const inner = (
               <Panel interactive className="h-full !p-6" style={{ ['--fc' as string]: f.color }}>
                 <div className="mb-4">{renderIcon(f)}</div>

--- a/components/SiteNav.tsx
+++ b/components/SiteNav.tsx
@@ -28,8 +28,8 @@ export const NAV_GROUPS: NavGroup[] = [
     label: 'PLAY',
     accent: 'var(--color-purple)',
     items: [
-      { href: '/sanctuary', label: 'Sanctuary', icon: '🪐', desc: 'Raise your companion', accent: 'var(--color-feature-sanctuary)' },
-      { href: '/casino', label: 'Cosmic Casino', icon: '🎰', desc: 'Provably-fair games', accent: 'var(--color-feature-casino)' },
+      { href: '/sanctuary', label: 'Sanctuary', icon: '🪐', desc: 'Raise your companion', accent: 'var(--color-feature-sanctuary)', dev: true },
+      { href: '/casino', label: 'Cosmic Casino', icon: '🎰', desc: 'Provably-fair games', accent: 'var(--color-feature-casino)', dev: true },
       { href: '/raffle', label: 'Cosmic Raffle', icon: '🎟️', desc: 'Holder-tier raffles', accent: 'var(--color-feature-raffle)' },
       { href: '/starforge', label: 'Star Forge', icon: '🔨', desc: 'Forge the grid', accent: 'var(--color-feature-forge)', dev: true },
     ],

--- a/middleware.ts
+++ b/middleware.ts
@@ -29,6 +29,26 @@ import {
   normalizeCountry,
 } from '@/lib/casino/geo';
 
+// WIP surfaces hidden outside dev mode [SWO_WIP_PROD_GATE]. Sanctuary and
+// the casino are not launched yet: routes are incomplete and the features
+// don't fully work, so on prod they 404 (themed not-found page) and their
+// nav/landing entries are hidden via the `dev: true` item flag. The
+// sanctuary API is gated too — it lazily creates its schema in the prod DB
+// on first hit, which we don't want until launch. `/api/casino/*` (health
+// probe) stays reachable. Dev mode requires NEXT_PUBLIC_ENV_MODE=dev
+// (set in DEV/.env.local); prod runs with =prod via the systemd unit.
+const WIP_PREFIXES = ['/sanctuary', '/casino', '/api/sanctuary'];
+
+function isDevEnv(): boolean {
+  return process.env.NEXT_PUBLIC_ENV_MODE?.toLowerCase() === 'dev';
+}
+
+function isWipPath(pathname: string): boolean {
+  return WIP_PREFIXES.some(
+    (p) => pathname === p || pathname.startsWith(p + '/'),
+  );
+}
+
 function countryFromRequest(req: NextRequest): string {
   const geoCountry = (req as unknown as { geo?: { country?: string } }).geo
     ?.country;
@@ -41,6 +61,22 @@ function countryFromRequest(req: NextRequest): string {
 }
 
 export function middleware(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+
+  if (!isDevEnv() && isWipPath(pathname)) {
+    if (pathname.startsWith('/api/')) {
+      return NextResponse.json(
+        { success: false, error: 'Not found' },
+        { status: 404 },
+      );
+    }
+    // Rewrite to a path that doesn't exist so app/not-found.tsx renders
+    // with a real 404 status (mirrors the geo rewrite pattern below).
+    const url = req.nextUrl.clone();
+    url.pathname = '/__wip-hidden__';
+    return NextResponse.rewrite(url, { status: 404 });
+  }
+
   const country = countryFromRequest(req);
   const blocked = isBlockedCountry(country);
   const mode = modeFromEnv();
@@ -61,5 +97,9 @@ export function middleware(req: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/casino/:path*'],
+  matcher: [
+    '/casino/:path*',
+    '/sanctuary/:path*',
+    '/api/sanctuary/:path*',
+  ],
 };

--- a/tests/e2e/casino/climb.connected.spec.ts
+++ b/tests/e2e/casino/climb.connected.spec.ts
@@ -23,6 +23,15 @@ const CONSTELLATION_CLIMB_ADDRESS: `0x${string}` =
   '0xd9B9b6c37ad4f3D5b07ae76dE261c5C865600d6e';
 
 test.describe('@casino-connected /casino/constellation-climb', () => {
+  // Skip the STAR-64 boot overlay for the pre-connect specs too — the
+  // wallet-mocked specs get this via installWalletMock, but bare
+  // `page.goto` interaction specs would otherwise have clicks
+  // intercepted by the fixed overlay.
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      window.sessionStorage.setItem('swo-loading-seen', '1');
+    });
+  });
   test('renders Constellation Climb page metadata + direction picker', async ({
     page,
   }) => {

--- a/tests/e2e/casino/coinflip.connected.spec.ts
+++ b/tests/e2e/casino/coinflip.connected.spec.ts
@@ -27,6 +27,16 @@ const COSMIC_FLIP_ADDRESS: `0x${string}` =
   '0x064b8bfc03b23D2b525deD9d3969090347A21983';
 
 test.describe('@casino-connected /casino/coinflip', () => {
+  // Skip the STAR-64 boot overlay for the pre-connect specs too — the
+  // wallet-mocked specs get this via installWalletMock, but the bare
+  // `page.goto` interaction specs (side selector) would otherwise have
+  // every click intercepted by the fixed overlay.
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      window.sessionStorage.setItem('swo-loading-seen', '1');
+    });
+  });
+
   test('renders Cosmic Flip page metadata + side selector pre-connect', async ({
     page,
   }) => {

--- a/tests/e2e/casino/dice.connected.spec.ts
+++ b/tests/e2e/casino/dice.connected.spec.ts
@@ -19,6 +19,15 @@ const GRAVITY_DICE_ADDRESS: `0x${string}` =
   '0xAC023542A8168465EE4A1b3e8Ae0f58F36A6d84B';
 
 test.describe('@casino-connected /casino/dice', () => {
+  // Skip the STAR-64 boot overlay for the pre-connect specs too — the
+  // wallet-mocked specs get this via installWalletMock, but bare
+  // `page.goto` interaction specs would otherwise have clicks
+  // intercepted by the fixed overlay.
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      window.sessionStorage.setItem('swo-loading-seen', '1');
+    });
+  });
   test('renders Gravity Dice page metadata + rollUnder slider', async ({
     page,
   }) => {

--- a/tests/e2e/casino/fixtures/wallet-mock.ts
+++ b/tests/e2e/casino/fixtures/wallet-mock.ts
@@ -281,6 +281,18 @@ export async function installRpcRoute(
 
   logQueues.set(page, []);
 
+  // Filter registry for the eth_newFilter / eth_getFilterChanges path.
+  // viem's watchContractEvent PREFERS installed filters when the node
+  // accepts eth_newFilter — and each of HiLo's three parallel
+  // subscriptions installs its own. Returning a shared id and ignoring
+  // the stored topics (the old behaviour) made the first poller drain
+  // the whole queue topic-blind, starving the other subscriptions —
+  // SessionCashedOut/StepPlayed logs vanished into the SessionPushed
+  // watcher and the climb specs hung. Store each filter's topics and
+  // replay them through the same drain-by-topic logic instead.
+  const filters = new Map<string, { topics?: Array<string | string[] | null> }>();
+  let nextFilterId = 1;
+
   function handleSingle(req: JsonRpcRequest): unknown {
     const queue = logQueues.get(page) ?? [];
     switch (req.method) {
@@ -374,16 +386,35 @@ export async function installRpcRoute(
           removed: false,
         }));
       }
-      case 'eth_newFilter':
+      case 'eth_newFilter': {
+        const id = '0x' + (nextFilterId++).toString(16);
+        filters.set(
+          id,
+          (req.params?.[0] as { topics?: Array<string | string[] | null> }) ??
+            {},
+        );
+        return id;
+      }
       case 'eth_newBlockFilter':
-        return '0x1';
-      case 'eth_getFilterChanges':
-        // Filter-based polling: viem prefers getLogs when it can, so we
-        // route the same drain-by-topic logic via the (rarely hit)
-        // getFilterChanges fallback.
-        return handleSingle({ ...req, method: 'eth_getLogs' });
-      case 'eth_uninstallFilter':
+        return '0x' + (nextFilterId++).toString(16);
+      case 'eth_getFilterChanges': {
+        // Filter-based polling: params[0] is the filter ID, not a filter
+        // object — resolve it to the stored topics and reuse the
+        // drain-by-topic logic above so parallel subscriptions don't
+        // starve each other.
+        const id = String(req.params?.[0] ?? '');
+        const stored = filters.get(id);
+        if (!stored) return [];
+        return handleSingle({
+          ...req,
+          method: 'eth_getLogs',
+          params: [stored],
+        });
+      }
+      case 'eth_uninstallFilter': {
+        filters.delete(String(req.params?.[0] ?? ''));
         return true;
+      }
       case 'eth_getTransactionReceipt':
         return null;
       case 'eth_getTransactionByHash':

--- a/tests/e2e/casino/fixtures/wallet-mock.ts
+++ b/tests/e2e/casino/fixtures/wallet-mock.ts
@@ -48,6 +48,16 @@ export async function installWalletMock(
   const chainId = options.chainId ?? DEFAULT_CHAIN_ID;
   const walletLabel = options.walletLabel ?? 'SWO Mock Wallet';
 
+  // Skip the STAR-64 boot/cartridge overlay (components/LoadingScreen.tsx).
+  // It renders fixed at zIndex 9999, only advances on a user click, and
+  // short-circuits when `sessionStorage["swo-loading-seen"]` is truthy —
+  // fresh Playwright contexts never have it, so without this every click in
+  // the connected specs is intercepted by the overlay. (visual.spec.ts sets
+  // the same key independently.)
+  await page.addInitScript(() => {
+    window.sessionStorage.setItem('swo-loading-seen', '1');
+  });
+
   await page.addInitScript(
     ({ address, chainId, walletLabel }) => {
       // Hex-encode the chain id without leading zeros (EIP-695).


### PR DESCRIPTION
## Summary
- **WIP gate**: sanctuary + casino are not launched — middleware now 404s `/sanctuary`, `/casino` and `/api/sanctuary` outside dev mode (themed not-found; sanctuary API also gated so it can't lazily create schema in the prod DB). Nav + landing entries hidden via the existing `dev: true` flag. DEV keeps everything via `NEXT_PUBLIC_ENV_MODE=dev`.
- **casino-e2e CI**: lane green for the first time (20/20) — repo secret, fork-pin bump 5M→36.6M, correct app env (`NEXT_PUBLIC_MONAD_CHAIN_ID` + commit vars), boot-overlay skip, and a per-id filter registry in the RPC mock (fixes watcher starvation).

## Verification
- tsc 0 errors, vitest 1420/1420
- DEV (:3081): /sanctuary, /casino, /api/sanctuary all still 200 in dev mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)